### PR TITLE
Create maven deployment on each push on develop

### DIFF
--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -5,6 +5,8 @@ on:
   push:
     tags:
       - '**'
+    branches:
+      - develop
 
 permissions:
   id-token: write

--- a/.github/workflows/release-desktop-bins.yml
+++ b/.github/workflows/release-desktop-bins.yml
@@ -5,6 +5,8 @@ on:
   push:
     tags:
       - '**'
+    branches:
+      - develop
 
 permissions:
   id-token: write


### PR DESCRIPTION
Android and desktop binaries were not being built as they were expecting a tag to be created. For now CD workflows will start on each develop push