### PR TITLE
Sendable Swift Types

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,11 @@
 
 import PackageDescription
 
+let swiftSettings: [SwiftSetting] = [
+	.enableExperimentalFeature("StrictConcurrency"),
+	.unsafeFlags(["-warnings-as-errors"])
+]
+
 let sargonBinaryTargetName = "SargonCoreRS"
 let binaryTarget: Target
 let useLocalFramework = true
@@ -49,7 +54,8 @@ let package = Package(
 		.target(
 			name: "Sargon",
 			dependencies: [.target(name: "SargonUniFFI")],
-			path: "apple/Sources/Sargon"
+			path: "apple/Sources/Sargon",
+			swiftSettings: swiftSettings
 		),
 		.testTarget(
 			name: "SargonTests",
@@ -57,7 +63,8 @@ let package = Package(
 				.target(name: "Sargon"),
 				.product(name: "CustomDump", package: "swift-custom-dump"),
 			],
-			path: "apple/Tests"
+			path: "apple/Tests",
+			swiftSettings: swiftSettings
 		),
 	]
 )

--- a/apple/Sources/Sargon/Extensions/Swiftified/Address/AccessControllerAddress+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Address/AccessControllerAddress+Swiftified.swift
@@ -1,2 +1,1 @@
-extension AccessControllerAddress: @unchecked Sendable {}
 extension AccessControllerAddress: AddressProtocol {}

--- a/apple/Sources/Sargon/Extensions/Swiftified/Address/AccountAddress+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Address/AccountAddress+Swiftified.swift
@@ -1,2 +1,1 @@
-extension AccountAddress: @unchecked Sendable {}
 extension AccountAddress: EntityAddressProtocol {}

--- a/apple/Sources/Sargon/Extensions/Swiftified/Address/AddressOfAccountOrPersona+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Address/AddressOfAccountOrPersona+Swiftified.swift
@@ -1,2 +1,1 @@
-extension AddressOfAccountOrPersona: @unchecked Sendable {}
 extension AddressOfAccountOrPersona: AddressProtocol {}

--- a/apple/Sources/Sargon/Extensions/Swiftified/Address/ComponentAddress+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Address/ComponentAddress+Swiftified.swift
@@ -1,2 +1,1 @@
-extension ComponentAddress: @unchecked Sendable {}
 extension ComponentAddress: AddressProtocol {}

--- a/apple/Sources/Sargon/Extensions/Swiftified/Address/IdentityAddress+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Address/IdentityAddress+Swiftified.swift
@@ -1,2 +1,1 @@
-extension IdentityAddress: @unchecked Sendable {}
 extension IdentityAddress: EntityAddressProtocol {}

--- a/apple/Sources/Sargon/Extensions/Swiftified/Address/LegacyOlympiaAccountAddress+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Address/LegacyOlympiaAccountAddress+Swiftified.swift
@@ -1,2 +1,1 @@
-extension LegacyOlympiaAccountAddress: @unchecked Sendable {}
 extension LegacyOlympiaAccountAddress: BaseAddressProtocol {}

