### PR TITLE
Create extensions for TransactionManifest

### DIFF
--- a/apple/Sources/Sargon/Extensions/Methods/RET/TransactionManifest+Wrap+Functions.swift
+++ b/apple/Sources/Sargon/Extensions/Methods/RET/TransactionManifest+Wrap+Functions.swift
@@ -1,3 +1,7 @@
+extension TransactionManifest: CustomStringConvertible {
+	public var description: String { instructionsString }
+}
+
 extension TransactionManifest {
 
 	public var instructionsString: String {

--- a/apple/Sources/Sargon/Extensions/Methods/RET/TransactionManifest+Wrap+Functions.swift
+++ b/apple/Sources/Sargon/Extensions/Methods/RET/TransactionManifest+Wrap+Functions.swift
@@ -1,5 +1,14 @@
-extension TransactionManifest: CustomStringConvertible {
-	public var description: String {
-		transactionManifestToString(manifest: self)
+extension TransactionManifest {
+
+	public var instructionsString: String {
+		transactionManifestInstructionsString(manifest: self)
+	}
+
+	public var networkID: NetworkID {
+		transactionManifestNetworkId(manifest: self)
+	}
+
+	public var blobs: Blobs {
+		transactionManifestBlobs(manifest: self)
 	}
 }

--- a/apple/Tests/TestCases/RET/ManifestBuilding/ManifestBuildingTests.swift
+++ b/apple/Tests/TestCases/RET/ManifestBuilding/ManifestBuildingTests.swift
@@ -9,9 +9,9 @@ final class ManifestBuildingTests: XCTestCase {
 			addressOfReceivingAccount: AccountAddress.sample
 		)
 		
-		XCTAssert(manifest.instructionsString.contains("CALL_METHOD"))
-		XCTAssert(manifest.instructionsString.contains(AccountAddress.sample.description))
-		XCTAssert(manifest.instructionsString.contains("lock_fee"))
+		XCTAssert(manifest.description.contains("CALL_METHOD"))
+		XCTAssert(manifest.description.contains(AccountAddress.sample.description))
+		XCTAssert(manifest.description.contains("lock_fee"))
 	}
 	
 	func test_manifest_for_faucet_without_lock_fee() {
@@ -21,17 +21,17 @@ final class ManifestBuildingTests: XCTestCase {
 			addressOfReceivingAccount: AccountAddress.sampleOther
 		)
 		
-		XCTAssert(manifest.instructionsString.contains("CALL_METHOD"))
-		XCTAssert(manifest.instructionsString.contains(AccountAddress.sampleOther.description))
-		XCTAssertFalse(manifest.instructionsString.contains("lock_fee"))
+		XCTAssert(manifest.description.contains("CALL_METHOD"))
+		XCTAssert(manifest.description.contains(AccountAddress.sampleOther.description))
+		XCTAssertFalse(manifest.description.contains("lock_fee"))
 	}
 	
     func test_manifest_set_owner_keys_hashes() {
         func doTest(_ address: AddressOfAccountOrPersona, keyHashes: [PublicKeyHash]) {
             let manifest = manifestSetOwnerKeysHashes(addressOfAccountOrPersona: address, ownerKeyHashes: keyHashes)
-            XCTAssert(manifest.instructionsString.contains(address.description))
-            XCTAssert(manifest.instructionsString.contains("SET_METADATA"))
-            XCTAssert(manifest.instructionsString.contains("owner_keys"))
+            XCTAssert(manifest.description.contains(address.description))
+            XCTAssert(manifest.description.contains("SET_METADATA"))
+            XCTAssert(manifest.description.contains("owner_keys"))
         }
         
         AddressOfAccountOrPersona.allCases.forEach {
@@ -57,7 +57,7 @@ final class ManifestBuildingTests: XCTestCase {
                 metadata: metadata
             )
             func oneOf(_ needle: String, line: UInt = #line) {
-                XCTAssertEqual(manifest.instructionsString.ranges(of: needle).count, 1, line: line)
+                XCTAssertEqual(manifest.description.ranges(of: needle).count, 1, line: line)
             }
             func oneIn<P: CustomStringConvertible>(metadata keyPath: KeyPath<TokenDefinitionMetadata, P>, line: UInt = #line) {
                 let property = metadata[keyPath: keyPath]
@@ -75,7 +75,7 @@ final class ManifestBuildingTests: XCTestCase {
     func test_create_multiple_fungible_tokens() {
         func doTest(_ accountAddress: AccountAddress) {
             let manifest = manifestCreateMultipleFungibleTokens(addressOfOwner: accountAddress)
-            XCTAssertEqual(manifest.instructionsString.ranges(of: "symbol").count, 25)
+            XCTAssertEqual(manifest.description.ranges(of: "symbol").count, 25)
         }
         [
             AccountAddress.sampleStokenet,
@@ -86,9 +86,9 @@ final class ManifestBuildingTests: XCTestCase {
 	func test_manifest_marking_account_as_dapp_definition_type() {
 		func doTest(_ accountAddress: AccountAddress) {
 			let manifest = manifestMarkingAccountAsDappDefinitionType(accountAddress: accountAddress)
-			XCTAssert(manifest.instructionsString.contains(accountAddress.description))
-			XCTAssert(manifest.instructionsString.contains("SET_METADATA"))
-			XCTAssert(manifest.instructionsString.contains("dapp definition"))
+			XCTAssert(manifest.description.contains(accountAddress.description))
+			XCTAssert(manifest.description.contains("SET_METADATA"))
+			XCTAssert(manifest.description.contains("dapp definition"))
 		}
 		AccountAddress.allCases.forEach(doTest)
 	}

--- a/apple/Tests/TestCases/RET/ManifestBuilding/ManifestBuildingTests.swift
+++ b/apple/Tests/TestCases/RET/ManifestBuilding/ManifestBuildingTests.swift
@@ -9,9 +9,9 @@ final class ManifestBuildingTests: XCTestCase {
 			addressOfReceivingAccount: AccountAddress.sample
 		)
 		
-		XCTAssert(manifest.description.contains("CALL_METHOD"))
-		XCTAssert(manifest.description.contains(AccountAddress.sample.description))
-		XCTAssert(manifest.description.contains("lock_fee"))
+		XCTAssert(manifest.instructionsString.contains("CALL_METHOD"))
+		XCTAssert(manifest.instructionsString.contains(AccountAddress.sample.description))
+		XCTAssert(manifest.instructionsString.contains("lock_fee"))
 	}
 	
 	func test_manifest_for_faucet_without_lock_fee() {
@@ -21,17 +21,17 @@ final class ManifestBuildingTests: XCTestCase {
 			addressOfReceivingAccount: AccountAddress.sampleOther
 		)
 		
-		XCTAssert(manifest.description.contains("CALL_METHOD"))
-		XCTAssert(manifest.description.contains(AccountAddress.sampleOther.description))
-		XCTAssertFalse(manifest.description.contains("lock_fee"))
+		XCTAssert(manifest.instructionsString.contains("CALL_METHOD"))
+		XCTAssert(manifest.instructionsString.contains(AccountAddress.sampleOther.description))
+		XCTAssertFalse(manifest.instructionsString.contains("lock_fee"))
 	}
 	
     func test_manifest_set_owner_keys_hashes() {
         func doTest(_ address: AddressOfAccountOrPersona, keyHashes: [PublicKeyHash]) {
             let manifest = manifestSetOwnerKeysHashes(addressOfAccountOrPersona: address, ownerKeyHashes: keyHashes)
-            XCTAssert(manifest.description.contains(address.description))
-            XCTAssert(manifest.description.contains("SET_METADATA"))
-            XCTAssert(manifest.description.contains("owner_keys"))
+            XCTAssert(manifest.instructionsString.contains(address.description))
+            XCTAssert(manifest.instructionsString.contains("SET_METADATA"))
+            XCTAssert(manifest.instructionsString.contains("owner_keys"))
         }
         
         AddressOfAccountOrPersona.allCases.forEach {
@@ -57,7 +57,7 @@ final class ManifestBuildingTests: XCTestCase {
                 metadata: metadata
             )
             func oneOf(_ needle: String, line: UInt = #line) {
-                XCTAssertEqual(manifest.description.ranges(of: needle).count, 1, line: line)
+                XCTAssertEqual(manifest.instructionsString.ranges(of: needle).count, 1, line: line)
             }
             func oneIn<P: CustomStringConvertible>(metadata keyPath: KeyPath<TokenDefinitionMetadata, P>, line: UInt = #line) {
                 let property = metadata[keyPath: keyPath]
@@ -75,7 +75,7 @@ final class ManifestBuildingTests: XCTestCase {
     func test_create_multiple_fungible_tokens() {
         func doTest(_ accountAddress: AccountAddress) {
             let manifest = manifestCreateMultipleFungibleTokens(addressOfOwner: accountAddress)
-            XCTAssertEqual(manifest.description.ranges(of: "symbol").count, 25)
+            XCTAssertEqual(manifest.instructionsString.ranges(of: "symbol").count, 25)
         }
         [
             AccountAddress.sampleStokenet,
@@ -86,9 +86,9 @@ final class ManifestBuildingTests: XCTestCase {
 	func test_manifest_marking_account_as_dapp_definition_type() {
 		func doTest(_ accountAddress: AccountAddress) {
 			let manifest = manifestMarkingAccountAsDappDefinitionType(accountAddress: accountAddress)
-			XCTAssert(manifest.description.contains(accountAddress.description))
-			XCTAssert(manifest.description.contains("SET_METADATA"))
-			XCTAssert(manifest.description.contains("dapp definition"))
+			XCTAssert(manifest.instructionsString.contains(accountAddress.description))
+			XCTAssert(manifest.instructionsString.contains("SET_METADATA"))
+			XCTAssert(manifest.instructionsString.contains("dapp definition"))
 		}
 		AccountAddress.allCases.forEach(doTest)
 	}

--- a/apple/Tests/TestCases/RET/TransactionManifestTests.swift
+++ b/apple/Tests/TestCases/RET/TransactionManifestTests.swift
@@ -11,13 +11,13 @@ final class TransactionManifestTests: Test<TransactionManifest> {
 		
 		let manifest = TransactionManifest.sample
 		
-		XCTAssert(manifest.networkID == .mainnet)
+		XCTAssertEqual(manifest.networkID, .mainnet)
 	}
 
     func test_manifest_blobs() {
 		
 		let manifest = TransactionManifest.sample
 		
-		XCTAssert(manifest.blobs == newBlobsFromBlobList(blobs: []))
+		XCTAssertEqual(manifest.blobs, newBlobsFromBlobList(blobs: []))
 	}
 }

--- a/apple/Tests/TestCases/RET/TransactionManifestTests.swift
+++ b/apple/Tests/TestCases/RET/TransactionManifestTests.swift
@@ -1,1 +1,23 @@
-final class TransactionManifestTests: Test<TransactionManifest> {}
+final class TransactionManifestTests: Test<TransactionManifest> {
+
+    func test_manifest_instructions_string() {
+		
+		let manifest = TransactionManifest.sample
+		
+		XCTAssert(manifest.instructionsString.contains("CALL_METHOD"))
+	}
+
+    func test_manifest_network_id() {
+		
+		let manifest = TransactionManifest.sample
+		
+		XCTAssert(manifest.networkID == .mainnet)
+	}
+
+    func test_manifest_blobs() {
+		
+		let manifest = TransactionManifest.sample
+		
+		XCTAssert(manifest.blobs == newBlobsFromBlobList(blobs: []))
+	}
+}

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/TransactionManifest.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/TransactionManifest.kt
@@ -28,7 +28,9 @@ import com.radixdlt.sargon.manifestThirdPartyDepositUpdate
 import com.radixdlt.sargon.modifyManifestAddGuarantees
 import com.radixdlt.sargon.modifyManifestLockFee
 import com.radixdlt.sargon.newTransactionManifestFromInstructionsStringAndBlobs
-import com.radixdlt.sargon.transactionManifestToString
+import com.radixdlt.sargon.transactionManifestBlobs
+import com.radixdlt.sargon.transactionManifestInstructionsString
+import com.radixdlt.sargon.transactionManifestNetworkId
 import com.radixdlt.sargon.utils.KoverIgnore
 
 @Throws(SargonException::class)
@@ -145,5 +147,11 @@ fun TransactionManifest.modifyLockFee(
     fee: Decimal192?
 ) = modifyManifestLockFee(manifest = this, addressOfFeePayer = addressOfFeePayer, fee = fee)
 
-val TransactionManifest.string: String
-    get() = transactionManifestToString(manifest = this)
+val TransactionManifest.instructionsString: String
+    get() = transactionManifestInstructionsString(manifest = this)
+
+val TransactionManifest.networkId: NetworkId
+    get() = transactionManifestNetworkId(manifest = this)
+
+val TransactionManifest.blobs: Blobs
+    get() = transactionManifestBlobs(manifest = this)

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/TransactionManifestTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/TransactionManifestTest.kt
@@ -1,5 +1,6 @@
 package com.radixdlt.sargon
 
+import com.radixdlt.sargon.extensions.blobs
 import com.radixdlt.sargon.extensions.createFungibleToken
 import com.radixdlt.sargon.extensions.createFungibleTokenWithMetadata
 import com.radixdlt.sargon.extensions.createMultipleFungibleTokens
@@ -16,7 +17,8 @@ import com.radixdlt.sargon.extensions.perAssetTransfers
 import com.radixdlt.sargon.extensions.perRecipientTransfers
 import com.radixdlt.sargon.extensions.setOwnerKeysHashes
 import com.radixdlt.sargon.extensions.stakesClaim
-import com.radixdlt.sargon.extensions.string
+import com.radixdlt.sargon.extensions.instructionsString
+import com.radixdlt.sargon.extensions.networkId
 import com.radixdlt.sargon.extensions.thirdPartyDepositUpdate
 import com.radixdlt.sargon.extensions.toDecimal192
 import com.radixdlt.sargon.samples.Sample
@@ -59,14 +61,15 @@ class TransactionManifestTest: SampleTestable<TransactionManifest> {
         
         """.trimIndent()
 
-        assertEquals(TransactionManifest.sample().string, instructionsString)
-
         val manifest = TransactionManifest.init(
             instructionsString = instructionsString,
-            networkId = NetworkId.MAINNET
+            networkId = NetworkId.MAINNET,
+            blobs = Blobs.sample()
         )
 
-        assertEquals(TransactionManifest.sample(), manifest)
+        assertEquals(instructionsString, manifest.instructionsString)
+        assertEquals(NetworkId.MAINNET, manifest.networkId)
+        assertEquals(Blobs.sample(), manifest.blobs)
     }
 
     @Test
@@ -204,7 +207,7 @@ class TransactionManifestTest: SampleTestable<TransactionManifest> {
             )
         )
 
-        assertEquals(instructionsString, manifest.string)
+        assertEquals(instructionsString, manifest.instructionsString)
     }
 
     @Test
@@ -493,7 +496,7 @@ class TransactionManifestTest: SampleTestable<TransactionManifest> {
             )
         )
 
-        assertEquals(instructionsString, manifest.string)
+        assertEquals(instructionsString, manifest.instructionsString)
     }
 
     @Test
@@ -639,7 +642,7 @@ class TransactionManifestTest: SampleTestable<TransactionManifest> {
             )
         )
 
-        assertEquals(instructionsString, manifest.string)
+        assertEquals(instructionsString, manifest.instructionsString)
     }
 
     @Test
@@ -3634,7 +3637,7 @@ class TransactionManifestTest: SampleTestable<TransactionManifest> {
             )
         )
 
-        assertEquals(instructionsString, manifest.string)
+        assertEquals(instructionsString, manifest.instructionsString)
     }
 
     @Test
@@ -6939,7 +6942,7 @@ class TransactionManifestTest: SampleTestable<TransactionManifest> {
             )
         )
 
-        assertEquals(instructionsString, manifest.string)
+        assertEquals(instructionsString, manifest.instructionsString)
     }
 
     @Test
@@ -6969,7 +6972,7 @@ class TransactionManifestTest: SampleTestable<TransactionManifest> {
             )
         )
 
-        assertEquals(instructionsString, manifest.string)
+        assertEquals(instructionsString, manifest.instructionsString)
     }
 
     @Test
@@ -6990,7 +6993,7 @@ class TransactionManifestTest: SampleTestable<TransactionManifest> {
             )
         )
 
-        assertEquals(instructionsString, manifest.string)
+        assertEquals(instructionsString, manifest.instructionsString)
     }
 
     @Test
@@ -7042,7 +7045,7 @@ class TransactionManifestTest: SampleTestable<TransactionManifest> {
             )
         )
 
-        assertEquals(instructionsString, manifest.string)
+        assertEquals(instructionsString, manifest.instructionsString)
     }
 
     @Test
@@ -7092,7 +7095,7 @@ class TransactionManifestTest: SampleTestable<TransactionManifest> {
             )
         )
 
-        assertEquals(instructionsString, manifest.string)
+        assertEquals(instructionsString, manifest.instructionsString)
     }
 
     @Test
@@ -7122,7 +7125,7 @@ class TransactionManifestTest: SampleTestable<TransactionManifest> {
                 )
             )
         )
-        assertEquals(instructionsString, manifest.string)
+        assertEquals(instructionsString, manifest.instructionsString)
     }
 
     @Test
@@ -7175,7 +7178,7 @@ class TransactionManifestTest: SampleTestable<TransactionManifest> {
                 )
             )
         )
-        assertEquals(instructionsString, manifest.string)
+        assertEquals(instructionsString, manifest.instructionsString)
     }
 
     @Test
@@ -7204,7 +7207,7 @@ class TransactionManifestTest: SampleTestable<TransactionManifest> {
                 depositorsAllowList = emptyList()
             )
         )
-        assertEquals(instructionsString, manifest.string)
+        assertEquals(instructionsString, manifest.instructionsString)
     }
 
     @Test
@@ -7281,7 +7284,7 @@ class TransactionManifestTest: SampleTestable<TransactionManifest> {
 
         """.trimIndent()
 
-        assertEquals(expectedModified, modifiedManifest.string)
+        assertEquals(expectedModified, modifiedManifest.instructionsString)
     }
 
     @Test
@@ -7343,6 +7346,6 @@ class TransactionManifestTest: SampleTestable<TransactionManifest> {
 
         """.trimIndent()
 
-        assertEquals(expectedModified, modifiedManifest.string)
+        assertEquals(expectedModified, modifiedManifest.instructionsString)
     }
 }

--- a/src/wrapped_radix_engine_toolkit/low_level/transaction_manifest/mod.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/transaction_manifest/mod.rs
@@ -3,9 +3,11 @@ mod execution_summary;
 mod instructions;
 mod transaction_manifest;
 mod transaction_manifest_secret_magic;
+mod transaction_manifest_uniffi_fn;
 
 pub use blobs::*;
 pub use execution_summary::*;
 pub use instructions::*;
 pub use transaction_manifest::*;
 pub use transaction_manifest_secret_magic::*;
+pub use transaction_manifest_uniffi_fn::*;

--- a/src/wrapped_radix_engine_toolkit/low_level/transaction_manifest/transaction_manifest.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/transaction_manifest/transaction_manifest.rs
@@ -121,33 +121,6 @@ impl TransactionManifest {
     }
 }
 
-#[uniffi::export]
-pub fn new_transaction_manifest_from_instructions_string_and_blobs(
-    instructions_string: String,
-    network_id: NetworkID,
-    blobs: Blobs,
-) -> Result<TransactionManifest> {
-    TransactionManifest::new(instructions_string, network_id, blobs)
-}
-
-#[uniffi::export]
-pub fn new_transaction_manifest_sample() -> TransactionManifest {
-    TransactionManifest::sample()
-}
-
-#[uniffi::export]
-pub fn new_transaction_manifest_sample_other() -> TransactionManifest {
-    TransactionManifest::sample_other()
-}
-
-#[uniffi::export]
-pub fn transaction_manifest_to_string(
-    manifest: &TransactionManifest,
-) -> String {
-    // FIXME add blobs
-    manifest.instructions_string()
-}
-
 impl HasSampleValues for TransactionManifest {
     fn sample() -> Self {
         TransactionManifestSecretMagic::sample().into()
@@ -338,46 +311,5 @@ mod tests {
         let manifest = SUT::sample();
         let resources = manifest.resource_addresses_to_refresh();
         assert_eq!(resources[0].address(), "resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd");
-    }
-}
-
-#[cfg(test)]
-mod uniffi_tests {
-    use crate::prelude::*;
-
-    #[allow(clippy::upper_case_acronyms)]
-    type SUT = TransactionManifest;
-
-    #[test]
-    fn samples() {
-        assert_eq!(new_transaction_manifest_sample(), SUT::sample());
-        assert_eq!(
-            new_transaction_manifest_sample_other(),
-            SUT::sample_other()
-        );
-    }
-
-    #[test]
-    fn to_string() {
-        assert_eq!(
-            transaction_manifest_to_string(&SUT::sample()),
-            SUT::sample().to_string()
-        );
-    }
-
-    #[test]
-    fn test_new_transaction_manifest_from_instructions_string_and_blobs() {
-        let s = new_transaction_manifest_sample().instructions_string();
-
-        assert_eq!(
-            new_transaction_manifest_from_instructions_string_and_blobs(
-                s.clone(),
-                NetworkID::Mainnet,
-                Blobs::default()
-            )
-            .unwrap()
-            .instructions_string(),
-            s
-        );
     }
 }

--- a/src/wrapped_radix_engine_toolkit/low_level/transaction_manifest/transaction_manifest_uniffi_fn.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/transaction_manifest/transaction_manifest_uniffi_fn.rs
@@ -1,0 +1,96 @@
+use crate::prelude::*;
+
+#[uniffi::export]
+pub fn new_transaction_manifest_from_instructions_string_and_blobs(
+    instructions_string: String,
+    network_id: NetworkID,
+    blobs: Blobs,
+) -> Result<TransactionManifest> {
+    TransactionManifest::new(instructions_string, network_id, blobs)
+}
+
+#[uniffi::export]
+pub fn transaction_manifest_instructions_string(
+    manifest: &TransactionManifest,
+) -> String {
+    manifest.instructions_string()
+}
+
+#[uniffi::export]
+pub fn transaction_manifest_network_id(
+    manifest: &TransactionManifest,
+) -> NetworkID {
+    manifest.network_id()
+}
+
+#[uniffi::export]
+pub fn transaction_manifest_blobs(manifest: &TransactionManifest) -> Blobs {
+    manifest.blobs().clone()
+}
+
+#[uniffi::export]
+pub fn new_transaction_manifest_sample() -> TransactionManifest {
+    TransactionManifest::sample()
+}
+
+#[uniffi::export]
+pub fn new_transaction_manifest_sample_other() -> TransactionManifest {
+    TransactionManifest::sample_other()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::prelude::*;
+
+    #[allow(clippy::upper_case_acronyms)]
+    type SUT = TransactionManifest;
+
+    #[test]
+    fn samples() {
+        assert_eq!(new_transaction_manifest_sample(), SUT::sample());
+        assert_eq!(
+            new_transaction_manifest_sample_other(),
+            SUT::sample_other()
+        );
+    }
+
+    #[test]
+    fn test_new_transaction_manifest_from_instructions_string_and_blobs() {
+        let s = new_transaction_manifest_sample().instructions_string();
+
+        assert_eq!(
+            new_transaction_manifest_from_instructions_string_and_blobs(
+                s.clone(),
+                NetworkID::Mainnet,
+                Blobs::default()
+            )
+            .unwrap()
+            .instructions_string(),
+            s
+        );
+    }
+
+    #[test]
+    fn test_instructions_string() {
+        assert_eq!(
+            transaction_manifest_instructions_string(&SUT::sample()),
+            SUT::sample().instructions_string()
+        );
+    }
+
+    #[test]
+    fn test_network_id() {
+        assert_eq!(
+            transaction_manifest_network_id(&SUT::sample()),
+            SUT::sample().network_id()
+        );
+    }
+
+    #[test]
+    fn test_blobs() {
+        assert_eq!(
+            transaction_manifest_blobs(&SUT::sample()),
+            SUT::sample().blobs().clone()
+        );
+    }
+}


### PR DESCRIPTION
Exposed 3 uniffi methods on TransactionManifest and created extensions for them in swift/kotlin
* for instructions
* for network id
* for blobs
Specifically for swift, I removed the `description` for TransactionManifest, since a Manifest cannot be described only with instructions and I replaced all usages with `instructionsString`.