### PR TITLE
Wrap RET: batch 8 (format Decimal)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,12 +92,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 
 [[package]]
-name = "arrayvec"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
-
-[[package]]
 name = "askama"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1400,16 +1394,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
-name = "num-format"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
-dependencies = [
- "arrayvec",
- "itoa",
-]
-
-[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1994,7 +1978,6 @@ dependencies = [
  "itertools 0.12.1",
  "log",
  "memoize",
- "num-format",
  "nutype",
  "paste",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,6 @@ bip39 = { version = "2.0.0", features = ["serde"] }
 time-util = { version = "0.3.4", features = ["chrono"] }
 assert-json-diff = "2.0.2"
 url = { version = "2.5.0", features = ["serde"] }
-num-format = "0.4.4"
 paste = "1.0.14"
 clap = { version = "4", default-features = false, features = ["std", "derive"] }
 camino = "1.0.8"

--- a/apple/Sources/Sargon/Extensions/Methods/Decimal192+Wrap+Functions.swift
+++ b/apple/Sources/Sargon/Extensions/Methods/Decimal192+Wrap+Functions.swift
@@ -29,42 +29,30 @@ extension Decimal192 {
 }
 
 // MARK: Formatting
-extension Option<UInt> {
-	fileprivate var asU8: UInt8? {
-		if let value = self {
-		precondition(
-			value < UInt(UInt8.max),
-			"Must not specify more than \(UInt8.max) places, got: \(value).")
-			value
-		} else {
-			nil
-		}
-
-
-	}
-}
 extension Decimal192 {
 
 	/// A human readable, locale respecting string, rounded to `totalPlaces` places, counting all digits
 	public func formatted(
 		locale: Locale = .autoupdatingCurrent,
-		totalPlaces: UInt? = nil,
+		totalPlaces: UInt8,
 		useGroupingSeparator: Bool = true
 	) -> String {
 		decimalFormatted(
-			locale: LocaleConfig(locale: local),
-			totalPlaces: totalPlaces.asU8,
+			decimal: self,
+			locale: LocaleConfig(locale: locale),
+			totalPlaces: totalPlaces,
 			useGroupingSeparator: useGroupingSeparator
 		)
 	}
 
 	public func formattedEngineeringNotation(
 		locale: Locale = .autoupdatingCurrent,
-		totalPlaces: UInt? = nil
+		totalPlaces: UInt8? = nil
 	) -> String {
 		decimalFormattedEngineeringNotation(
-			locale: LocaleConfig(locale: local),
-			totalPlaces: totalPlaces.asU8
+			decimal: self,
+			locale: LocaleConfig(locale: locale),
+			totalPlaces: totalPlaces
 		)
 	}
 
@@ -74,7 +62,8 @@ extension Decimal192 {
 		useGroupingSeparator: Bool = true
 	) -> String {
 		decimalFormattedPlain(
-			locale: LocaleConfig(locale: local),
+			decimal: self,
+			locale: LocaleConfig(locale: locale),
 			useGroupingSeparator: useGroupingSeparator
 		)
 	}
@@ -91,7 +80,7 @@ extension Decimal192 {
 		do {
 			return try decimalRound(
 				decimal: self,
-				decimalPlaces: Int32(decimalPlaces),
+				decimalPlaces: decimalPlaces,
 				roundingMode: roundingMode
 			)
 		} catch {

--- a/apple/Sources/Sargon/Extensions/Methods/Decimal192+Wrap+Functions.swift
+++ b/apple/Sources/Sargon/Extensions/Methods/Decimal192+Wrap+Functions.swift
@@ -28,13 +28,64 @@ extension Decimal192 {
 	}
 }
 
-// MARK: Truncation and rounding
+// MARK: Formatting
+extension Option<UInt> {
+	fileprivate var asU8: UInt8? {
+		if let value = self {
+		precondition(
+			value < UInt(UInt8.max),
+			"Must not specify more than \(UInt8.max) places, got: \(value).")
+			value
+		} else {
+			nil
+		}
 
+
+	}
+}
 extension Decimal192 {
-	
+
+	/// A human readable, locale respecting string, rounded to `totalPlaces` places, counting all digits
+	public func formatted(
+		locale: Locale = .autoupdatingCurrent,
+		totalPlaces: UInt? = nil,
+		useGroupingSeparator: Bool = true
+	) -> String {
+		decimalFormatted(
+			locale: LocaleConfig(locale: local),
+			totalPlaces: totalPlaces.asU8,
+			useGroupingSeparator: useGroupingSeparator
+		)
+	}
+
+	public func formattedEngineeringNotation(
+		locale: Locale = .autoupdatingCurrent,
+		totalPlaces: UInt? = nil
+	) -> String {
+		decimalFormattedEngineeringNotation(
+			locale: LocaleConfig(locale: local),
+			totalPlaces: totalPlaces.asU8
+		)
+	}
+
+	/// A human readable, locale respecting string. Does not perform any rounding or truncation.
+	public func formattedPlain(
+		locale: Locale = .autoupdatingCurrent,
+		useGroupingSeparator: Bool = true
+	) -> String {
+		decimalFormattedPlain(
+			locale: LocaleConfig(locale: local),
+			useGroupingSeparator: useGroupingSeparator
+		)
+	}
+}
+
+// MARK: Truncation and rounding
+extension Decimal192 {
+
 	private func rounded(decimalPlaces: UInt8, roundingMode: RoundingMode) -> Self {
 		precondition(
-			decimalPlaces <= Decimal192.maxDivisibility, 
+			decimalPlaces <= Decimal192.maxDivisibility,
 			"Decimal places MUST be 0...18, was: \(decimalPlaces)"
 		)
 		do {
@@ -47,8 +98,7 @@ extension Decimal192 {
 			fatalError("Failed to round, error: \(error)")
 		}
 	}
-	
-	
+
 	/// Rounds to `decimalPlaces` decimals
 	public func rounded(decimalPlaces: UInt8 = 0) -> Self {
 		rounded(
@@ -56,7 +106,7 @@ extension Decimal192 {
 			roundingMode: .toNearestMidpointAwayFromZero
 		)
 	}
-	
+
 	/// Rounds to `decimalPlaces` decimals, in the direction of 0
 	public func floor(decimalPlaces: UInt8) -> Self {
 		rounded(decimalPlaces: decimalPlaces, roundingMode: .toZero)

--- a/examples/iOS/Planbok.xcworkspace/contents.xcworkspacedata
+++ b/examples/iOS/Planbok.xcworkspace/contents.xcworkspacedata
@@ -49,6 +49,9 @@
                   location = "group:Swiftified"
                   name = "Swiftified">
                   <FileRef
+                     location = "group:NonFungibleResourceAddress+Swiftified.swift">
+                  </FileRef>
+                  <FileRef
                      location = "group:AccessControllerAddress+Swiftified.swift">
                   </FileRef>
                   <FileRef
@@ -83,9 +86,6 @@
                   </FileRef>
                   <FileRef
                      location = "group:NetworkID+Swiftified.swift">
-                  </FileRef>
-                  <FileRef
-                     location = "group:/Users/alexandercyon/Developer/Babylon/Sargon/apple/Sources/Sargon/Extensions/Swiftified/NonFungibleResourceAddress+Swiftified.swift">
                   </FileRef>
                   <FileRef
                      location = "group:PackageAddress+Swiftified.swift">

--- a/examples/iOS/Sources/Planbok/Features/Flows/CreateAccount/Steps/SelectGradientFeature.swift
+++ b/examples/iOS/Sources/Planbok/Features/Flows/CreateAccount/Steps/SelectGradientFeature.swift
@@ -50,7 +50,7 @@ public struct SelectGradientFeature {
 					let height: CGFloat = 20
 					ForEach(AppearanceID.allCases) { appearanceID in
 						let isSelected = appearanceID == store.state.gradient
-						Button.init(action: { send(.selectedGradient(appearanceID)) }, label: {
+						Button(action: { send(.selectedGradient(appearanceID)) }, label: {
 							HStack {
 								Text("Gradient \(String(describing: appearanceID))")
 									.font(isSelected ? .headline : .subheadline)
@@ -65,7 +65,7 @@ public struct SelectGradientFeature {
 								}
 							}
 						})
-						
+						.buttonStyle(.borderless)
 						.foregroundColor(.app.white)
 						.frame(maxWidth: .infinity, idealHeight: height, alignment: .leading)
 						.padding()

--- a/scripts/ios/release.sh
+++ b/scripts/ios/release.sh
@@ -20,7 +20,8 @@ function last_tag() {
     local out=`git tag --sort=taggerdate | tail -1`
     echo $out
 }
-echo "🚢 🏷️  Last tag: $(last_tag)"
+LAST_TAG=$(last_tag)
+echo "🚢 🏷️  Last tag: $LAST_TAG"
 
 # one liner from: https://stackoverflow.com/a/8653732
 NEXT_TAG=$(echo $(last_tag) | awk -F. -v OFS=. 'NF==1{print ++$NF}; NF>1{if(length($NF+1)>length($NF))$(NF-1)++; $NF=sprintf("%0*d", length($NF), ($NF+1)%(10^length($NF))); print}')
@@ -55,7 +56,7 @@ echo "🚢 🏷️ 📡 Pushing tag: $(NEXT_TAG), but only tag, not commit."
 SWIFT_SARGON_BINARY_ASSET_NAME="libsargon-rs.xcframework.zip" 
 
 GH_RELEASE_TITLE="Sargon Swift Only v$NEXT_TAG"
-RELEASE_CMD="gh release create $NEXT_TAG '$XCFRAME_ZIP_PATH#$SWIFT_SARGON_BINARY_ASSET_NAME' --generate-notes --title '$GH_RELEASE_TITLE'"
+RELEASE_CMD="gh release create $NEXT_TAG '$XCFRAME_ZIP_PATH#$SWIFT_SARGON_BINARY_ASSET_NAME' --generate-notes --notes-start-tag $LAST_TAG --title '$GH_RELEASE_TITLE'"
 eval $RELEASE_CMD
 
 echo "🚢  End of release script ✅"

--- a/src/core/types/decimal192.rs
+++ b/src/core/types/decimal192.rs
@@ -441,21 +441,6 @@ fn trailing_zero_count_of(s: impl AsRef<str>) -> usize {
         .unwrap_or(str.len())
 }
 
-#[cfg(test)]
-#[test]
-fn test_trailing_zero_count_of() {
-    let test = |s: &str, exp: usize| assert_eq!(trailing_zero_count_of(s), exp);
-
-    test("", 0);
-    test("1", 0);
-    test("0", 1);
-    test("100", 2);
-    test("1001", 0);
-    test("90000", 4);
-    test("9000.0", 1);
-    test("9.000", 3);
-}
-
 fn insert_grouping_separator_into(s: &mut String, separator: String) {
     let digits = s.len();
     let zeroes_per_thousand = 3;
@@ -472,28 +457,6 @@ fn insert_grouping_separator_into(s: &mut String, separator: String) {
     }
 }
 
-#[cfg(test)]
-#[test]
-fn test_insert_grouping_separator_into() {
-    let test_w = |s: &str, exp: &str, sep: char| {
-        let mut string = s.to_owned();
-        insert_grouping_separator_into(&mut string, sep.to_string());
-        assert_eq!(string, exp.to_owned())
-    };
-    let test = |s: &str, exp: &str| test_w(s, exp, ' ');
-
-    test("", "");
-    test("1", "1");
-    test("22", "22");
-    test("333", "333");
-    test("4444", "4 444");
-    test("123456789", "123 456 789");
-    test("12345678987654321", "12 345 678 987 654 321");
-
-    test_w("123456789", "123.456.789", '.');
-    test_w("123456789", "123,456,789", ',');
-}
-
 fn split_str(s: impl AsRef<str>, after: i8) -> (String, String) {
     let mut s = s.as_ref().to_owned();
     if after <= 0 {
@@ -501,51 +464,6 @@ fn split_str(s: impl AsRef<str>, after: i8) -> (String, String) {
     }
     let other: String = s.drain(0..after as usize).collect();
     (other, s)
-}
-
-#[cfg(test)]
-#[test]
-fn test_split_str() {
-    let test = |s: &str, a: i8, exp: (&str, &str)| {
-        let res = split_str(s, a);
-        assert_eq!(res.0, exp.0.to_string());
-        assert_eq!(res.1, exp.1.to_string());
-    };
-
-    test("12345.09876", -2, ("", "12345.09876"));
-
-    test("9.8", 0, ("", "9.8"));
-    test("9.8", 1, ("9", ".8"));
-    test("9.8", 2, ("9.", "8"));
-
-    test("3.1415", 0, ("", "3.1415"));
-    test("3.1415", 1, ("3", ".1415"));
-    test("3.1415", 2, ("3.", "1415"));
-
-    test("42.1828", 0, ("", "42.1828"));
-    test("42.1828", 1, ("4", "2.1828"));
-    test("42.1828", 2, ("42", ".1828"));
-    test("42.1828", 3, ("42.", "1828"));
-    test("42.1828", 4, ("42.1", "828"));
-    test("42.1828", 5, ("42.18", "28"));
-    test("42.1828", 6, ("42.182", "8"));
-    test("42.1828", 7, ("42.1828", ""));
-}
-
-#[cfg(test)]
-#[test]
-fn test_digits() {
-    let test = |s: &str, e: &str| {
-        let x = Decimal192::from(s);
-        assert_eq!(x.digits(), e);
-    };
-    test("1", "1000000000000000000");
-    test("1.2", "1200000000000000000");
-    test("123456789.098765432105", "123456789098765432105000000");
-    test(
-        "123456789.098765432105000098",
-        "123456789098765432105000098",
-    );
 }
 
 impl Decimal192 {
@@ -1263,6 +1181,113 @@ mod test_decimal {
         test(x, 4, "3138550867693340381917894711603833208051.16");
         test(x, 5, "3138550867693340381917894711603833208051.15999");
         test(x, 6, "3138550867693340381917894711603833208051.15999");
+    }
+
+    /// Low level test, testing helper function used by formatting of decimal
+    #[test]
+    fn test_insert_grouping_separator_into() {
+        let test_w = |s: &str, exp: &str, sep: char| {
+            let mut string = s.to_owned();
+            insert_grouping_separator_into(&mut string, sep.to_string());
+            assert_eq!(string, exp.to_owned())
+        };
+        let test = |s: &str, exp: &str| test_w(s, exp, ' ');
+
+        test("", "");
+        test("1", "1");
+        test("22", "22");
+        test("333", "333");
+        test("4444", "4 444");
+        test("123456789", "123 456 789");
+        test("12345678987654321", "12 345 678 987 654 321");
+
+        test_w("123456789", "123.456.789", '.');
+        test_w("123456789", "123,456,789", ',');
+    }
+
+    /// Low level test, testing helper function used by formatting of decimal
+    #[test]
+    fn test_trailing_zero_count_of() {
+        let test =
+            |s: &str, exp: usize| assert_eq!(trailing_zero_count_of(s), exp);
+
+        test("", 0);
+        test("1", 0);
+        test("0", 1);
+        test("100", 2);
+        test("1001", 0);
+        test("90000", 4);
+        test("9000.0", 1);
+        test("9.000", 3);
+    }
+
+    /// Low level test, testing helper function used by formatting of decimal
+    #[test]
+    fn test_split_str() {
+        let test = |s: &str, a: i8, exp: (&str, &str)| {
+            let res = split_str(s, a);
+            assert_eq!(res.0, exp.0.to_string());
+            assert_eq!(res.1, exp.1.to_string());
+        };
+
+        test("12345.09876", -2, ("", "12345.09876"));
+
+        test("9.8", 0, ("", "9.8"));
+        test("9.8", 1, ("9", ".8"));
+        test("9.8", 2, ("9.", "8"));
+
+        test("3.1415", 0, ("", "3.1415"));
+        test("3.1415", 1, ("3", ".1415"));
+        test("3.1415", 2, ("3.", "1415"));
+
+        test("42.1828", 0, ("", "42.1828"));
+        test("42.1828", 1, ("4", "2.1828"));
+        test("42.1828", 2, ("42", ".1828"));
+        test("42.1828", 3, ("42.", "1828"));
+        test("42.1828", 4, ("42.1", "828"));
+        test("42.1828", 5, ("42.18", "28"));
+        test("42.1828", 6, ("42.182", "8"));
+        test("42.1828", 7, ("42.1828", ""));
+    }
+
+    /// Low level test, testing helper function used by formatting of decimal
+    #[test]
+    fn test_digits() {
+        let test = |s: &str, e: &str| {
+            let x = Decimal192::from(s);
+            assert_eq!(x.digits(), e);
+        };
+        test("1", "1000000000000000000");
+        test("1.2", "1200000000000000000");
+        test("123456789.098765432105", "123456789098765432105000000");
+        test(
+            "123456789.098765432105000098",
+            "123456789098765432105000098",
+        );
+    }
+
+    #[test]
+    fn format_grouping_separator() {
+        let test = |x: &str, exp: &str| {
+            let locale = LocaleConfig::us();
+            let decimal: Decimal192 = x.into();
+            let actual = decimal.formatted(locale, 8, true);
+            assert_eq!(actual, exp);
+        };
+
+        test("123456789", "123.45679 M");
+        test("12345678", "12.345678 M");
+        test("1234567", "1.234567 M");
+
+        test("123456", "123,456");
+        test("12345", "12,345");
+        test("1234", "1,234");
+        test("123", "123");
+
+        test("123456.4321", "123,456.43");
+        test("12345.4321", "12,345.432");
+        test("1234.4321", "1,234.4321");
+        test("123.4321", "123.4321");
     }
 
     #[test]

--- a/src/core/types/decimal192.rs
+++ b/src/core/types/decimal192.rs
@@ -142,55 +142,236 @@ impl Decimal {
         value.parse()
     }
 
+    /// The number `0` as a `Decimal192`.
+    ///
+    /// ```
+    /// extern crate sargon;
+    /// use sargon::prelude::*;
+    ///
+    /// assert_eq!(Decimal192::zero().to_string(), "0");
+    /// ```
+    ///
     pub fn zero() -> Self {
         Self::from_native(ScryptoDecimal192::zero())
     }
 
+    /// The minimum possible value of `Decimal192`:
+    ///
+    /// ```
+    /// extern crate sargon;
+    /// use sargon::prelude::*;
+    ///
+    /// assert_eq!(Decimal192::min().to_string(), "-3138550867693340381917894711603833208051.177722232017256448");
+    /// ```
+    ///
     pub fn min() -> Self {
         Self::from_native(ScryptoDecimal192::MIN)
     }
 
+    /// The maximum possible value of `Decimal192`
+    ///
+    /// ```
+    /// extern crate sargon;
+    /// use sargon::prelude::*;
+    ///
+    /// assert_eq!(Decimal192::max().to_string(), "3138550867693340381917894711603833208051.177722232017256447");
+    /// ```
+    ///
     pub fn max() -> Self {
         Self::from_native(ScryptoDecimal192::MAX)
     }
 
+    /// The number `1` as a `Decimal192`.
+    ///
+    /// ```
+    /// extern crate sargon;
+    /// use sargon::prelude::*;
+    ///
+    /// assert_eq!(Decimal192::one().to_string(), "1");
+    /// ```
+    ///
     pub fn one() -> Self {
         Self::from_native(ScryptoDecimal192::one())
     }
 
+    /// The number `2` as a `Decimal192`.
+    ///
+    /// ```
+    /// extern crate sargon;
+    /// use sargon::prelude::*;
+    ///
+    /// assert_eq!(Decimal192::two().to_string(), "2");
+    /// ```
+    ///
     pub fn two() -> Self {
         Self::from_native(ScryptoDecimal192::from(2))
     }
 
+    /// The number `3` as a `Decimal192`.
+    ///
+    /// ```
+    /// extern crate sargon;
+    /// use sargon::prelude::*;
+    ///
+    /// assert_eq!(Decimal192::three().to_string(), "3");
+    /// ```
+    ///
     pub fn three() -> Self {
         Self::from_native(ScryptoDecimal192::from(3))
+    }
+
+    /// The number `4` as a `Decimal192`.
+    ///
+    /// ```
+    /// extern crate sargon;
+    /// use sargon::prelude::*;
+    ///
+    /// assert_eq!(Decimal192::four().to_string(), "4");
+    /// ```
+    ///
+    pub fn four() -> Self {
+        Self::from_native(ScryptoDecimal192::from(4))
+    }
+
+    /// The number `5` as a `Decimal192`.
+    ///
+    /// ```
+    /// extern crate sargon;
+    /// use sargon::prelude::*;
+    ///
+    /// assert_eq!(Decimal192::five().to_string(), "5");
+    /// ```
+    ///
+    pub fn five() -> Self {
+        Self::from_native(ScryptoDecimal192::from(5))
+    }
+
+    /// The number `6` as a `Decimal192`.
+    ///
+    /// ```
+    /// extern crate sargon;
+    /// use sargon::prelude::*;
+    ///
+    /// assert_eq!(Decimal192::six().to_string(), "6");
+    /// ```
+    ///
+    pub fn six() -> Self {
+        Self::from_native(ScryptoDecimal192::from(6))
+    }
+
+    /// The number `7` as a `Decimal192`.
+    ///
+    /// ```
+    /// extern crate sargon;
+    /// use sargon::prelude::*;
+    ///
+    /// assert_eq!(Decimal192::seven().to_string(), "7");
+    /// ```
+    ///
+    pub fn seven() -> Self {
+        Self::from_native(ScryptoDecimal192::from(7))
+    }
+
+    /// The number `8` as a `Decimal192`.
+    ///
+    /// ```
+    /// extern crate sargon;
+    /// use sargon::prelude::*;
+    ///
+    /// assert_eq!(Decimal192::eight().to_string(), "8");
+    /// ```
+    ///
+    pub fn eight() -> Self {
+        Self::from_native(ScryptoDecimal192::from(8))
+    }
+
+    /// The number `9` as a `Decimal192`.
+    ///
+    /// ```
+    /// extern crate sargon;
+    /// use sargon::prelude::*;
+    ///
+    /// assert_eq!(Decimal192::nine().to_string(), "9");
+    /// ```
+    ///
+    pub fn nine() -> Self {
+        Self::from_native(ScryptoDecimal192::from(9))
+    }
+
+    /// The number `10` as a `Decimal192`.
+    ///
+    /// ```
+    /// extern crate sargon;
+    /// use sargon::prelude::*;
+    ///
+    /// assert_eq!(Decimal192::ten().to_string(), "10");
+    /// ```
+    ///
+    pub fn ten() -> Self {
+        Self::from_native(ScryptoDecimal192::from(10))
     }
 }
 
 impl Add for Decimal {
     type Output = Self;
-    /// self + rhs
+    /// Addition: `self + rhs`
+    ///
+    /// ```
+    /// extern crate sargon;
+    /// use sargon::prelude::*;
+    ///
+    /// assert_eq!(Decimal::one().add(Decimal::two()), Decimal::three());
+    /// ```
+    ///
     fn add(self, rhs: Self) -> Self::Output {
         Self::from(self.native() + rhs.native())
     }
 }
 impl Sub for Decimal {
     type Output = Self;
-    /// self - rhs
+    /// Subtraction: `self - rhs`
+    ///
+    /// ```
+    /// extern crate sargon;
+    /// use sargon::prelude::*;
+    /// type SUT = Decimal;
+    ///
+    /// assert_eq!(SUT::three().sub(SUT::two()), SUT::one());
+    /// ```
+    ///
     fn sub(self, rhs: Self) -> Self::Output {
         Self::from(self.native() - rhs.native())
     }
 }
 impl Mul for Decimal {
     type Output = Self;
-    /// self * rhs
+    /// Multiplication: `self * rhs`
+    ///
+    /// ```
+    /// extern crate sargon;
+    /// use sargon::prelude::*;
+    /// type SUT = Decimal;
+    ///
+    /// assert_eq!(SUT::two().mul(SUT::three()), SUT::six());
+    /// ```
+    ///
     fn mul(self, rhs: Self) -> Self::Output {
         Self::from(self.native() * rhs.native())
     }
 }
 impl Div for Decimal {
     type Output = Self;
-    /// self / rhs
+    /// Division: `self / rhs`
+    ///
+    /// ```
+    /// extern crate sargon;
+    /// use sargon::prelude::*;
+    /// #[allow(clippy::upper_case_acronyms)]
+    /// type SUT = Decimal;
+    ///
+    /// assert_eq!(SUT::eight().div(SUT::four()), SUT::two());
+    /// ```
+    ///
     fn div(self, rhs: Self) -> Self::Output {
         Self::from(self.native() / rhs.native())
     }
@@ -199,7 +380,17 @@ impl Div for Decimal {
 impl Neg for Decimal {
     type Output = Self;
 
-    /// `-self`
+    /// Negates `self`
+    ///
+    /// ```
+    /// extern crate sargon;
+    /// use sargon::prelude::*;
+    /// #[allow(clippy::upper_case_acronyms)]
+    /// type SUT = Decimal;
+    ///
+    /// assert_eq!(SUT::five().neg().to_string(), "-5");
+    /// ```
+    ///
     fn neg(self) -> Self::Output {
         self.native().neg().into()
     }
@@ -209,38 +400,110 @@ impl Decimal {
     delegate! {
         to self.native() {
 
-            /// Whether this decimal is zero.
+            /// Whether this decimal is zero
+            ///
+            /// ```
+            /// extern crate sargon;
+            /// use sargon::prelude::*;
+            /// #[allow(clippy::upper_case_acronyms)]
+            /// type SUT = Decimal;
+            ///
+            /// assert!(SUT::zero().is_zero());
+            /// assert!(!SUT::one().is_zero());
+            /// assert!(!SUT::one().neg().is_zero());
+            /// ```
+            ///
             pub fn is_zero(&self) -> bool;
 
             /// Whether this decimal is positive.
+            ///
+            /// ```
+            /// extern crate sargon;
+            /// use sargon::prelude::*;
+            /// #[allow(clippy::upper_case_acronyms)]
+            /// type SUT = Decimal;
+            ///
+            /// assert!(SUT::one().is_positive());
+            /// assert!(!SUT::zero().is_positive());
+            /// assert!(!SUT::one().neg().is_positive());
+            /// ```
+            ///
             pub fn is_positive(&self) -> bool;
 
             /// Whether this decimal is negative.
+            ///
+            /// ```
+            /// extern crate sargon;
+            /// use sargon::prelude::*;
+            /// #[allow(clippy::upper_case_acronyms)]
+            /// type SUT = Decimal;
+            ///
+            /// assert!(SUT::one().neg().is_negative());
+            /// assert!(!SUT::one().is_negative());
+            /// assert!(!SUT::zero().is_negative());
+            /// ```
+            ///
             pub fn is_negative(&self) -> bool;
         }
     }
 }
 
 impl Decimal {
-    pub fn checked_powi(&self, exp: i64) -> Option<Self> {
+    /// Creates the Decimal `10^exponent`, returns `None` if overflows.
+    pub(crate) fn checked_powi(&self, exp: i64) -> Option<Self> {
         self.native().checked_powi(exp).map(|n| n.into())
     }
 
     /// Creates the Decimal `10^exponent`
+    ///
+    /// ```
+    /// extern crate sargon;
+    /// use sargon::prelude::*;
+    /// #[allow(clippy::upper_case_acronyms)]
+    /// type SUT = Decimal192;
+    ///
+    /// assert_eq!(SUT::pow(2).to_string(), "100");
+    /// assert_eq!(SUT::pow(3).to_string(), "1000");
+    /// ```
+    ///
     pub fn pow(exponent: u8) -> Self {
         Self::from(10)
             .checked_powi(exponent as i64)
             .expect("Too large exponent, 10^39 is max.")
     }
 
-    /// `abs(self)`
-    /// Panics if Self is Self::MIN.
+    /// Returns the absolute value.
+    ///
+    /// ```
+    /// extern crate sargon;
+    /// use sargon::prelude::*;
+    /// #[allow(clippy::upper_case_acronyms)]
+    /// type SUT = Decimal192;
+    ///
+    /// assert_eq!(SUT::two().neg().abs(), SUT::two());
+    /// assert_eq!(SUT::three().abs(), SUT::three());
+    /// assert_eq!(SUT::max().abs(), SUT::max());
+    /// ```
+    ///
+    /// # Panics
+    /// Panics if Self is `Self::min*(`.
+    ///
     pub fn abs(&self) -> Self {
         self.native().checked_abs().expect("Expected clients of Sargon to not use so large negative numbers (Self::MIN).").into()
     }
 
-    /// `max(self, 0)`, which is often called
-    /// "clamping to zero"
+    /// `max(self, 0)`, which is often called "clamping to zero"
+    ///
+    /// ```
+    /// extern crate sargon;
+    /// use sargon::prelude::*;
+    /// #[allow(clippy::upper_case_acronyms)]
+    /// type SUT = Decimal192;
+    ///
+    /// assert_eq!(SUT::one().neg().clamped_to_zero(), SUT::zero());
+    /// assert_eq!(SUT::two().clamped_to_zero(), SUT::two());
+    /// ```
+    ///
     pub fn clamped_to_zero(self) -> Self {
         if self.is_negative() {
             Self::zero()
@@ -392,6 +655,7 @@ impl Decimal192 {
     }
 }
 
+/// Million, Billion or Trillion, helper for Decimal192 formatting.
 #[derive(
     Serialize_repr,
     Deserialize_repr,
@@ -413,24 +677,30 @@ pub(crate) enum Multiplier {
     Billion = 9,
     Trillion = 12,
 }
+
 impl Multiplier {
     /// The exponent of this multiplier
     pub fn discriminant(&self) -> u8 {
         *self as u8
     }
+
+    /// The exponent of a `Multiplier`, i.e. `6` for `Million`.
     pub(crate) fn value(&self) -> Decimal192 {
         Decimal192::pow(self.discriminant())
     }
-    pub(crate) fn suffix(&self) -> String {
+
+    /// Symbol of a `Multiplier`, i.e. 'M' for `Million`.
+    pub(crate) fn suffix(&self) -> char {
         match self {
-            Self::Million => "M",
-            Self::Billion => "B",
-            Self::Trillion => "T",
+            Self::Million => 'M',
+            Self::Billion => 'B',
+            Self::Trillion => 'T',
         }
         .to_owned()
     }
 }
 
+/// Format decimal helper - counts '0' at end of `s`.
 fn trailing_zero_count_of(s: impl AsRef<str>) -> usize {
     let str = s.as_ref();
     str.chars()
@@ -441,6 +711,7 @@ fn trailing_zero_count_of(s: impl AsRef<str>) -> usize {
         .unwrap_or(str.len())
 }
 
+/// Format decimal helper - inserts `separator` at every `3` places.
 fn insert_grouping_separator_into(s: &mut String, separator: String) {
     let digits = s.len();
     let zeroes_per_thousand = 3;
@@ -457,13 +728,14 @@ fn insert_grouping_separator_into(s: &mut String, separator: String) {
     }
 }
 
+/// Format decimal helper - splits string after `after` if pos, else at 0.
 fn split_str(s: impl AsRef<str>, after: i8) -> (String, String) {
     let mut s = s.as_ref().to_owned();
     if after <= 0 {
-        return ("".to_owned(), s);
+        ("".to_owned(), s)
+    } else {
+        (s.drain(0..after as usize).collect(), s)
     }
-    let other: String = s.drain(0..after as usize).collect();
-    (other, s)
 }
 
 impl Decimal192 {
@@ -500,32 +772,19 @@ impl Decimal192 {
             }
         }
         if trailing_zero_count >= Self::SCALE as usize {
-            // println!("🔮🥓 No non-zero decimals, we only have an integer part");
             // No non-zero decimals, we only have an integer part
             format!("{}{}", sign, integer_part)
         } else {
             let zeros_to_pad = std::cmp::max(-integer_count, 0) as usize;
             let zeroes = "0".repeat(zeros_to_pad);
-            // println!("🔮 trailing_zero_count: '{}'", trailing_zero_count);
-            // println!("🔮 decimal_part: '{}'", decimal_part);
             decimal_part = decimal_part
                 .drain(0..decimal_part.len() - trailing_zero_count)
                 .collect();
-            // println!("🔮 AFTER decimal_part: '{}'", decimal_part);
 
-            let a = sign.to_owned();
-            let b = integer_part.clone();
-            let c = decimal_separator.clone();
-            let d = zeroes.clone();
-            let e = decimal_part.clone();
-            let res = format!("{}{}{}{}{}", a, b, c, d, e);
-            // println!("🔮 a: '{}'", a);
-            // println!("🔮 b: '{}'", b);
-            // println!("🔮 c: '{}'", c);
-            // println!("🔮 d: '{}'", d);
-            // println!("🔮 e: '{}'", e);
-            // println!("🔮 RES: {}", res);
-            res
+            format!(
+                "{}{}{}{}{}",
+                sign, integer_part, decimal_separator, zeroes, decimal_part
+            )
         }
     }
 
@@ -544,32 +803,18 @@ impl Decimal192 {
         locale: LocaleConfig,
         decimal_places: u8,
     ) -> String {
-        let rounded = self.rounded_n_digits(decimal_places);
+        let rounded = self.rounded_to_total_places(decimal_places);
         let integer_count = rounded.digits().len() as u8 - Self::SCALE;
         let exponent = integer_count - 1;
         let scaled = rounded / Self::pow(exponent);
-
-        // println!("🚀 engineer - decimal_places: '{}", &decimal_places);
-        // println!("🚀 engineer - rounded: '{}", &rounded);
-        // println!("🚀 engineer - rounded.digits(): '{}", &rounded.digits());
-        // println!("🚀 engineer - integerCount: '{}'", &integer_count);
-        // println!("🚀 engineer - exponent: '{}'", &exponent);
-        // println!("🚀 engineer - scaled: '{}'", &scaled);
-        // println!("🚀 engineer - scaled.digits(): '{}'", &scaled.digits());
-
-        let a = scaled.formatted_plain(locale, false);
-        let b = exponent;
-        // println!("🚀 engineer - a: '{}'", &a);
-        // println!("🚀 engineer - b: '{}'", &b);
-        let res = format!("{}e{}", a, b);
-        // println!("🚀 res: '{}'", &res);
-        res
+        format!("{}e{}", scaled.formatted_plain(locale, false), exponent)
     }
 }
 
 impl Decimal192 {
-    /// Rounds to `n` digits, counting both the integer and decimal parts, as well as any leading zeros
-    fn rounded_n_digits(&self, n: u8) -> Self {
+    /// Rounds `self`` to `n` places, counting both the integer and decimal parts,
+    /// as well as any leading zeros.
+    pub(crate) fn rounded_to_total_places(&self, n: u8) -> Self {
         let total_places = n;
         let digits = self.digits();
         // If we only have decimals, we will still count the 0 before the separator as an integer
@@ -587,18 +832,6 @@ impl Decimal192 {
     }
 }
 
-#[cfg(test)]
-#[test]
-fn do_test_formatted_engineering_notation() {
-    let test = |x: &str, n: u8, expected: &str| {
-        let a = Decimal192::from(x);
-        let actual = a.formatted_engineering_notation(LocaleConfig::us(), n);
-        assert_eq!(actual, expected);
-    };
-    test("111222111222111222333.222333", 18, "1.11222111222111222e20");
-    test("111222111222111222333.222333", 8, "1.1122211e20");
-}
-
 impl Decimal192 {
     /// A human readable, locale respecting string, rounded to `decimal_places` places, counting all digits
     pub fn formatted(
@@ -610,30 +843,19 @@ impl Decimal192 {
         let format = |number: Self| {
             number.formatted_plain(locale.clone(), use_grouping_separator)
         };
-        // println!("🌱 decimal_places: '{}'", &decimal_places);
-        let rounded_to_total_places = self.rounded_n_digits(decimal_places);
-        // println!("🌱 rounded_to_total_places: '{}'", &rounded_to_total_places);
+        let rounded_to_total_places =
+            self.rounded_to_total_places(decimal_places);
 
         if let Some(multiplier) = rounded_to_total_places.multiplier() {
-            // println!("✨ multiplier '{:?}'", &multiplier);
             let scaled = rounded_to_total_places / multiplier.value();
-            // println!("✨ scaled '{}'", &scaled);
             let integer_count = scaled.digits().len() as u8 - Self::SCALE;
-            // println!("✨ integer_count '{}'", &integer_count);
             if integer_count > decimal_places {
-                // println!("✨ USING ENGINEERING");
                 self.formatted_engineering_notation(
                     locale,
                     Self::MAX_PLACES_ENGINEERING_NOTATION,
                 )
             } else {
-                let a = format(scaled);
-                let b = multiplier.suffix();
-                let res = format!("{} {}", a, b);
-                // println!("✨ a '{}'", &a);
-                // println!("✨ b '{}'", &b);
-                // println!("✨ RES '{}'", &res);
-                res
+                format!("{} {}", format(scaled), multiplier.suffix())
             }
         } else {
             format(rounded_to_total_places)
@@ -1029,6 +1251,18 @@ mod test_decimal {
     fn from_negative_string() {
         let sut: SUT = "-3.2".parse().unwrap();
         assert_eq!(sut * sut, "10.24".parse().unwrap());
+    }
+
+    #[test]
+    fn test_formatted_engineering_notation() {
+        let test = |x: &str, n: u8, expected: &str| {
+            let a = Decimal192::from(x);
+            let actual =
+                a.formatted_engineering_notation(LocaleConfig::us(), n);
+            assert_eq!(actual, expected);
+        };
+        test("111222111222111222333.222333", 18, "1.11222111222111222e20");
+        test("111222111222111222333.222333", 8, "1.1122211e20");
     }
 
     #[test]

--- a/src/core/types/locale_config.rs
+++ b/src/core/types/locale_config.rs
@@ -16,46 +16,30 @@ impl LocaleConfig {
             grouping_separator: grouping_separator.into(),
         }
     }
-}
 
-impl Default for LocaleConfig {
-    fn default() -> Self {
-        Self::new(".".to_owned(), " ".to_owned())
-    }
-}
-
-impl From<num_format::Locale> for LocaleConfig {
-    fn from(value: num_format::Locale) -> Self {
+    pub fn with(
+        decimal_separator: impl AsRef<str>,
+        grouping_separator: impl AsRef<str>,
+    ) -> Self {
         Self::new(
-            Some(value.decimal().to_owned()),
-            Some(value.separator().to_owned()),
+            Some(decimal_separator.as_ref().to_owned()),
+            Some(grouping_separator.as_ref().to_owned()),
         )
     }
 }
 
-impl LocaleConfig {
-    /// Tries to create a
-    /// A BCP-47 language identifier such as `"en_US_POSIX"`, `"sv_FI"` or `"zh_Hant_MO"`,
-    /// see: [list][list]
-    ///
-    /// [list]: https://docs.rs/num-format/0.4.4/src/num_format/locale.rs.html#5565-6444
-    pub fn from_identifier(identifier: impl AsRef<str>) -> Result<Self> {
-        let identifier = identifier.as_ref().to_owned();
-        num_format::Locale::from_name(identifier.clone())
-            .map_err(|_| CommonError::UnrecognizedLocaleIdentifier {
-                bad_value: identifier,
-            })
-            .map(Self::from)
+impl Default for LocaleConfig {
+    fn default() -> Self {
+        Self::with(".", " ")
     }
 }
 
-#[cfg(test)]
 impl LocaleConfig {
-    pub fn swedish() -> Self {
-        Self::from_identifier("sv").expect("Sweden exists")
+    pub fn swedish_sweden() -> Self {
+        Self::with(",", "\u{a0}")
     }
-    pub fn us() -> Self {
-        Self::from_identifier("en_US_POSIX").expect("US exists")
+    pub fn english_united_states() -> Self {
+        Self::with(".", ",")
     }
 }
 
@@ -65,17 +49,30 @@ mod tests {
 
     #[test]
     fn swedish() {
-        assert_eq!(LocaleConfig::swedish().decimal_separator.unwrap(), ",");
         assert_eq!(
-            LocaleConfig::swedish().grouping_separator.unwrap(),
+            LocaleConfig::swedish_sweden().decimal_separator.unwrap(),
+            ","
+        );
+        assert_eq!(
+            LocaleConfig::swedish_sweden().grouping_separator.unwrap(),
             "\u{a0}"
         );
     }
 
     #[test]
     fn english_us() {
-        assert_eq!(LocaleConfig::us().decimal_separator.unwrap(), ".");
-        assert_eq!(LocaleConfig::us().grouping_separator.unwrap(), ",");
+        assert_eq!(
+            LocaleConfig::english_united_states()
+                .decimal_separator
+                .unwrap(),
+            "."
+        );
+        assert_eq!(
+            LocaleConfig::english_united_states()
+                .grouping_separator
+                .unwrap(),
+            ","
+        );
     }
 
     #[test]
@@ -88,15 +85,5 @@ mod tests {
     fn default_uses_dot_as_decimal_separator() {
         let sut = LocaleConfig::default();
         assert_eq!(&sut.decimal_separator.unwrap(), ".");
-    }
-
-    #[test]
-    fn from_identifier_invalid() {
-        assert_eq!(
-            LocaleConfig::from_identifier("foo"),
-            Err(CommonError::UnrecognizedLocaleIdentifier {
-                bad_value: "foo".to_owned()
-            })
-        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ pub mod prelude {
     pub(crate) use std::cmp::Ordering;
     pub(crate) use std::collections::BTreeMap;
     pub(crate) use std::fs;
-    pub(crate) use std::ops::{Add, AddAssign, Deref, Div, Mul, Neg, Sub};
+    pub use std::ops::{Add, AddAssign, Deref, Div, Mul, Neg, Sub};
     pub(crate) use std::str::FromStr;
     pub(crate) use std::sync::Arc;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ pub mod prelude {
     pub(crate) use serde_repr::{Deserialize_repr, Serialize_repr};
     pub(crate) use serde_with::*;
 
+    pub use radix_engine_common::math::traits::CheckedMul as ScryptoCheckedMul;
     pub(crate) use std::cmp::Ordering;
     pub(crate) use std::collections::BTreeMap;
     pub(crate) use std::fs;

--- a/src/profile/v100/address/account_address.rs
+++ b/src/profile/v100/address/account_address.rs
@@ -184,6 +184,7 @@ mod tests {
             PublicKey::Ed25519 { value: public_key },
             network_id,
         );
+
         assert_eq!(address.address(), "account_tdx_e_128vkt2fur65p4hqhulfv3h0cknrppwtjsstlttkfamj4jnnpm82gsw");
 
         use radix_engine_toolkit::models::canonical_address_types::{

--- a/src/profile/v100/address/non_fungible_global_id.rs
+++ b/src/profile/v100/address/non_fungible_global_id.rs
@@ -139,6 +139,17 @@ impl FromStr for NonFungibleGlobalId {
     }
 }
 
+#[cfg(test)]
+impl From<&str> for NonFungibleGlobalId {
+    /// TEST ONLY
+    fn from(value: &str) -> Self {
+        value.parse().expect(&format!(
+            "Test failed since the passed in str is not a NonFungibleGlobalId: '{}'",
+            value
+        ))
+    }
+}
+
 impl NonFungibleGlobalId {
     /// Returns the canonical string representation of a NonFungibleGlobalID: "<resource>:<local>"
     ///

--- a/src/profile/v100/address/non_fungible_global_id.rs
+++ b/src/profile/v100/address/non_fungible_global_id.rs
@@ -143,10 +143,8 @@ impl FromStr for NonFungibleGlobalId {
 impl From<&str> for NonFungibleGlobalId {
     /// TEST ONLY
     fn from(value: &str) -> Self {
-        value.parse().expect(&format!(
-            "Test failed since the passed in str is not a NonFungibleGlobalId: '{}'",
-            value
-        ))
+        value.parse().unwrap_or_else(|_| panic!("Test failed since the passed in str is not a NonFungibleGlobalId: '{}'",
+            value))
     }
 }
 

--- a/src/profile/v100/address/non_fungible_local_id.rs
+++ b/src/profile/v100/address/non_fungible_local_id.rs
@@ -136,7 +136,7 @@ impl FromStr for NonFungibleLocalId {
 impl From<&str> for NonFungibleLocalId {
     /// TEST ONLY
     fn from(value: &str) -> Self {
-        value.parse().expect(&format!("Test failed since the passed in str is not a valid NonFungibleLocalId: '{}'", value))
+        value.parse().unwrap_or_else(|_| panic!("Test failed since the passed in str is not a valid NonFungibleLocalId: '{}'", value))
     }
 }
 

--- a/src/profile/v100/address/non_fungible_local_id.rs
+++ b/src/profile/v100/address/non_fungible_local_id.rs
@@ -132,6 +132,14 @@ impl FromStr for NonFungibleLocalId {
     }
 }
 
+#[cfg(test)]
+impl From<&str> for NonFungibleLocalId {
+    /// TEST ONLY
+    fn from(value: &str) -> Self {
+        value.parse().expect(&format!("Test failed since the passed in str is not a valid NonFungibleLocalId: '{}'", value))
+    }
+}
+
 impl HasSampleValues for NonFungibleLocalId {
     fn sample() -> Self {
         Self::ruid(Exactly32Bytes::sample_dead()).unwrap()

--- a/src/profile/v100/address/non_fungible_resource_address.rs
+++ b/src/profile/v100/address/non_fungible_resource_address.rs
@@ -88,6 +88,14 @@ macro_rules! decl_specialized_address {
                 }
             }
 
+            #[cfg(test)]
+            impl From<&str> for $specialized_address_type {
+                /// TEST ONLY
+                fn from(value: &str) -> Self {
+                    value.parse().expect(&format!("Test failed since the passed in str is not a valid address: '{}'", value))
+                }
+            }
+
             impl AddressViaRet for $specialized_address_type {
                 fn new(
                     node_id: impl Into<ScryptoNodeId>,

--- a/src/profile/v100/address/wrap_ret_address.rs
+++ b/src/profile/v100/address/wrap_ret_address.rs
@@ -87,6 +87,14 @@ macro_rules! decl_ret_wrapped_address {
                 }
             }
 
+            #[cfg(test)]
+            impl From<&str> for [< $address_type:camel Address >] {
+                /// TEST ONLY
+                fn from(value: &str) -> Self {
+                    value.parse().expect(&format!("Test failed since the passed in str is not a valid address: '{}'", value))
+                }
+            }
+
             impl FromRetAddress for [< $address_type:camel Address >] {
                 type RetAddress = [< Ret $address_type:camel Address >];
             }

--- a/src/wrapped_radix_engine_toolkit/high_level/manifest_building/bucket.rs
+++ b/src/wrapped_radix_engine_toolkit/high_level/manifest_building/bucket.rs
@@ -10,6 +10,7 @@ impl AsRef<str> for Bucket {
         self.name.as_str()
     }
 }
+
 impl ScryptoNewManifestBucket for &Bucket {
     fn register(self, registrar: &ScryptoManifestNameRegistrar) {
         registrar.register_bucket(registrar.new_bucket(self.name.clone()));

--- a/src/wrapped_radix_engine_toolkit/high_level/manifest_building/manifest_assets_transfers.rs
+++ b/src/wrapped_radix_engine_toolkit/high_level/manifest_building/manifest_assets_transfers.rs
@@ -154,166 +154,8 @@ mod tests {
 
     #[test]
     fn multi_token_multi_recipient() {
-        let sender: AccountAddress = "account_tdx_2_128rkfzdztjpgajucstydar2gz2vp9jj779k33jy3gect2rh5r28rgn".parse().unwrap();
-        let recip0: AccountAddress = "account_tdx_2_129e9h6zp5z08qkc0q5tdqz9zc67gg2k7tergrj9erznmke6qeevmsv".parse().unwrap();
-        let recip1: AccountAddress = "account_tdx_2_128a45a7hetjfpfqdlsp07eyrmhq7edldefgd7263jd58puzuq09qks".parse().unwrap();
-
-        let nft_c0: NonFungibleResourceAddress = "resource_tdx_2_1n2sjxxtk6vm6pvk8dxr798e8zpxqz50q5wlmldlat0qhh04u2mwmy8".parse().unwrap();
-        let nft_c1: NonFungibleResourceAddress = "resource_tdx_2_1ntuaekqexa73m9en04jj3vdt3fk9u9kdk8q9su4efldun2y7nd3cga".parse().unwrap();
-
-        let fung_0: ResourceAddress = ResourceAddress::sample_stokenet_xrd();
-        let fung_1: ResourceAddress =
-            ResourceAddress::sample_stokenet_gc_tokens();
-
-        let per_recipient_transfers = PerRecipientAssetTransfers::new(
-            sender.clone(),
-            [
-                PerRecipientAssetTransfer::new(
-                    recip0.clone(),
-                    [
-                        PerRecipientFungibleTransfer::new(
-                            fung_0.clone(),
-                            30,
-                            true,
-                            18,
-                        ),
-                        PerRecipientFungibleTransfer::new(
-                            fung_1.clone(),
-                            3,
-                            true,
-                            18,
-                        ),
-                    ],
-                    [
-                        PerRecipientNonFungiblesTransfer::new(
-                            nft_c0.clone(),
-                            true,
-                            [
-                                NonFungibleLocalId::integer(40),
-                                NonFungibleLocalId::integer(48),
-                            ],
-                        ),
-                        PerRecipientNonFungiblesTransfer::new(
-                            nft_c1.clone(),
-                            true,
-                            [
-                                NonFungibleLocalId::integer(21),
-                                NonFungibleLocalId::integer(3),
-                            ],
-                        ),
-                    ],
-                ),
-                PerRecipientAssetTransfer::new(
-                    recip1.clone(),
-                    [
-                        PerRecipientFungibleTransfer::new(
-                            fung_0.clone(),
-                            50,
-                            true,
-                            18,
-                        ),
-                        PerRecipientFungibleTransfer::new(
-                            fung_1.clone(),
-                            5,
-                            true,
-                            18,
-                        ),
-                    ],
-                    [
-                        PerRecipientNonFungiblesTransfer::new(
-                            nft_c0.clone(),
-                            true,
-                            [
-                                NonFungibleLocalId::integer(34),
-                                NonFungibleLocalId::integer(22),
-                            ],
-                        ),
-                        PerRecipientNonFungiblesTransfer::new(
-                            nft_c1.clone(),
-                            true,
-                            [
-                                NonFungibleLocalId::integer(15),
-                                NonFungibleLocalId::integer(9),
-                                NonFungibleLocalId::integer(13),
-                            ],
-                        ),
-                    ],
-                ),
-            ],
-        );
-
-        let per_asset_transfers = PerAssetTransfers::new(
-            sender.clone(),
-            [
-                PerAssetTransfersOfFungibleResource::new(
-                    PerAssetFungibleResource::new(fung_0.clone(), 18),
-                    [
-                        PerAssetFungibleTransfer::new(recip0.clone(), true, 30),
-                        PerAssetFungibleTransfer::new(recip1.clone(), true, 50),
-                    ],
-                ),
-                PerAssetTransfersOfFungibleResource::new(
-                    PerAssetFungibleResource::new(fung_1.clone(), 18),
-                    [
-                        PerAssetFungibleTransfer::new(recip0.clone(), true, 3),
-                        PerAssetFungibleTransfer::new(recip1.clone(), true, 5),
-                    ],
-                ),
-            ],
-            [
-                PerAssetTransfersOfNonFungibleResource::new(
-                    nft_c0.clone(),
-                    [
-                        PerAssetNonFungibleTransfer::new(
-                            recip0.clone(),
-                            true,
-                            [
-                                NonFungibleLocalId::integer(40),
-                                NonFungibleLocalId::integer(48),
-                            ],
-                        ),
-                        PerAssetNonFungibleTransfer::new(
-                            recip1.clone(),
-                            true,
-                            [
-                                NonFungibleLocalId::integer(34),
-                                NonFungibleLocalId::integer(22),
-                            ],
-                        ),
-                    ],
-                ),
-                PerAssetTransfersOfNonFungibleResource::new(
-                    nft_c1.clone(),
-                    [
-                        PerAssetNonFungibleTransfer::new(
-                            recip0.clone(),
-                            true,
-                            [
-                                NonFungibleLocalId::integer(21),
-                                NonFungibleLocalId::integer(3),
-                            ],
-                        ),
-                        PerAssetNonFungibleTransfer::new(
-                            recip1.clone(),
-                            true,
-                            [
-                                NonFungibleLocalId::integer(15),
-                                NonFungibleLocalId::integer(9),
-                                NonFungibleLocalId::integer(13),
-                            ],
-                        ),
-                    ],
-                ),
-            ],
-        );
-
-        let transposed = per_recipient_transfers.clone().transpose();
-        pretty_assertions::assert_eq!(per_asset_transfers.clone(), transposed);
-
-        let sut = SUT::per_asset_transfers(per_asset_transfers.clone());
-        assert_eq!(
-            SUT::per_recipient_transfers(per_recipient_transfers),
-            sut.clone()
+        let sut = SUT::per_recipient_transfers(
+            PerRecipientAssetTransfers::sample_other(),
         );
 
         manifest_eq(
@@ -513,14 +355,14 @@ mod tests {
         CALL_METHOD
             Address("account_rdx16xlfcpp0vf7e3gqnswv8j9k58n6rjccu58vvspmdva22kf3aplease")
             "withdraw_non_fungibles"
-            Address("resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd")
+            Address("resource_rdx1nfyg2f68jw7hfdlg5hzvd8ylsa7e0kjl68t5t62v3ttamtejc9wlxa")
             Array<NonFungibleLocalId>(
                 NonFungibleLocalId("{deaddeaddeaddead-deaddeaddeaddead-deaddeaddeaddead-deaddeaddeaddead}"),
                 NonFungibleLocalId("<foobar>")
             )
         ;
         TAKE_NON_FUNGIBLES_FROM_WORKTOP
-            Address("resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd")
+            Address("resource_rdx1nfyg2f68jw7hfdlg5hzvd8ylsa7e0kjl68t5t62v3ttamtejc9wlxa")
             Array<NonFungibleLocalId>(
                 NonFungibleLocalId("{deaddeaddeaddead-deaddeaddeaddead-deaddeaddeaddead-deaddeaddeaddead}"),
                 NonFungibleLocalId("<foobar>")
@@ -534,7 +376,7 @@ mod tests {
             Enum<0u8>()
         ;
         TAKE_NON_FUNGIBLES_FROM_WORKTOP
-            Address("resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd")
+            Address("resource_rdx1nfyg2f68jw7hfdlg5hzvd8ylsa7e0kjl68t5t62v3ttamtejc9wlxa")
             Array<NonFungibleLocalId>(
                 NonFungibleLocalId("<foobar>")
             )
@@ -549,13 +391,13 @@ mod tests {
         CALL_METHOD
             Address("account_rdx16xlfcpp0vf7e3gqnswv8j9k58n6rjccu58vvspmdva22kf3aplease")
             "withdraw_non_fungibles"
-            Address("resource_rdx1t4dy69k6s0gv040xa64cyadyefwtett62ng6xfdnljyydnml7t6g3j")
+            Address("resource_rdx1n2ekdd2m0jsxjt9wasmu3p49twy2yfalpaa6wf08md46sk8dfmldnd")
             Array<NonFungibleLocalId>(
                 NonFungibleLocalId("<foobar>")
             )
         ;
         TAKE_NON_FUNGIBLES_FROM_WORKTOP
-            Address("resource_rdx1t4dy69k6s0gv040xa64cyadyefwtett62ng6xfdnljyydnml7t6g3j")
+            Address("resource_rdx1n2ekdd2m0jsxjt9wasmu3p49twy2yfalpaa6wf08md46sk8dfmldnd")
             Array<NonFungibleLocalId>(
                 NonFungibleLocalId("<foobar>")
             )

--- a/src/wrapped_radix_engine_toolkit/high_level/manifest_building/modify_manifest.rs
+++ b/src/wrapped_radix_engine_toolkit/high_level/manifest_building/modify_manifest.rs
@@ -174,7 +174,7 @@ mod tests {
 
     #[test]
     fn default_dev_fee_is() {
-        assert_eq!(default_fee().to_string(), "25");
+        assert_eq!(default_fee(), 25.into());
     }
 
     #[test]

--- a/src/wrapped_radix_engine_toolkit/high_level/manifest_building/third_party_deposit_update/manifest_third_party_deposit_update.rs
+++ b/src/wrapped_radix_engine_toolkit/high_level/manifest_building/third_party_deposit_update/manifest_third_party_deposit_update.rs
@@ -78,7 +78,7 @@ mod tests {
 
     #[test]
     fn update_third_party_deposits() {
-        let owner:AccountAddress = "account_tdx_2_128x8q5es2dstqtcc8wqm843xdtfs0lgetfcdn62a54wxspj6yhpxkf".parse().unwrap();
+        let owner:AccountAddress = "account_tdx_2_128x8q5es2dstqtcc8wqm843xdtfs0lgetfcdn62a54wxspj6yhpxkf".into();
         let to_json = r#"
         {
             "assetsExceptionList" : [

--- a/src/wrapped_radix_engine_toolkit/high_level/sargon_specific_types/assets_transfers/per_asset/per_asset_fungible_resource.rs
+++ b/src/wrapped_radix_engine_toolkit/high_level/sargon_specific_types/assets_transfers/per_asset/per_asset_fungible_resource.rs
@@ -3,13 +3,13 @@ use crate::prelude::*;
 #[derive(Clone, Debug, PartialEq, Eq, Hash, uniffi::Record)]
 pub struct PerAssetFungibleResource {
     pub resource_address: ResourceAddress,
-    pub divisibility: Option<i32>,
+    pub divisibility: Option<u8>,
 }
 
 impl PerAssetFungibleResource {
     pub fn new(
         resource_address: ResourceAddress,
-        divisibility: impl Into<Option<i32>>,
+        divisibility: impl Into<Option<u8>>,
     ) -> Self {
         Self {
             resource_address,

--- a/src/wrapped_radix_engine_toolkit/high_level/sargon_specific_types/assets_transfers/per_asset/per_asset_fungible_transfer.rs
+++ b/src/wrapped_radix_engine_toolkit/high_level/sargon_specific_types/assets_transfers/per_asset/per_asset_fungible_transfer.rs
@@ -59,7 +59,7 @@ impl PerAssetFungibleTransfer {
 
     pub(crate) fn sample_mainnet_other() -> Self {
         Self::new(AssetsTransfersRecipient::ForeignAccount {
-            value: AccountAddress::from_str("account_rdx129a9wuey40lducsf6yu232zmzk5kscpvnl6fv472r0ja39f3hced69").unwrap() 
+            value: AccountAddress::from_str("account_rdx129a9wuey40lducsf6yu232zmzk5kscpvnl6fv472r0ja39f3hced69").unwrap()
         },
         true,
         Decimal192::from_str("987654.1234").unwrap())

--- a/src/wrapped_radix_engine_toolkit/high_level/sargon_specific_types/assets_transfers/per_asset/per_asset_fungible_transfer.rs
+++ b/src/wrapped_radix_engine_toolkit/high_level/sargon_specific_types/assets_transfers/per_asset/per_asset_fungible_transfer.rs
@@ -15,7 +15,7 @@ impl PerAssetFungibleTransfer {
 
     pub fn amount(
         &self,
-        divisibility: impl Into<Option<i32>>,
+        divisibility: impl Into<Option<u8>>,
     ) -> ScryptoDecimal192 {
         self.amount.round(divisibility).into()
     }

--- a/src/wrapped_radix_engine_toolkit/high_level/sargon_specific_types/assets_transfers/per_asset/per_asset_transfers_of_non_fungible_resource.rs
+++ b/src/wrapped_radix_engine_toolkit/high_level/sargon_specific_types/assets_transfers/per_asset/per_asset_transfers_of_non_fungible_resource.rs
@@ -41,7 +41,7 @@ impl PerAssetTransfersOfNonFungibleResource {
 impl PerAssetTransfersOfNonFungibleResource {
     pub(crate) fn sample_mainnet() -> Self {
         Self::new(
-            ResourceAddress::sample_mainnet_xrd(),
+            NonFungibleResourceAddress::sample_mainnet(),
             [
                 PerAssetNonFungibleTransfer::sample_mainnet(),
                 PerAssetNonFungibleTransfer::sample_mainnet_other(),
@@ -51,14 +51,14 @@ impl PerAssetTransfersOfNonFungibleResource {
 
     pub(crate) fn sample_mainnet_other() -> Self {
         Self::new(
-            ResourceAddress::sample_mainnet_candy(),
+            NonFungibleResourceAddress::sample_mainnet_other(),
             [PerAssetNonFungibleTransfer::sample_mainnet_other()],
         )
     }
 
     pub(crate) fn sample_stokenet() -> Self {
         Self::new(
-            ResourceAddress::sample_stokenet_candy(),
+            NonFungibleResourceAddress::sample_stokenet(),
             [
                 PerAssetNonFungibleTransfer::sample_stokenet(),
                 PerAssetNonFungibleTransfer::sample_stokenet_other(),
@@ -68,7 +68,7 @@ impl PerAssetTransfersOfNonFungibleResource {
 
     pub(crate) fn sample_stokenet_other() -> Self {
         Self::new(
-            ResourceAddress::sample_stokenet_gum(),
+            NonFungibleResourceAddress::sample_stokenet_other(),
             [PerAssetNonFungibleTransfer::sample_stokenet_other()],
         )
     }

--- a/src/wrapped_radix_engine_toolkit/high_level/sargon_specific_types/assets_transfers/per_recipient/per_recipient_asset_transfers.rs
+++ b/src/wrapped_radix_engine_toolkit/high_level/sargon_specific_types/assets_transfers/per_recipient/per_recipient_asset_transfers.rs
@@ -303,12 +303,12 @@ mod tests {
 
     #[test]
     fn transpose_complex() {
-        let sender: AccountAddress = "account_tdx_2_128rkfzdztjpgajucstydar2gz2vp9jj779k33jy3gect2rh5r28rgn".parse().unwrap();
-        let recip0: AccountAddress = "account_tdx_2_129e9h6zp5z08qkc0q5tdqz9zc67gg2k7tergrj9erznmke6qeevmsv".parse().unwrap();
-        let recip1: AccountAddress = "account_tdx_2_128a45a7hetjfpfqdlsp07eyrmhq7edldefgd7263jd58puzuq09qks".parse().unwrap();
+        let sender: AccountAddress = "account_tdx_2_128rkfzdztjpgajucstydar2gz2vp9jj779k33jy3gect2rh5r28rgn".into();
+        let recip0: AccountAddress = "account_tdx_2_129e9h6zp5z08qkc0q5tdqz9zc67gg2k7tergrj9erznmke6qeevmsv".into();
+        let recip1: AccountAddress = "account_tdx_2_128a45a7hetjfpfqdlsp07eyrmhq7edldefgd7263jd58puzuq09qks".into();
 
-        let nft_c0: NonFungibleResourceAddress = "resource_tdx_2_1n2sjxxtk6vm6pvk8dxr798e8zpxqz50q5wlmldlat0qhh04u2mwmy8".parse().unwrap();
-        let nft_c1: NonFungibleResourceAddress = "resource_tdx_2_1ntuaekqexa73m9en04jj3vdt3fk9u9kdk8q9su4efldun2y7nd3cga".parse().unwrap();
+        let nft_c0: NonFungibleResourceAddress = "resource_tdx_2_1n2sjxxtk6vm6pvk8dxr798e8zpxqz50q5wlmldlat0qhh04u2mwmy8".into();
+        let nft_c1: NonFungibleResourceAddress = "resource_tdx_2_1ntuaekqexa73m9en04jj3vdt3fk9u9kdk8q9su4efldun2y7nd3cga".into();
 
         let fung_0: ResourceAddress = ResourceAddress::sample_stokenet_xrd();
         let fung_1: ResourceAddress =

--- a/src/wrapped_radix_engine_toolkit/high_level/sargon_specific_types/assets_transfers/per_recipient/per_recipient_asset_transfers.rs
+++ b/src/wrapped_radix_engine_toolkit/high_level/sargon_specific_types/assets_transfers/per_recipient/per_recipient_asset_transfers.rs
@@ -57,11 +57,135 @@ impl PerRecipientAssetTransfers {
 
 impl HasSampleValues for PerRecipientAssetTransfers {
     fn sample() -> Self {
-        Self::sample_mainnet()
+        Self::new(
+            AccountAddress::sample_mainnet(),
+            [PerRecipientAssetTransfer::new(
+                Account::sample_mainnet_carol(),
+                [PerRecipientFungibleTransfer::new(
+                    ResourceAddress::sample_mainnet_xrd(),
+                    Decimal192::from_str("237.13372718281828").unwrap(),
+                    true,
+                    None,
+                )],
+                [
+                    PerRecipientNonFungiblesTransfer::new(NonFungibleResourceAddress::sample_mainnet(), true, [
+                        NonFungibleLocalId::sample(),
+                        NonFungibleLocalId::sample_other(),
+                    ])
+                ],
+            ),
+            PerRecipientAssetTransfer::new(
+                AccountAddress::from_str("account_rdx129a9wuey40lducsf6yu232zmzk5kscpvnl6fv472r0ja39f3hced69").unwrap(),
+                [PerRecipientFungibleTransfer::new(
+                    ResourceAddress::sample_mainnet_xrd(),
+                    Decimal192::from_str("987654.1234").unwrap(),
+                    true,
+                    None,
+                ),
+                PerRecipientFungibleTransfer::new(
+                    ResourceAddress::sample_mainnet_candy(),
+                    Decimal192::from_str("987654.1234").unwrap(),
+                    true,
+                    4
+                )
+                ],
+                [
+                    PerRecipientNonFungiblesTransfer::new(NonFungibleResourceAddress::sample_mainnet(), true, [NonFungibleLocalId::sample_other()]),
+                    PerRecipientNonFungiblesTransfer::new(NonFungibleResourceAddress::sample_mainnet_other(), true, [NonFungibleLocalId::sample_other()])
+                ],
+            )
+            ],
+        )
     }
 
     fn sample_other() -> Self {
-        Self::sample_stokenet_other()
+        let sender: AccountAddress = "account_tdx_2_128rkfzdztjpgajucstydar2gz2vp9jj779k33jy3gect2rh5r28rgn".parse().unwrap();
+        let recip0: AccountAddress = "account_tdx_2_129e9h6zp5z08qkc0q5tdqz9zc67gg2k7tergrj9erznmke6qeevmsv".parse().unwrap();
+        let recip1: AccountAddress = "account_tdx_2_128a45a7hetjfpfqdlsp07eyrmhq7edldefgd7263jd58puzuq09qks".parse().unwrap();
+
+        let nft_c0: NonFungibleResourceAddress = "resource_tdx_2_1n2sjxxtk6vm6pvk8dxr798e8zpxqz50q5wlmldlat0qhh04u2mwmy8".parse().unwrap();
+        let nft_c1: NonFungibleResourceAddress = "resource_tdx_2_1ntuaekqexa73m9en04jj3vdt3fk9u9kdk8q9su4efldun2y7nd3cga".parse().unwrap();
+
+        let fung_0: ResourceAddress = ResourceAddress::sample_stokenet_xrd();
+        let fung_1: ResourceAddress =
+            ResourceAddress::sample_stokenet_gc_tokens();
+
+        Self::new(
+            sender.clone(),
+            [
+                PerRecipientAssetTransfer::new(
+                    recip0.clone(),
+                    [
+                        PerRecipientFungibleTransfer::new(
+                            fung_0.clone(),
+                            30,
+                            true,
+                            18,
+                        ),
+                        PerRecipientFungibleTransfer::new(
+                            fung_1.clone(),
+                            3,
+                            true,
+                            18,
+                        ),
+                    ],
+                    [
+                        PerRecipientNonFungiblesTransfer::new(
+                            nft_c0.clone(),
+                            true,
+                            [
+                                NonFungibleLocalId::integer(40),
+                                NonFungibleLocalId::integer(48),
+                            ],
+                        ),
+                        PerRecipientNonFungiblesTransfer::new(
+                            nft_c1.clone(),
+                            true,
+                            [
+                                NonFungibleLocalId::integer(21),
+                                NonFungibleLocalId::integer(3),
+                            ],
+                        ),
+                    ],
+                ),
+                PerRecipientAssetTransfer::new(
+                    recip1.clone(),
+                    [
+                        PerRecipientFungibleTransfer::new(
+                            fung_0.clone(),
+                            50,
+                            true,
+                            18,
+                        ),
+                        PerRecipientFungibleTransfer::new(
+                            fung_1.clone(),
+                            5,
+                            true,
+                            18,
+                        ),
+                    ],
+                    [
+                        PerRecipientNonFungiblesTransfer::new(
+                            nft_c0.clone(),
+                            true,
+                            [
+                                NonFungibleLocalId::integer(34),
+                                NonFungibleLocalId::integer(22),
+                            ],
+                        ),
+                        PerRecipientNonFungiblesTransfer::new(
+                            nft_c1.clone(),
+                            true,
+                            [
+                                NonFungibleLocalId::integer(15),
+                                NonFungibleLocalId::integer(9),
+                                NonFungibleLocalId::integer(13),
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+        )
     }
 }
 
@@ -169,8 +293,92 @@ mod tests {
         )
     }
 
-    // #[test]
-    // fn transpose() {
-    //     pretty_assertions::assert_eq!(SUT::sample().transpose(), PerAssetTransfers::sample())
-    // }
+    #[test]
+    fn transpose_simple() {
+        pretty_assertions::assert_eq!(
+            SUT::sample().transpose(),
+            PerAssetTransfers::sample()
+        )
+    }
+
+    #[test]
+    fn transpose_complex() {
+        let sender: AccountAddress = "account_tdx_2_128rkfzdztjpgajucstydar2gz2vp9jj779k33jy3gect2rh5r28rgn".parse().unwrap();
+        let recip0: AccountAddress = "account_tdx_2_129e9h6zp5z08qkc0q5tdqz9zc67gg2k7tergrj9erznmke6qeevmsv".parse().unwrap();
+        let recip1: AccountAddress = "account_tdx_2_128a45a7hetjfpfqdlsp07eyrmhq7edldefgd7263jd58puzuq09qks".parse().unwrap();
+
+        let nft_c0: NonFungibleResourceAddress = "resource_tdx_2_1n2sjxxtk6vm6pvk8dxr798e8zpxqz50q5wlmldlat0qhh04u2mwmy8".parse().unwrap();
+        let nft_c1: NonFungibleResourceAddress = "resource_tdx_2_1ntuaekqexa73m9en04jj3vdt3fk9u9kdk8q9su4efldun2y7nd3cga".parse().unwrap();
+
+        let fung_0: ResourceAddress = ResourceAddress::sample_stokenet_xrd();
+        let fung_1: ResourceAddress =
+            ResourceAddress::sample_stokenet_gc_tokens();
+
+        let per_asset_transfers = PerAssetTransfers::new(
+            sender.clone(),
+            [
+                PerAssetTransfersOfFungibleResource::new(
+                    PerAssetFungibleResource::new(fung_0.clone(), 18),
+                    [
+                        PerAssetFungibleTransfer::new(recip0.clone(), true, 30),
+                        PerAssetFungibleTransfer::new(recip1.clone(), true, 50),
+                    ],
+                ),
+                PerAssetTransfersOfFungibleResource::new(
+                    PerAssetFungibleResource::new(fung_1.clone(), 18),
+                    [
+                        PerAssetFungibleTransfer::new(recip0.clone(), true, 3),
+                        PerAssetFungibleTransfer::new(recip1.clone(), true, 5),
+                    ],
+                ),
+            ],
+            [
+                PerAssetTransfersOfNonFungibleResource::new(
+                    nft_c0.clone(),
+                    [
+                        PerAssetNonFungibleTransfer::new(
+                            recip0.clone(),
+                            true,
+                            [
+                                NonFungibleLocalId::integer(40),
+                                NonFungibleLocalId::integer(48),
+                            ],
+                        ),
+                        PerAssetNonFungibleTransfer::new(
+                            recip1.clone(),
+                            true,
+                            [
+                                NonFungibleLocalId::integer(34),
+                                NonFungibleLocalId::integer(22),
+                            ],
+                        ),
+                    ],
+                ),
+                PerAssetTransfersOfNonFungibleResource::new(
+                    nft_c1.clone(),
+                    [
+                        PerAssetNonFungibleTransfer::new(
+                            recip0.clone(),
+                            true,
+                            [
+                                NonFungibleLocalId::integer(21),
+                                NonFungibleLocalId::integer(3),
+                            ],
+                        ),
+                        PerAssetNonFungibleTransfer::new(
+                            recip1.clone(),
+                            true,
+                            [
+                                NonFungibleLocalId::integer(15),
+                                NonFungibleLocalId::integer(9),
+                                NonFungibleLocalId::integer(13),
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+        );
+
+        assert_eq!(SUT::sample_other().transpose(), per_asset_transfers);
+    }
 }

--- a/src/wrapped_radix_engine_toolkit/high_level/sargon_specific_types/assets_transfers/per_recipient/per_recipient_fungible_transfer.rs
+++ b/src/wrapped_radix_engine_toolkit/high_level/sargon_specific_types/assets_transfers/per_recipient/per_recipient_fungible_transfer.rs
@@ -5,7 +5,7 @@ impl PerRecipientFungibleTransfer {
         resource_address: ResourceAddress,
         amount: impl Into<Decimal192>,
         use_try_deposit_or_abort: bool,
-        divisibility: impl Into<Option<i32>>,
+        divisibility: impl Into<Option<u8>>,
     ) -> Self {
         Self {
             resource_address,

--- a/src/wrapped_radix_engine_toolkit/high_level/sargon_specific_types/assets_transfers/transfer_types.rs
+++ b/src/wrapped_radix_engine_toolkit/high_level/sargon_specific_types/assets_transfers/transfer_types.rs
@@ -113,7 +113,7 @@ decl_per_recipient_transfer_of!(
     Fungible,
     /// Amount
     pub(crate) amount: Decimal192,
-    pub divisibility: Option<i32>,
+    pub divisibility: Option<u8>,
 );
 
 decl_per_recipient_transfer_of!(

--- a/src/wrapped_radix_engine_toolkit/high_level/sargon_specific_types/stake_claim.rs
+++ b/src/wrapped_radix_engine_toolkit/high_level/sargon_specific_types/stake_claim.rs
@@ -50,3 +50,22 @@ impl HasSampleValues for StakeClaim {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[allow(clippy::upper_case_acronyms)]
+    type SUT = StakeClaim;
+
+    #[test]
+    fn equality() {
+        assert_eq!(SUT::sample(), SUT::sample());
+        assert_eq!(SUT::sample_other(), SUT::sample_other());
+    }
+
+    #[test]
+    fn inequality() {
+        assert_ne!(SUT::sample(), SUT::sample_other());
+    }
+}

--- a/src/wrapped_radix_engine_toolkit/high_level/sargon_specific_types/transaction_guarantee.rs
+++ b/src/wrapped_radix_engine_toolkit/high_level/sargon_specific_types/transaction_guarantee.rs
@@ -5,7 +5,7 @@ pub struct TransactionGuarantee {
     amount: Decimal192,
     pub instruction_index: u64,
     pub resource_address: ResourceAddress,
-    pub resource_divisibility: Option<i32>,
+    pub resource_divisibility: Option<u8>,
 }
 
 impl TransactionGuarantee {
@@ -13,7 +13,7 @@ impl TransactionGuarantee {
         amount: impl Into<Decimal192>,
         instruction_index: u64,
         resource_address: ResourceAddress,
-        resource_divisibility: impl Into<Option<i32>>,
+        resource_divisibility: impl Into<Option<u8>>,
     ) -> Self {
         Self {
             amount: amount.into(),

--- a/src/wrapped_radix_engine_toolkit/high_level/sargon_specific_types/transaction_guarantee.rs
+++ b/src/wrapped_radix_engine_toolkit/high_level/sargon_specific_types/transaction_guarantee.rs
@@ -60,16 +60,9 @@ mod tests {
 
     #[test]
     fn rounding() {
-        let sut = SUT::new(
-            "0.12344".parse::<Decimal192>().unwrap(),
-            2,
-            ResourceAddress::sample_mainnet_candy(),
-            4,
-        );
+        let sut =
+            SUT::new("0.12344", 2, ResourceAddress::sample_mainnet_candy(), 4);
 
-        assert_eq!(
-            sut.rounded_amount(),
-            "0.1234".parse::<Decimal192>().unwrap()
-        );
+        assert_eq!(sut.rounded_amount(), "0.1234".into());
     }
 }

--- a/src/wrapped_radix_engine_toolkit/low_level/address_conversion/resource_address_from.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/address_conversion/resource_address_from.rs
@@ -18,10 +18,11 @@ impl From<(ScryptoResourceSpecifier, NetworkID)> for ResourceAddress {
 mod tests {
     use super::*;
 
+    #[allow(clippy::upper_case_acronyms)]
+    type SUT = ResourceAddress;
+
     #[test]
     fn resource_address_from_scrypto_resource_specifier_amount_mainnet() {
-        type SUT = ResourceAddress;
-
         let exp = SUT::sample_mainnet_candy();
         let ret =
             ScryptoResourceSpecifier::Amount(exp.clone().into(), 0.into());
@@ -33,8 +34,6 @@ mod tests {
 
     #[test]
     fn resource_address_from_scrypto_resource_specifier_amount_stokenet() {
-        type SUT = ResourceAddress;
-
         let exp = SUT::sample_stokenet_gum();
         let ret =
             ScryptoResourceSpecifier::Amount(exp.clone().into(), 0.into());
@@ -46,8 +45,6 @@ mod tests {
 
     #[test]
     fn resource_address_from_scrypto_resource_specifier_ids_mainnet() {
-        type SUT = ResourceAddress;
-
         let exp = SUT::sample_mainnet_candy();
         let ret = ScryptoResourceSpecifier::Ids(exp.clone().into(), [].into());
         assert_eq!(SUT::from((ret.clone(), NetworkID::Mainnet)), exp.clone());
@@ -58,8 +55,6 @@ mod tests {
 
     #[test]
     fn resource_address_from_scrypto_resource_specifier_ids_stokenet() {
-        type SUT = ResourceAddress;
-
         let exp = SUT::sample_stokenet_gum();
         let ret = ScryptoResourceSpecifier::Ids(exp.clone().into(), [].into());
         assert_eq!(SUT::from((ret.clone(), NetworkID::Stokenet)), exp.clone());

--- a/src/wrapped_radix_engine_toolkit/low_level/execution_summary/resource_indicator/fungible_resource_indicator.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/execution_summary/resource_indicator/fungible_resource_indicator.rs
@@ -6,6 +6,25 @@ pub enum FungibleResourceIndicator {
     Predicted { predicted_decimal: PredictedDecimal },
 }
 
+impl FungibleResourceIndicator {
+    pub fn guaranteed(decimal: impl Into<Decimal>) -> Self {
+        Self::Guaranteed {
+            decimal: decimal.into(),
+        }
+    }
+    pub fn predicted(
+        decimal: impl Into<Decimal>,
+        instruction_index: u64,
+    ) -> Self {
+        Self::Predicted {
+            predicted_decimal: PredictedDecimal::new(
+                decimal,
+                instruction_index,
+            ),
+        }
+    }
+}
+
 impl From<RetFungibleResourceIndicator> for FungibleResourceIndicator {
     fn from(value: RetFungibleResourceIndicator) -> Self {
         match value {
@@ -27,15 +46,11 @@ impl From<RetFungibleResourceIndicator> for FungibleResourceIndicator {
 
 impl HasSampleValues for FungibleResourceIndicator {
     fn sample() -> Self {
-        Self::Guaranteed {
-            decimal: Decimal::one(),
-        }
+        Self::guaranteed(1)
     }
 
     fn sample_other() -> Self {
-        Self::Predicted {
-            predicted_decimal: PredictedDecimal::new(Decimal::two(), 0),
-        }
+        Self::predicted(2, 0)
     }
 }
 

--- a/src/wrapped_radix_engine_toolkit/low_level/execution_summary/resource_indicator/non_fungible_resource_indicator.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/execution_summary/resource_indicator/non_fungible_resource_indicator.rs
@@ -7,12 +7,38 @@ pub enum NonFungibleResourceIndicator {
         predicted_ids: PredictedNonFungibleLocalIds,
     },
     ByAmount {
-        amount: Decimal,
+        amount: Decimal192,
         predicted_ids: PredictedNonFungibleLocalIds,
     },
     ByIds {
         ids: Vec<NonFungibleLocalId>,
     },
+}
+
+impl NonFungibleResourceIndicator {
+    pub fn by_all(
+        predicted_amount: PredictedDecimal,
+        predicted_ids: PredictedNonFungibleLocalIds,
+    ) -> Self {
+        Self::ByAll {
+            predicted_amount,
+            predicted_ids,
+        }
+    }
+    pub fn by_amount(
+        amount: impl Into<Decimal192>,
+        predicted_ids: PredictedNonFungibleLocalIds,
+    ) -> Self {
+        Self::ByAmount {
+            amount: amount.into(),
+            predicted_ids,
+        }
+    }
+    pub fn by_ids(ids: impl IntoIterator<Item = NonFungibleLocalId>) -> Self {
+        Self::ByIds {
+            ids: ids.into_iter().collect(),
+        }
+    }
 }
 
 impl From<RetNonFungibleResourceIndicator> for NonFungibleResourceIndicator {
@@ -41,17 +67,14 @@ impl From<RetNonFungibleResourceIndicator> for NonFungibleResourceIndicator {
 
 impl HasSampleValues for NonFungibleResourceIndicator {
     fn sample() -> Self {
-        Self::ByAmount {
-            amount: Decimal192::three(),
-            predicted_ids: PredictedNonFungibleLocalIds::sample(),
-        }
+        Self::by_amount(3, PredictedNonFungibleLocalIds::sample())
     }
 
     fn sample_other() -> Self {
-        Self::ByAll {
-            predicted_amount: PredictedDecimal::sample(),
-            predicted_ids: PredictedNonFungibleLocalIds::sample_other(),
-        }
+        Self::by_all(
+            PredictedDecimal::sample(),
+            PredictedNonFungibleLocalIds::sample_other(),
+        )
     }
 }
 
@@ -76,7 +99,7 @@ mod tests {
     }
 
     #[test]
-    fn from_ret() {
+    fn from_ret_by_amount() {
         let ret = RetNonFungibleResourceIndicator::ByAmount {
             amount: 3.into(),
             predicted_ids: Predicted {
@@ -91,5 +114,22 @@ mod tests {
             },
         };
         assert_eq!(SUT::from(ret), SUT::sample());
+    }
+
+    #[test]
+    fn from_ret_by_ids() {
+        let ids = vec![
+            NonFungibleLocalId::sample(),
+            NonFungibleLocalId::sample_other(),
+        ];
+
+        let ret = RetNonFungibleResourceIndicator::ByIds(
+            ids.clone()
+                .into_iter()
+                .map(ScryptoNonFungibleLocalId::from)
+                .collect(),
+        );
+
+        assert_eq!(SUT::from(ret), SUT::by_ids(ids));
     }
 }

--- a/src/wrapped_radix_engine_toolkit/low_level/execution_summary/resource_indicator/resource_indicator.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/execution_summary/resource_indicator/resource_indicator.rs
@@ -12,6 +12,27 @@ pub enum ResourceIndicator {
     },
 }
 
+impl ResourceIndicator {
+    pub fn fungible(
+        resource_address: impl Into<ResourceAddress>,
+        indicator: FungibleResourceIndicator,
+    ) -> Self {
+        Self::Fungible {
+            resource_address: resource_address.into(),
+            indicator,
+        }
+    }
+    pub fn non_fungible(
+        resource_address: impl Into<ResourceAddress>,
+        indicator: NonFungibleResourceIndicator,
+    ) -> Self {
+        Self::NonFungible {
+            resource_address: resource_address.into(),
+            indicator,
+        }
+    }
+}
+
 impl From<(RetResourceIndicator, NetworkID)> for ResourceIndicator {
     fn from(value: (RetResourceIndicator, NetworkID)) -> Self {
         let (ret, network_id) = value;
@@ -36,17 +57,17 @@ impl From<(RetResourceIndicator, NetworkID)> for ResourceIndicator {
 
 impl HasSampleValues for ResourceIndicator {
     fn sample() -> Self {
-        Self::Fungible {
-            resource_address: ResourceAddress::sample(),
-            indicator: FungibleResourceIndicator::sample(),
-        }
+        Self::fungible(
+            ResourceAddress::sample(),
+            FungibleResourceIndicator::sample(),
+        )
     }
 
     fn sample_other() -> Self {
-        Self::NonFungible {
-            resource_address: ResourceAddress::sample_other(),
-            indicator: NonFungibleResourceIndicator::sample_other(),
-        }
+        Self::non_fungible(
+            NonFungibleResourceAddress::sample_other(),
+            NonFungibleResourceIndicator::sample_other(),
+        )
     }
 }
 
@@ -85,10 +106,10 @@ mod tests {
 
     #[test]
     fn from_ret_non_fungible() {
-        let resource_address = ResourceAddress::sample_other();
+        let resource_address = NonFungibleResourceAddress::sample_other();
 
         let ret = RetResourceIndicator::NonFungible(
-            resource_address.into(),
+            ResourceAddress::from(resource_address).into(),
             RetNonFungibleResourceIndicator::ByAll {
                 predicted_amount: RetPredicted {
                     value: 1.into(),

--- a/src/wrapped_radix_engine_toolkit/low_level/notary_signature.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/notary_signature.rs
@@ -77,7 +77,7 @@ mod tests {
 
     #[test]
     fn to_from_scrypto() {
-        let roundtrip = |s: SUT| SUT::from(NotarySignature::from(s));
+        let roundtrip = |s: SUT| SUT::from(s);
         roundtrip(SUT::sample());
         roundtrip(SUT::sample_other());
     }

--- a/src/wrapped_radix_engine_toolkit/low_level/transaction_manifest/execution_summary/transaction_manifest_execution_summary.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/transaction_manifest/execution_summary/transaction_manifest_execution_summary.rs
@@ -95,7 +95,7 @@ mod tests {
             )
             .unwrap();
 
-        let acc_gk: AccountAddress = "account_tdx_2_1288efhmjt8kzce77par4ex997x2zgnlv5qqv9ltpxqg7ur0xpqm6gk".parse().unwrap();
+        let acc_gk: AccountAddress = "account_tdx_2_1288efhmjt8kzce77par4ex997x2zgnlv5qqv9ltpxqg7ur0xpqm6gk".into();
 
         pretty_assertions::assert_eq!(
             sut,
@@ -104,54 +104,54 @@ mod tests {
                     (
                         acc_gk.clone(),
                         vec![
-                            ResourceIndicator::Fungible {
-                                resource_address: "resource_tdx_2_1thw7yclz24h5xjp3086cj8z2ya0d7p9mydk0yh68c28ha02uhzrnyy".parse::<ResourceAddress>().unwrap(),
-                                indicator: FungibleResourceIndicator::Guaranteed { decimal: "36.4567896543".parse::<Decimal>().unwrap() }
-                            },
-                            ResourceIndicator::Fungible {
-                                resource_address: "resource_tdx_2_1th6hufew82dpntmcn7kt9f7au50cr59996tawh4syph0kz5e99v2u6".parse::<ResourceAddress>().unwrap(),
-                                indicator: FungibleResourceIndicator::Guaranteed { decimal: "5.24".parse::<Decimal>().unwrap() }
-                            },
-                            ResourceIndicator::Fungible {
-                                resource_address: "resource_tdx_2_1thnhmen4wg29tnqrfpk9w2v90s64z8at9sethnjma76866rfvcc2gs".parse::<ResourceAddress>().unwrap(),
-                                indicator: FungibleResourceIndicator::Guaranteed { decimal: "42.23727".parse::<Decimal>().unwrap() }
-                            },
-                            ResourceIndicator::Fungible {
-                                resource_address: "resource_tdx_2_1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxtfd2jc".parse::<ResourceAddress>().unwrap(),
-                                indicator: FungibleResourceIndicator::Guaranteed { decimal: "237.987654".parse::<Decimal>().unwrap() }
-                            },
+                            ResourceIndicator::fungible(
+                                "resource_tdx_2_1thw7yclz24h5xjp3086cj8z2ya0d7p9mydk0yh68c28ha02uhzrnyy",
+                                FungibleResourceIndicator::guaranteed("36.4567896543")
+                            ),
+                            ResourceIndicator::fungible(
+                                "resource_tdx_2_1th6hufew82dpntmcn7kt9f7au50cr59996tawh4syph0kz5e99v2u6",
+                                FungibleResourceIndicator::guaranteed("5.24")
+                            ),
+                            ResourceIndicator::fungible(
+                                "resource_tdx_2_1thnhmen4wg29tnqrfpk9w2v90s64z8at9sethnjma76866rfvcc2gs",
+                                FungibleResourceIndicator::guaranteed("42.23727")
+                            ),
+                            ResourceIndicator::fungible(
+                                "resource_tdx_2_1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxtfd2jc",
+                                FungibleResourceIndicator::guaranteed("237.987654")
+                            ),
                         ]
                     )
                 ],
                 [
                     (
-                        "account_tdx_2_12x0xzsa3dm2tthpz3nwsvh94e8kq7acu0x2kfjlpv5kulsynt7rpwp".parse::<AccountAddress>().unwrap(),
+                        AccountAddress::from("account_tdx_2_12x0xzsa3dm2tthpz3nwsvh94e8kq7acu0x2kfjlpv5kulsynt7rpwp"),
                         vec![
-                            ResourceIndicator::Fungible {
-                                resource_address: "resource_tdx_2_1thw7yclz24h5xjp3086cj8z2ya0d7p9mydk0yh68c28ha02uhzrnyy".parse::<ResourceAddress>().unwrap(),
-                                indicator: FungibleResourceIndicator::Guaranteed { decimal: "12.4567896543".parse::<Decimal>().unwrap() }
-                            }
+                            ResourceIndicator::fungible(
+                                "resource_tdx_2_1thw7yclz24h5xjp3086cj8z2ya0d7p9mydk0yh68c28ha02uhzrnyy",
+                                FungibleResourceIndicator::guaranteed("12.4567896543")
+                            )
                         ]
                     ),
                     (
-                        "account_tdx_2_12xwdc3gsu48juzkj56s0zz0vqx26xcmw9kehcudm85w57cynter9z4".parse::<AccountAddress>().unwrap(),
+                        AccountAddress::from("account_tdx_2_12xwdc3gsu48juzkj56s0zz0vqx26xcmw9kehcudm85w57cynter9z4"),
                         vec![
-                            ResourceIndicator::Fungible {
-                                resource_address: "resource_tdx_2_1thw7yclz24h5xjp3086cj8z2ya0d7p9mydk0yh68c28ha02uhzrnyy".parse::<ResourceAddress>().unwrap(),
-                                indicator: FungibleResourceIndicator::Guaranteed { decimal: "24".parse::<Decimal>().unwrap() }
-                            },
-                            ResourceIndicator::Fungible {
-                                resource_address: "resource_tdx_2_1th6hufew82dpntmcn7kt9f7au50cr59996tawh4syph0kz5e99v2u6".parse::<ResourceAddress>().unwrap(),
-                                indicator: FungibleResourceIndicator::Guaranteed { decimal: "5.24".parse::<Decimal>().unwrap() }
-                            },
-                            ResourceIndicator::Fungible {
-                                resource_address: "resource_tdx_2_1thnhmen4wg29tnqrfpk9w2v90s64z8at9sethnjma76866rfvcc2gs".parse::<ResourceAddress>().unwrap(),
-                                indicator: FungibleResourceIndicator::Guaranteed { decimal: "42.23727".parse::<Decimal>().unwrap() }
-                            },
-                            ResourceIndicator::Fungible {
-                                resource_address: "resource_tdx_2_1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxtfd2jc".parse::<ResourceAddress>().unwrap(),
-                                indicator: FungibleResourceIndicator::Guaranteed { decimal: "237.987654".parse::<Decimal>().unwrap() }
-                            }
+                            ResourceIndicator::fungible(
+                                "resource_tdx_2_1thw7yclz24h5xjp3086cj8z2ya0d7p9mydk0yh68c28ha02uhzrnyy",
+                                FungibleResourceIndicator::guaranteed(24)
+                            ),
+                            ResourceIndicator::fungible(
+                                "resource_tdx_2_1th6hufew82dpntmcn7kt9f7au50cr59996tawh4syph0kz5e99v2u6",
+                                FungibleResourceIndicator::guaranteed("5.24")
+                            ),
+                            ResourceIndicator::fungible(
+                                "resource_tdx_2_1thnhmen4wg29tnqrfpk9w2v90s64z8at9sethnjma76866rfvcc2gs",
+                                FungibleResourceIndicator::guaranteed("42.23727")
+                            ),
+                            ResourceIndicator::fungible(
+                                "resource_tdx_2_1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxtfd2jc",
+                                FungibleResourceIndicator::guaranteed("237.987654")
+                            )
                         ]
                     )
                 ],
@@ -169,9 +169,9 @@ mod tests {
                 ],
                 FeeLocks::default(),
                 FeeSummary::new(
-                    "0.4077857".parse::<Decimal>().unwrap(),
-                    "0.1307814".parse::<Decimal>().unwrap(),
-                    "0.52433013014".parse::<Decimal>().unwrap(),
+                    "0.4077857",
+                    "0.1307814",
+                    "0.52433013014",
                     0,
                 ),
                 NewEntities::default()
@@ -199,7 +199,7 @@ mod tests {
             )
             .unwrap();
 
-        let acc_g2: AccountAddress = "account_tdx_2_12xx9jz27aa0mqjj8cwhk7pzkhtkthv09yclmurse42hlyme2gegyg2".parse().unwrap();
+        let acc_g2: AccountAddress = "account_tdx_2_12xx9jz27aa0mqjj8cwhk7pzkhtkthv09yclmurse42hlyme2gegyg2".into();
 
         pretty_assertions::assert_eq!(
             sut,
@@ -251,9 +251,9 @@ mod tests {
                 ],
                 FeeLocks::default(),
                 FeeSummary::new(
-                    "0.092499".parse::<Decimal>().unwrap(),
-                    "0.02100205".parse::<Decimal>().unwrap(),
-                    "0.08459091041".parse::<Decimal>().unwrap(),
+                    "0.092499",
+                    "0.02100205",
+                    "0.08459091041",
                     0
                 ),
                 NewEntities::default()
@@ -279,8 +279,8 @@ mod tests {
             )
             .unwrap();
 
-        let acc_g2: AccountAddress = "account_tdx_2_12xx9jz27aa0mqjj8cwhk7pzkhtkthv09yclmurse42hlyme2gegyg2".parse().unwrap();
-        let token_address: ResourceAddress = "resource_tdx_2_1t4wty7nq976ej4wtx7p4ckm073p32cyaajk4cq256rcvzz20e7qrm9".parse().unwrap();
+        let acc_g2: AccountAddress = "account_tdx_2_12xx9jz27aa0mqjj8cwhk7pzkhtkthv09yclmurse42hlyme2gegyg2".into();
+        let token_address: ResourceAddress = "resource_tdx_2_1t4wty7nq976ej4wtx7p4ckm073p32cyaajk4cq256rcvzz20e7qrm9".into();
 
         pretty_assertions::assert_eq!(
             sut,
@@ -288,12 +288,10 @@ mod tests {
                 [],
                 [(
                     acc_g2.clone(),
-                    vec![ResourceIndicator::Fungible {
-                        resource_address: token_address.clone(),
-                        indicator: FungibleResourceIndicator::Predicted {
-                            predicted_decimal: PredictedDecimal::new(100000, 1)
-                        }
-                    },]
+                    vec![ResourceIndicator::fungible(
+                        token_address.clone(),
+                        FungibleResourceIndicator::predicted(100000, 1)
+                    )]
                 )],
                 [], // addresses_of_accounts_requiring_auth
                 [], // addresses_of_identities_requiring_auth
@@ -303,12 +301,7 @@ mod tests {
                 [], // encountered_component_addresses
                 [DetailedManifestClass::General],
                 FeeLocks::default(),
-                FeeSummary::new(
-                    "0.15800815".parse::<Decimal>().unwrap(),
-                    "0.1160115".parse::<Decimal>().unwrap(),
-                    "0.25339126151".parse::<Decimal>().unwrap(),
-                    0,
-                ),
+                FeeSummary::new("0.15800815", "0.1160115", "0.25339126151", 0,),
                 NewEntities::new([(
                     token_address.clone(),
                     NewlyCreatedResource::with(
@@ -362,14 +355,14 @@ mod tests {
                     ],
                     FeeLocks::default(),
                     FeeSummary::new(
-                        "0.21852455".parse::<Decimal>().unwrap(),
-                        "0.3320334".parse::<Decimal>().unwrap(),
-                        "0.73328016927".parse::<Decimal>().unwrap(),
+                        "0.21852455",
+                        "0.3320334",
+                        "0.73328016927",
                         0,
                     ),
                     NewEntities::new([
                         (
-                            "resource_tdx_2_1ntwlumm8g8hsx0emmxgj3akcx6aajspx06llvfmq733x2ssm4v3g0e".parse::<ResourceAddress>().unwrap(),
+                            ResourceAddress::from("resource_tdx_2_1ntwlumm8g8hsx0emmxgj3akcx6aajspx06llvfmq733x2ssm4v3g0e"),
                             NewlyCreatedResource::with(
                                 "Abandon",
                                 "ABANDON",
@@ -379,7 +372,7 @@ mod tests {
                             )
                         ),
                         (
-                            "resource_tdx_2_1nfe6ugwjvuqc7aqhcltnwmp8xfkpqnm9mc8n9jh5xcvnx38r2wncre".parse::<ResourceAddress>().unwrap(),
+                            ResourceAddress::from("resource_tdx_2_1nfe6ugwjvuqc7aqhcltnwmp8xfkpqnm9mc8n9jh5xcvnx38r2wncre"),
                             NewlyCreatedResource::with(
                                 "Ability",
                                 "ABILITY",
@@ -411,7 +404,7 @@ mod tests {
             )
             .unwrap();
 
-        let acc_gk: AccountAddress = "account_tdx_2_1288efhmjt8kzce77par4ex997x2zgnlv5qqv9ltpxqg7ur0xpqm6gk".parse().unwrap();
+        let acc_gk: AccountAddress = "account_tdx_2_1288efhmjt8kzce77par4ex997x2zgnlv5qqv9ltpxqg7ur0xpqm6gk".into();
 
         pretty_assertions::assert_eq!(
             sut,
@@ -420,10 +413,10 @@ mod tests {
                     (
                         acc_gk.clone(),
                         vec![
-                            ResourceIndicator::Fungible {
-                                resource_address: "resource_tdx_2_1thqcgjw37fjgycpvqr52nx4jcsdeuq75mf2nywme07kzsuds9a4psp".parse::<ResourceAddress>().unwrap(), 
-                                indicator: FungibleResourceIndicator::Guaranteed { decimal: "5".parse::<Decimal>().unwrap() } 
-                            },
+                            ResourceIndicator::fungible(
+                                "resource_tdx_2_1thqcgjw37fjgycpvqr52nx4jcsdeuq75mf2nywme07kzsuds9a4psp",
+                                FungibleResourceIndicator::guaranteed(5)
+                            ),
                         ]
                     )
                 ],
@@ -431,18 +424,15 @@ mod tests {
                     (
                         acc_gk.clone(),
                         vec![
-                            ResourceIndicator::NonFungible {
-                                resource_address: "resource_tdx_2_1ng88qk08hrgmad30rzdxpyx779yuta4cwcjc3gstk60jhachsv94g9".parse::<ResourceAddress>().unwrap(), 
-                                indicator: NonFungibleResourceIndicator::ByAmount {
-                                    amount: Decimal::from(1),
-                                    predicted_ids: PredictedNonFungibleLocalIds::new(
-                                        [
-                                            NonFungibleLocalId::string("Member_44").unwrap()
-                                        ],
-                                        3
-                                    )
-                                }
-                            }
+                            ResourceIndicator::non_fungible(
+                                "resource_tdx_2_1ng88qk08hrgmad30rzdxpyx779yuta4cwcjc3gstk60jhachsv94g9",
+                                NonFungibleResourceIndicator::by_amount(1, PredictedNonFungibleLocalIds::new(
+                                    [
+                                        NonFungibleLocalId::string("Member_44").unwrap()
+                                    ],
+                                    3
+                                ))
+                            )
                         ]
                     )
                 ],
@@ -459,9 +449,9 @@ mod tests {
                 ],
                 FeeLocks::default(),
                 FeeSummary::new(
-                    "0.3751137".parse::<Decimal>().unwrap(),
-                    "0.0467599".parse::<Decimal>().unwrap(),
-                    "0.14677047477".parse::<Decimal>().unwrap(),
+                    "0.3751137",
+                    "0.0467599",
+                    "0.14677047477",
                     0,
                 ),
                 NewEntities::default()
@@ -498,7 +488,7 @@ mod tests {
                             vec![
                                 ResourceIndicator::Fungible {
                                     resource_address: "resource_tdx_2_1thqcgjw37fjgycpvqr52nx4jcsdeuq75mf2nywme07kzsuds9a4psp".parse::<ResourceAddress>().unwrap(), 
-                                    indicator: FungibleResourceIndicator::Guaranteed { decimal: "1".parse::<Decimal>().unwrap() } 
+                                    indicator: FungibleResourceIndicator::guaranteed(1)
                                 },
                             ]
                         )
@@ -509,12 +499,7 @@ mod tests {
                             vec![
                                 ResourceIndicator::Fungible {
                                     resource_address: "resource_tdx_2_1tk30vj4ene95e3vhymtf2p35fzl29rv4us36capu2rz0vretw9gzr3".parse::<ResourceAddress>().unwrap(),
-                                    indicator: FungibleResourceIndicator::Predicted {
-                                        predicted_decimal: PredictedDecimal::new(
-                                            Decimal::from(30),
-                                            4
-                                        )
-                                    }
+                                    indicator: FungibleResourceIndicator::predicted(30, 4)
                                 }
                             ]
                         ),
@@ -530,9 +515,9 @@ mod tests {
                     ],
                     FeeLocks::default(),
                     FeeSummary::new(
-                        "0.50142635".parse::<Decimal>().unwrap(),
-                        "0.0467589".parse::<Decimal>().unwrap(),
-                        "0.13551711803".parse::<Decimal>().unwrap(),
+                        "0.50142635",
+                        "0.0467589",
+                        "0.13551711803",
                         0,
                     ),
                     NewEntities::default()
@@ -574,9 +559,9 @@ mod tests {
                     ],
                     FeeLocks::default(),
                     FeeSummary::new(
-                        "0.1495719".parse::<Decimal>().unwrap(),
-                        "0.1557717".parse::<Decimal>().unwrap(),
-                        "0.3290176335".parse::<Decimal>().unwrap(),
+                        "0.1495719",
+                        "0.1557717",
+                        "0.3290176335",
                         0,
                     ),
                     NewEntities::new([
@@ -662,9 +647,9 @@ mod tests {
                     ],
                     FeeLocks::default(),
                     FeeSummary::new(
-                        "0.27435815".parse::<Decimal>().unwrap(),
-                        "0.04276125".parse::<Decimal>().unwrap(),
-                        "0.17910003354".parse::<Decimal>().unwrap(),
+                        "0.27435815",
+                        "0.04276125",
+                        "0.17910003354",
                         0,
                     ),
                     NewEntities::default()
@@ -720,32 +705,23 @@ mod tests {
                         ResourceIndicator::Fungible {
                             resource_address:
                                 validator_0_resource_address_of_stake.clone(),
-                            indicator: FungibleResourceIndicator::Predicted {
-                                predicted_decimal: PredictedDecimal::new(
-                                    "11".parse::<Decimal>().unwrap(),
-                                    3
-                                )
-                            }
+                            indicator: FungibleResourceIndicator::predicted(
+                                11, 3
+                            )
                         },
                         ResourceIndicator::Fungible {
                             resource_address:
                                 validator_1_resource_address_of_stake.clone(),
-                            indicator: FungibleResourceIndicator::Predicted {
-                                predicted_decimal: PredictedDecimal::new(
-                                    "222".parse::<Decimal>().unwrap(),
-                                    7
-                                )
-                            }
+                            indicator: FungibleResourceIndicator::predicted(
+                                222, 7
+                            )
                         },
                         ResourceIndicator::Fungible {
                             resource_address:
                                 validator_2_resource_address_of_stake.clone(),
-                            indicator: FungibleResourceIndicator::Predicted {
-                                predicted_decimal: PredictedDecimal::new(
-                                    "3333".parse::<Decimal>().unwrap(),
-                                    11
-                                )
-                            }
+                            indicator: FungibleResourceIndicator::predicted(
+                                3333, 11
+                            )
                         },
                     ]
                 )], // addresses_of_accounts_deposited_into
@@ -783,12 +759,7 @@ mod tests {
                     ]
                 }],
                 FeeLocks::default(),
-                FeeSummary::new(
-                    "0.34071685".parse::<Decimal>().unwrap(),
-                    "0.1150347".parse::<Decimal>().unwrap(),
-                    "0.32796859177".parse::<Decimal>().unwrap(),
-                    0,
-                ),
+                FeeSummary::new("0.34071685", "0.1150347", "0.32796859177", 0,),
                 NewEntities::default()
             )
         );
@@ -812,10 +783,10 @@ mod tests {
             )
             .unwrap();
 
-        let acc_gk: AccountAddress = "account_tdx_2_1288efhmjt8kzce77par4ex997x2zgnlv5qqv9ltpxqg7ur0xpqm6gk".parse().unwrap();
-        let resource_address_of_pool: ResourceAddress = "resource_tdx_2_1thnhmen4wg29tnqrfpk9w2v90s64z8at9sethnjma76866rfvcc2gs".parse().unwrap();
-        let pool_address: PoolAddress = "pool_tdx_2_1ckfjmjswvvf6y635f8l89uunu9cwgnglhqdk8627wrpf8ultdx2vc3".parse().unwrap();
-        let token0: ResourceAddress = "resource_tdx_2_1thw7yclz24h5xjp3086cj8z2ya0d7p9mydk0yh68c28ha02uhzrnyy".parse().unwrap();
+        let acc_gk = AccountAddress::from("account_tdx_2_1288efhmjt8kzce77par4ex997x2zgnlv5qqv9ltpxqg7ur0xpqm6gk");
+        let resource_address_of_pool = ResourceAddress::from("resource_tdx_2_1thnhmen4wg29tnqrfpk9w2v90s64z8at9sethnjma76866rfvcc2gs");
+        let pool_address = PoolAddress::from("pool_tdx_2_1ckfjmjswvvf6y635f8l89uunu9cwgnglhqdk8627wrpf8ultdx2vc3");
+        let token0 = ResourceAddress::from("resource_tdx_2_1thw7yclz24h5xjp3086cj8z2ya0d7p9mydk0yh68c28ha02uhzrnyy");
         let token1 = ResourceAddress::sample_stokenet_xrd();
 
         pretty_assertions::assert_eq!(
@@ -825,10 +796,8 @@ mod tests {
                     acc_gk.clone(),
                     vec![ResourceIndicator::Fungible {
                         resource_address: resource_address_of_pool.clone(),
-                        indicator: FungibleResourceIndicator::Guaranteed {
-                            decimal: "500".parse::<Decimal>().unwrap()
-                        }
-                    },]
+                        indicator: FungibleResourceIndicator::guaranteed(500)
+                    }]
                 )], // addresses_of_accounts_withdrawn_from
                 [(
                     acc_gk.clone(),
@@ -836,25 +805,17 @@ mod tests {
                         ResourceIndicator::Fungible {
                             resource_address:
                                 ResourceAddress::sample_stokenet_xrd(),
-                            indicator: FungibleResourceIndicator::Predicted {
-                                predicted_decimal: PredictedDecimal::new(
-                                    "210.512783488241137505"
-                                        .parse::<Decimal>()
-                                        .unwrap(),
-                                    3
-                                )
-                            }
+                            indicator: FungibleResourceIndicator::predicted(
+                                "210.512783488241137505",
+                                3
+                            )
                         },
                         ResourceIndicator::Fungible {
                             resource_address: token0.clone(),
-                            indicator: FungibleResourceIndicator::Predicted {
-                                predicted_decimal: PredictedDecimal::new(
-                                    "1187.5763355433"
-                                        .parse::<Decimal>()
-                                        .unwrap(),
-                                    3
-                                )
-                            }
+                            indicator: FungibleResourceIndicator::predicted(
+                                "1187.5763355433",
+                                3
+                            )
                         }
                     ]
                 )], // addresses_of_accounts_deposited_into
@@ -883,12 +844,7 @@ mod tests {
                     )]
                 }],
                 FeeLocks::default(),
-                FeeSummary::new(
-                    "0.25753315".parse::<Decimal>().unwrap(),
-                    "0.0325088".parse::<Decimal>().unwrap(),
-                    "0.12760162134".parse::<Decimal>().unwrap(),
-                    0,
-                ),
+                FeeSummary::new("0.25753315", "0.0325088", "0.12760162134", 0,),
                 NewEntities::default()
             )
         );
@@ -914,11 +870,11 @@ mod tests {
             )
             .unwrap();
 
-        let acc_gk: AccountAddress = "account_tdx_2_1288efhmjt8kzce77par4ex997x2zgnlv5qqv9ltpxqg7ur0xpqm6gk".parse().unwrap();
+        let acc_gk: AccountAddress = "account_tdx_2_1288efhmjt8kzce77par4ex997x2zgnlv5qqv9ltpxqg7ur0xpqm6gk".into();
 
-        let nf_global_id: NonFungibleGlobalId = "resource_tdx_2_1ngw8z6ut9mw54am4rr65kwcuz24q3n7waxtzyfvug5g4yuc00jydqj:{192ed08c15075e36-ec4892a8ba3b86f1-a1e050a6563b787e-adc9813f7fc90480}".parse().unwrap();
+        let nf_global_id: NonFungibleGlobalId = "resource_tdx_2_1ngw8z6ut9mw54am4rr65kwcuz24q3n7waxtzyfvug5g4yuc00jydqj:{192ed08c15075e36-ec4892a8ba3b86f1-a1e050a6563b787e-adc9813f7fc90480}".into();
 
-        let validator: ValidatorAddress = "validator_tdx_2_1sdlkptcwjpajqawnuya8r2mgl3eqt89hw27ww6du8kxmx3thmyu8l4".parse().unwrap();
+        let validator: ValidatorAddress = "validator_tdx_2_1sdlkptcwjpajqawnuya8r2mgl3eqt89hw27ww6du8kxmx3thmyu8l4".into();
 
         pretty_assertions::assert_eq!(
                 sut,
@@ -927,10 +883,10 @@ mod tests {
                         (
                            acc_gk.clone(),
                             vec![
-                                ResourceIndicator::Fungible {
-                                    resource_address: "resource_tdx_2_1t5hpjckz9tm63gqvxsl60ejhzvnlguly77tltvywnj06s2x9wjdxjn".parse::<ResourceAddress>().unwrap(), 
-                                    indicator: FungibleResourceIndicator::Guaranteed { decimal: "1234".parse::<Decimal>().unwrap() } 
-                                },
+                                ResourceIndicator::fungible(
+                                    "resource_tdx_2_1t5hpjckz9tm63gqvxsl60ejhzvnlguly77tltvywnj06s2x9wjdxjn", 
+                                    FungibleResourceIndicator::guaranteed(1234)
+                                ),
                             ]
                         )
                     ], // addresses_of_accounts_withdrawn_from
@@ -939,19 +895,18 @@ mod tests {
                         acc_gk.clone(),
                         vec![
                             (
-                               ResourceIndicator::NonFungible {
-                                resource_address:  "resource_tdx_2_1ngw8z6ut9mw54am4rr65kwcuz24q3n7waxtzyfvug5g4yuc00jydqj".parse::<ResourceAddress>().unwrap(), 
-                                indicator: NonFungibleResourceIndicator::ByAll {
-                                    predicted_amount: PredictedDecimal::new(
-                                        1,
-                                        3
-                                    ),
-                                    predicted_ids: PredictedNonFungibleLocalIds::new(
-                                        [NonFungibleLocalId::ruid(hex_decode("192ed08c15075e36ec4892a8ba3b86f1a1e050a6563b787eadc9813f7fc90480").unwrap()).unwrap()],
+                               ResourceIndicator::non_fungible(
+                                "resource_tdx_2_1ngw8z6ut9mw54am4rr65kwcuz24q3n7waxtzyfvug5g4yuc00jydqj",
+                                NonFungibleResourceIndicator::by_all(
+                                    PredictedDecimal::new(1, 3),
+                                    PredictedNonFungibleLocalIds::new(
+                                        [
+                                            NonFungibleLocalId::ruid(hex_decode("192ed08c15075e36ec4892a8ba3b86f1a1e050a6563b787eadc9813f7fc90480").unwrap()).unwrap()
+                                        ],
                                         3
                                     )
-                                }
-                             }
+                                )
+                            )
                             )
                         ]
                       )
@@ -973,9 +928,9 @@ mod tests {
                     ],
                     FeeLocks::default(),
                     FeeSummary::new(
-                        "0.2788849".parse::<Decimal>().unwrap(),
-                        "0.06251535".parse::<Decimal>().unwrap(),
-                        "0.16927718825".parse::<Decimal>().unwrap(),
+                        "0.2788849",
+                        "0.06251535",
+                        "0.16927718825",
                         0,
                     ),
                     NewEntities::default()
@@ -1003,13 +958,13 @@ mod tests {
             )
             .unwrap();
 
-        let acc_gk: AccountAddress = "account_tdx_2_1288efhmjt8kzce77par4ex997x2zgnlv5qqv9ltpxqg7ur0xpqm6gk".parse().unwrap();
+        let acc_gk: AccountAddress = "account_tdx_2_1288efhmjt8kzce77par4ex997x2zgnlv5qqv9ltpxqg7ur0xpqm6gk".into();
 
-        let validator_1: ValidatorAddress = "validator_tdx_2_1sdtnujyn3720ymg8lakydkvc5tw4q3zecdj95akdwt9de362mvtd94".parse().unwrap();
-        let validator_1_resource_address_of_stake: NonFungibleResourceAddress = "resource_tdx_2_1ng3g2nj5pfpmdphgz0nrh8z0gtqcxx5z5dn48t85ar0z0zjhefufaw".parse().unwrap();
+        let validator_1: ValidatorAddress = "validator_tdx_2_1sdtnujyn3720ymg8lakydkvc5tw4q3zecdj95akdwt9de362mvtd94".into();
+        let validator_1_resource_address_of_stake: NonFungibleResourceAddress = "resource_tdx_2_1ng3g2nj5pfpmdphgz0nrh8z0gtqcxx5z5dn48t85ar0z0zjhefufaw".into();
 
-        let validator_2: ValidatorAddress = "validator_tdx_2_1sdlkptcwjpajqawnuya8r2mgl3eqt89hw27ww6du8kxmx3thmyu8l4".parse().unwrap();
-        let validator_2_resource_address_of_stake: NonFungibleResourceAddress = "resource_tdx_2_1ngw8z6ut9mw54am4rr65kwcuz24q3n7waxtzyfvug5g4yuc00jydqj".parse().unwrap();
+        let validator_2: ValidatorAddress = "validator_tdx_2_1sdlkptcwjpajqawnuya8r2mgl3eqt89hw27ww6du8kxmx3thmyu8l4".into();
+        let validator_2_resource_address_of_stake: NonFungibleResourceAddress = "resource_tdx_2_1ngw8z6ut9mw54am4rr65kwcuz24q3n7waxtzyfvug5g4yuc00jydqj".into();
 
         pretty_assertions::assert_eq!(
                 sut,
@@ -1018,18 +973,18 @@ mod tests {
                         (
                             acc_gk.clone(),
                             vec![
-                                ResourceIndicator::NonFungible {
-                                    resource_address: "resource_tdx_2_1ng3g2nj5pfpmdphgz0nrh8z0gtqcxx5z5dn48t85ar0z0zjhefufaw".parse::<ResourceAddress>().unwrap(), 
-                                    indicator: NonFungibleResourceIndicator::ByIds { ids: vec![
+                                ResourceIndicator::non_fungible(
+                                    "resource_tdx_2_1ng3g2nj5pfpmdphgz0nrh8z0gtqcxx5z5dn48t85ar0z0zjhefufaw",
+                                    NonFungibleResourceIndicator::by_ids([
                                         NonFungibleLocalId::ruid(hex_decode("97c2b05d8529be58152d79c176d61d68f87611f279e0daa3d486426d5330795c").unwrap()).unwrap()
-                                    ] }
-                                },
-                                ResourceIndicator::NonFungible {
-                                    resource_address: "resource_tdx_2_1ngw8z6ut9mw54am4rr65kwcuz24q3n7waxtzyfvug5g4yuc00jydqj".parse::<ResourceAddress>().unwrap(), 
-                                    indicator: NonFungibleResourceIndicator::ByIds { ids: vec![
+                                    ])
+                                ),
+                                ResourceIndicator::non_fungible(
+                                    "resource_tdx_2_1ngw8z6ut9mw54am4rr65kwcuz24q3n7waxtzyfvug5g4yuc00jydqj",
+                                    NonFungibleResourceIndicator::by_ids([
                                         NonFungibleLocalId::ruid(hex_decode("f1edc2f0f8f54d33dab8e1bf90e196ce9714ef7b85478c6c82486b47a79b3002").unwrap()).unwrap()
-                                    ] }
-                                },
+                                    ])
+                                ),
                             ]
                         )
                     ], // addresses_of_accounts_withdrawn_from
@@ -1062,7 +1017,7 @@ mod tests {
                                     validator_1,
                                     validator_1_resource_address_of_stake,
                                     [
-                                        NonFungibleLocalId::from_str("{97c2b05d8529be58-152d79c176d61d68-f87611f279e0daa3-d486426d5330795c}").unwrap()
+                                        NonFungibleLocalId::from("{97c2b05d8529be58-152d79c176d61d68-f87611f279e0daa3-d486426d5330795c}")
                                     ],
                                     110
                                 ),
@@ -1070,7 +1025,7 @@ mod tests {
                                     validator_2,
                                     validator_2_resource_address_of_stake,
                                     [
-                                        NonFungibleLocalId::from_str("{f1edc2f0f8f54d33-dab8e1bf90e196ce-9714ef7b85478c6c-82486b47a79b3002}").unwrap()
+                                        NonFungibleLocalId::from("{f1edc2f0f8f54d33-dab8e1bf90e196ce-9714ef7b85478c6c-82486b47a79b3002}")
                                     ],
                                     1234
                                 ),
@@ -1079,9 +1034,9 @@ mod tests {
                     ],
                     FeeLocks::default(),
                     FeeSummary::new(
-                        "0.30518895".parse::<Decimal>().unwrap(),
-                        "0.05851055".parse::<Decimal>().unwrap(),
-                        "0.1916885343".parse::<Decimal>().unwrap(),
+                        "0.30518895",
+                        "0.05851055",
+                        "0.1916885343",
                         0,
                     ),
                     NewEntities::default()


### PR DESCRIPTION
Add three format methods to `Decimal192` - also UniFFI exported and sugared in Swift.
- `formatted_plain`
- `formatted_engineering_notation`
- `formatted` (using the previously mentioned)

I've used @kugel3 s implementation in Swift as ref, it is almost a 1:1 mapping. I've fixed a crash caused by an overflow bug the Swift impl has, when formatting Decimal::max. I will follow up with  bug fix in Swift.

Further changes:
- Changed impl of `abs` to never panic, in case of `Decimal::min().abs()` instead of panic I return `Decimal::max()` which seems like the correct thing to do???
- For TEST ONLY: Impl `From<str>` for Decimal and Address types, greatly simplifying writing of tests.