--- a/apple/Sources/Sargon/Extensions/Swiftified/Address/NonFungibleResourceAddress+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Address/NonFungibleResourceAddress+Swiftified.swift
@@ -1,4 +1,3 @@
-extension NonFungibleResourceAddress: @unchecked Sendable {}
 extension NonFungibleResourceAddress: AddressProtocol {}
 
 extension NonFungibleResourceAddress {

--- a/apple/Sources/Sargon/Extensions/Swiftified/Address/PackageAddress+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Address/PackageAddress+Swiftified.swift
@@ -1,2 +1,1 @@
-extension PackageAddress: @unchecked Sendable {}
 extension PackageAddress: AddressProtocol {}

--- a/apple/Sources/Sargon/Extensions/Swiftified/Address/PoolAddress+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Address/PoolAddress+Swiftified.swift
@@ -1,2 +1,1 @@
-extension PoolAddress: @unchecked Sendable {}
 extension PoolAddress: AddressProtocol {}

--- a/apple/Sources/Sargon/Extensions/Swiftified/Address/ResourceAddress+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Address/ResourceAddress+Swiftified.swift
@@ -1,4 +1,3 @@
-extension ResourceAddress: @unchecked Sendable {}
 extension ResourceAddress: AddressProtocol {}
 
 extension ResourceAddress {

--- a/apple/Sources/Sargon/Extensions/Swiftified/Address/ValidatorAddress+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Address/ValidatorAddress+Swiftified.swift
@@ -1,2 +1,1 @@
-extension ValidatorAddress: @unchecked Sendable {}
 extension ValidatorAddress: AddressProtocol {}

--- a/apple/Sources/Sargon/Extensions/Swiftified/Address/VaultAddress+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Address/VaultAddress+Swiftified.swift
@@ -1,2 +1,1 @@
-extension VaultAddress: @unchecked Sendable {}
 extension VaultAddress: AddressProtocol {}

--- a/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Derivation/AccountPath+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Derivation/AccountPath+Swiftified.swift
@@ -1,4 +1,3 @@
-extension AccountPath: @unchecked Sendable {}
 extension AccountPath: SargonModel, CAP26PathProtocol {}
 
 extension AccountPath {

--- a/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Derivation/BIP44LikePath+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Derivation/BIP44LikePath+Swiftified.swift
@@ -1,6 +1,5 @@
 public typealias BIP44LikePath = Bip44LikePath
 
-extension BIP44LikePath: @unchecked Sendable {}
 extension BIP44LikePath: SargonModel, HDPathProtocol {}
 
 extension BIP44LikePath: CustomStringConvertible {

--- a/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Derivation/CAP26Path+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Derivation/CAP26Path+Swiftified.swift
@@ -1,6 +1,5 @@
 public typealias CAP26Path = Cap26Path
 
-extension CAP26Path: @unchecked Sendable {}
 extension CAP26Path: SargonModel, CAP26PathProtocol {
     public func embed() -> CAP26Path {
         self

--- a/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Derivation/GetIDPath+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Derivation/GetIDPath+Swiftified.swift
@@ -1,6 +1,5 @@
 public typealias GetIDPath = GetIdPath
 
-extension GetIDPath: @unchecked Sendable {}
 extension GetIDPath {
     public static let `default`: Self = defaultGetIdPath()
 }

--- a/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Derivation/IdentityPath+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Derivation/IdentityPath+Swiftified.swift
@@ -1,4 +1,3 @@
-extension IdentityPath: @unchecked Sendable {}
 extension IdentityPath: SargonModel, CAP26PathProtocol {}
 
 extension IdentityPath {

--- a/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Derivation/Mnemonic+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Derivation/Mnemonic+Swiftified.swift
@@ -1,4 +1,3 @@
-extension Mnemonic: @unchecked Sendable {}
 extension Mnemonic: SargonModel {}
 
 extension Mnemonic: CustomStringConvertible {

--- a/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Hash/Hash+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Hash/Hash+Swiftified.swift
@@ -1,4 +1,3 @@
-extension Hash: @unchecked Sendable {}
 extension Hash: SargonModel {}
 
 extension Hash {

--- a/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Hash/IntentHash+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Hash/IntentHash+Swiftified.swift
@@ -1,4 +1,3 @@
-extension IntentHash: @unchecked Sendable {}
 extension IntentHash: SargonModel {}
 
 extension IntentHash: CustomStringConvertible {

--- a/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Hash/PublicKeyHash+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Hash/PublicKeyHash+Swiftified.swift
@@ -1,4 +1,3 @@
-extension PublicKeyHash: @unchecked Sendable {}
 extension PublicKeyHash: SargonModel {}
 
 extension PublicKeyHash {

--- a/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Hash/SignedIntentHash+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Hash/SignedIntentHash+Swiftified.swift
@@ -1,4 +1,3 @@
-extension SignedIntentHash: @unchecked Sendable {}
 extension SignedIntentHash: SargonModel {}
 
 extension SignedIntentHash: CustomStringConvertible {

--- a/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Keys/Ed25519PublicKey+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Keys/Ed25519PublicKey+Swiftified.swift
@@ -1,2 +1,1 @@
-extension Ed25519PublicKey: @unchecked Sendable {}
 extension Ed25519PublicKey: PublicKeyProtocol {}

--- a/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Keys/PublicKey+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Keys/PublicKey+Swiftified.swift
@@ -1,2 +1,1 @@
-extension PublicKey: @unchecked Sendable {}
 extension PublicKey: PublicKeyProtocol {}

--- a/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Keys/Secp256k1PublicKey+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Keys/Secp256k1PublicKey+Swiftified.swift
@@ -1,2 +1,1 @@
-extension Secp256k1PublicKey: @unchecked Sendable {}
 extension Secp256k1PublicKey: PublicKeyProtocol {}

--- a/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Nonce+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Nonce+Swiftified.swift
@@ -1,2 +1,1 @@
-extension Nonce: @unchecked Sendable {}
 extension Nonce: SargonModel {}

--- a/apple/Sources/Sargon/Extensions/Swiftified/Crypto/SignatureWithPublicKey+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Crypto/SignatureWithPublicKey+Swiftified.swift
@@ -1,2 +1,1 @@
-extension SignatureWithPublicKey: @unchecked Sendable {}
 extension SignatureWithPublicKey: SargonModel {}

--- a/apple/Sources/Sargon/Extensions/Swiftified/Prelude/Bytes/Exactly29Bytes+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Prelude/Bytes/Exactly29Bytes+Swiftified.swift
@@ -1,4 +1,3 @@
-extension Exactly29Bytes: @unchecked Sendable {}
 extension Exactly29Bytes: ExactlyNBytesProtocol {
 	public static let length = 29
 }

--- a/apple/Sources/Sargon/Extensions/Swiftified/Prelude/Bytes/Exactly32Bytes+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Prelude/Bytes/Exactly32Bytes+Swiftified.swift
@@ -1,4 +1,3 @@
-extension Exactly32Bytes: @unchecked Sendable {}
 extension Exactly32Bytes: ExactlyNBytesProtocol  {
 	public static let length = 32
 }

--- a/apple/Sources/Sargon/Extensions/Swiftified/Prelude/Bytes/Exactly33Bytes+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Prelude/Bytes/Exactly33Bytes+Swiftified.swift
@@ -1,4 +1,3 @@
-extension Exactly33Bytes: @unchecked Sendable {}
 extension Exactly33Bytes: ExactlyNBytesProtocol  {
 	public static let length = 33
 }

--- a/apple/Sources/Sargon/Extensions/Swiftified/Prelude/Bytes/Exactly64Bytes+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Prelude/Bytes/Exactly64Bytes+Swiftified.swift
@@ -1,4 +1,3 @@
-extension Exactly64Bytes: @unchecked Sendable {}
 extension Exactly64Bytes: ExactlyNBytesProtocol  {
 	public static let length = 64
 }

--- a/apple/Sources/Sargon/Extensions/Swiftified/Prelude/Bytes/Exactly65Bytes+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Prelude/Bytes/Exactly65Bytes+Swiftified.swift
@@ -1,4 +1,3 @@
-extension Exactly65Bytes: @unchecked Sendable {}
 extension Exactly65Bytes: ExactlyNBytesProtocol  {
 	public static let length = 65
 }

--- a/apple/Sources/Sargon/Extensions/Swiftified/Prelude/Decimal192+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Prelude/Decimal192+Swiftified.swift
@@ -1,4 +1,3 @@
-extension Decimal192: @unchecked Sendable {}
 extension Decimal192: SargonModel {}
 
 #if DEBUG

--- a/apple/Sources/Sargon/Extensions/Swiftified/Prelude/DisplayName+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Prelude/DisplayName+Swiftified.swift
@@ -1,4 +1,3 @@
-extension DisplayName: @unchecked Sendable {}
 extension DisplayName: SargonModel {}
 
 extension DisplayName: CustomStringConvertible {

--- a/apple/Sources/Sargon/Extensions/Swiftified/Prelude/LocaleConfig+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Prelude/LocaleConfig+Swiftified.swift
@@ -1,4 +1,3 @@
-extension LocaleConfig: @unchecked Sendable {}
 extension LocaleConfig {
 	public init(locale: Locale) {
 		self.init(

--- a/apple/Sources/Sargon/Extensions/Swiftified/Prelude/NetworkID+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Prelude/NetworkID+Swiftified.swift
@@ -1,4 +1,3 @@
 public typealias NetworkID = NetworkId
 
-extension NetworkID: @unchecked Sendable {}
 extension NetworkID: SargonModel {}

--- a/apple/Sources/Sargon/Extensions/Swiftified/Prelude/NonFungibleGlobalID+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Prelude/NonFungibleGlobalID+Swiftified.swift
@@ -1,5 +1,4 @@
 public typealias NonFungibleGlobalID = NonFungibleGlobalId
-extension NonFungibleGlobalID: @unchecked Sendable {}
 extension NonFungibleGlobalID: SargonModel {}
 
 extension NonFungibleGlobalID {

--- a/apple/Sources/Sargon/Extensions/Swiftified/Prelude/NonFungibleLocalID+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Prelude/NonFungibleLocalID+Swiftified.swift
@@ -1,6 +1,5 @@
 public typealias NonFungibleLocalID = NonFungibleLocalId
 
-extension NonFungibleLocalID: @unchecked Sendable {}
 extension NonFungibleLocalID: SargonModel {}
 
 extension NonFungibleLocalID: CustomStringConvertible {

--- a/apple/Sources/Sargon/Extensions/Swiftified/Prelude/NonFungibleLocalIDString+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Prelude/NonFungibleLocalIDString+Swiftified.swift
@@ -1,5 +1,4 @@
 public typealias NonFungibleLocalIDString = NonFungibleLocalIdString
-extension NonFungibleLocalIDString: @unchecked Sendable {}
 extension NonFungibleLocalIDString: SargonModel {}
 
 #if DEBUG

--- a/apple/Sources/Sargon/Extensions/Swiftified/Prelude/SargonBuildInformation+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Prelude/SargonBuildInformation+Swiftified.swift
@@ -1,4 +1,3 @@
-extension SargonBuildInformation: @unchecked Sendable {}
 extension SargonBuildInformation: SargonModel {}
 
 extension SargonBuildInformation {

--- a/apple/Sources/Sargon/Extensions/Swiftified/Prelude/SargonError+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Prelude/SargonError+Swiftified.swift
@@ -8,4 +8,3 @@
 import Foundation
 
 public typealias SargonError = CommonError
-extension SargonError: @unchecked Sendable {}

--- a/apple/Sources/Sargon/Extensions/Swiftified/Profile/Account/Account+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Profile/Account/Account+Swiftified.swift
@@ -1,4 +1,3 @@
-extension Account: @unchecked Sendable {}
 extension Account: EntityProtocol {}
 
 extension Account {

--- a/apple/Sources/Sargon/Extensions/Swiftified/Profile/Account/AppearanceID+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Profile/Account/AppearanceID+Swiftified.swift
@@ -1,6 +1,5 @@
 public typealias AppearanceID = AppearanceId
 
-extension AppearanceID: @unchecked Sendable {}
 extension AppearanceID: SargonModel {}
 extension AppearanceID: Identifiable {
 	public typealias ID = UInt8

--- a/apple/Sources/Sargon/Extensions/Swiftified/Profile/Account/ThirdPartyDeposits+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Profile/Account/ThirdPartyDeposits+Swiftified.swift
@@ -1,2 +1,1 @@
-extension ThirdPartyDeposits: @unchecked Sendable {}
 extension ThirdPartyDeposits: SargonModel {}

--- a/apple/Sources/Sargon/Extensions/Swiftified/Profile/Factor/FactorSource/FactorSource+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Profile/Factor/FactorSource/FactorSource+Swiftified.swift
@@ -1,2 +1,1 @@
-extension FactorSource: @unchecked Sendable {}
 extension FactorSource: SargonModel {}

--- a/apple/Sources/Sargon/Extensions/Swiftified/Profile/Profile+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Profile/Profile+Swiftified.swift
@@ -1,4 +1,3 @@
-extension Profile: @unchecked Sendable {}
 extension Profile: SargonModel {}
 
 extension Profile: Identifiable {

--- a/apple/Sources/Sargon/Extensions/Swiftified/RET/Blob+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/RET/Blob+Swiftified.swift
@@ -1,4 +1,3 @@
-extension Blob: @unchecked Sendable {}
 extension Blob: SargonModel {}
 
 extension Blob: CustomStringConvertible {

--- a/apple/Sources/Sargon/Extensions/Swiftified/RET/Blobs+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/RET/Blobs+Swiftified.swift
@@ -1,4 +1,3 @@
-extension Blobs: @unchecked Sendable {}
 extension Blobs: SargonModel {}
 
 extension Blobs: ExpressibleByArrayLiteral {

--- a/apple/Sources/Sargon/Extensions/Swiftified/RET/IntentSignature+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/RET/IntentSignature+Swiftified.swift
@@ -1,2 +1,1 @@
-extension IntentSignature: @unchecked Sendable {}
 extension IntentSignature: SargonModel {}

--- a/apple/Sources/Sargon/Extensions/Swiftified/RET/SignedIntent+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/RET/SignedIntent+Swiftified.swift
@@ -1,3 +1,2 @@
-extension SignedIntent: @unchecked Sendable {}
 extension SignedIntent: SargonModel {}
 

--- a/apple/Sources/Sargon/Extensions/Swiftified/RET/TransactionManifest+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/RET/TransactionManifest+Swiftified.swift
@@ -1,4 +1,3 @@
-extension TransactionManifest: @unchecked Sendable {}
 extension TransactionManifest: SargonModel {}
 
 // MARK: Build Manifest

--- a/apple/Sources/Sargon/Extensions/Swiftified/Transaction/PerAssetTransfers+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Transaction/PerAssetTransfers+Swiftified.swift
@@ -1,2 +1,1 @@
-extension PerAssetTransfers: @unchecked Sendable {}
 extension PerAssetTransfers: SargonModel {}

--- a/apple/Sources/Sargon/Extensions/Swiftified/Transaction/StakeClaim+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Transaction/StakeClaim+Swiftified.swift
@@ -1,2 +1,1 @@
-extension StakeClaim: @unchecked Sendable {}
 extension StakeClaim: SargonModel {}

--- a/apple/Sources/Sargon/Extensions/Swiftified/Wallet+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Wallet+Swiftified.swift
@@ -1,1 +1,0 @@
-extension Wallet: @unchecked Sendable {}

--- a/uniffi.toml
+++ b/uniffi.toml
@@ -1,5 +1,6 @@
 [bindings.swift]
 module_name = "Sargon"
+experimental_sendable_value_types = true
 
 [bindings.kotlin]
 package_name = "com.radixdlt.sargon"


### PR DESCRIPTION
Use `experimental_sendable_value_types` (written by my, in PR https://github.com/mozilla/uniffi-rs/pull/2045 ), which marks structs and enum's `Sendable` inside Sargon (bindgen generated Swift file), so that we can drop LOTS of `@unchecked Sendable`.