### PR TITLE
Kotlin extensions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1989,6 +1989,7 @@ dependencies = [
  "radix-engine-toolkit",
  "radix-engine-toolkit-json",
  "rand 0.8.5",
+ "regex",
  "sbor",
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ url = { version = "2.5.0", features = ["serde"] }
 paste = "1.0.14"
 clap = { version = "4", default-features = false, features = ["std", "derive"] }
 camino = "1.0.8"
+regex = "1.9.3"
 
 [build-dependencies]
 uniffi = { version = "0.27.0", features = ["build"] }

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/CompiledNotarizedIntent.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/CompiledNotarizedIntent.kt
@@ -1,9 +1,14 @@
 package com.radixdlt.sargon.extensions
 
+import com.radixdlt.sargon.BagOfBytes
 import com.radixdlt.sargon.CompiledNotarizedIntent
+import com.radixdlt.sargon.compiledNotarizedIntentGetBytes
 import com.radixdlt.sargon.debugPrintCompiledNotarizedIntent
 import com.radixdlt.sargon.utils.KoverIgnore
 
 @KoverIgnore
 fun CompiledNotarizedIntent.debugPrint(): String =
     debugPrintCompiledNotarizedIntent(compiled = this)
+
+val CompiledNotarizedIntent.bytes: BagOfBytes
+    get() = compiledNotarizedIntentGetBytes(compiledNotarizedIntent = this)

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/Hash.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/Hash.kt
@@ -1,0 +1,11 @@
+package com.radixdlt.sargon.extensions
+
+import com.radixdlt.sargon.BagOfBytes
+import com.radixdlt.sargon.Hash
+import com.radixdlt.sargon.hashGetBytes
+
+val Hash.bytes: BagOfBytes
+    get() = hashGetBytes(hash = this)
+
+val Hash.hex: String
+    get() = bytes.hex

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/IntentHash.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/IntentHash.kt
@@ -1,0 +1,8 @@
+package com.radixdlt.sargon.extensions
+
+import com.radixdlt.sargon.IntentHash
+import com.radixdlt.sargon.newIntentHashFromString
+
+@Throws(SargonException::class)
+fun IntentHash.Companion.init(string: String) =
+    newIntentHashFromString(string = string)

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/IntentSignature.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/IntentSignature.kt
@@ -1,0 +1,12 @@
+package com.radixdlt.sargon.extensions
+
+import com.radixdlt.sargon.IntentSignature
+import com.radixdlt.sargon.SignatureWithPublicKey
+import com.radixdlt.sargon.intentSignatureGetSignatureWithPublicKey
+import com.radixdlt.sargon.newIntentSignatureFromSignatureWithPublicKey
+
+fun IntentSignature.Companion.init(signatureWithPublicKey: SignatureWithPublicKey) =
+    newIntentSignatureFromSignatureWithPublicKey(signatureWithPublicKey = signatureWithPublicKey)
+
+val IntentSignature.signatureWithPublicKey: SignatureWithPublicKey
+    get() = intentSignatureGetSignatureWithPublicKey(intentSignature = this)

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/NonFungibleGlobalId.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/NonFungibleGlobalId.kt
@@ -2,7 +2,11 @@ package com.radixdlt.sargon.extensions
 
 import com.radixdlt.sargon.NonFungibleGlobalId
 import com.radixdlt.sargon.newNonFungibleGlobalIdFromString
+import com.radixdlt.sargon.nonFungibleGlobalIdToString
 
 @Throws(SargonException::class)
 fun NonFungibleGlobalId.Companion.init(globalId: String) =
     newNonFungibleGlobalIdFromString(string = globalId)
+
+val NonFungibleGlobalId.string: String
+    get() = nonFungibleGlobalIdToString(globalId = this)

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/Nonce.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/Nonce.kt
@@ -1,0 +1,10 @@
+package com.radixdlt.sargon.extensions
+
+import com.radixdlt.sargon.Nonce
+import com.radixdlt.sargon.newNonceRandom
+import com.radixdlt.sargon.nonceGetValue
+
+fun Nonce.Companion.secureRandom(): Nonce = newNonceRandom()
+
+val Nonce.value: UInt
+    get() = nonceGetValue(nonce = this)

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/NotarizedTransaction.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/NotarizedTransaction.kt
@@ -1,0 +1,6 @@
+package com.radixdlt.sargon.extensions
+
+import com.radixdlt.sargon.NotarizedTransaction
+import com.radixdlt.sargon.notarizedTransactionCompile
+
+fun NotarizedTransaction.compile() = notarizedTransactionCompile(notarizedTransaction = this)

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/NotarySignature.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/NotarySignature.kt
@@ -1,0 +1,11 @@
+package com.radixdlt.sargon.extensions
+
+import com.radixdlt.sargon.NotarySignature
+import com.radixdlt.sargon.Signature
+import com.radixdlt.sargon.newNotarySignature
+import com.radixdlt.sargon.notarySignatureGetSignature
+
+fun NotarySignature.Companion.init(signature: Signature) = newNotarySignature(signature = signature)
+
+val NotarySignature.signature: Signature
+    get() = notarySignatureGetSignature(notarySignature = this)

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/Signature.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/Signature.kt
@@ -1,0 +1,67 @@
+package com.radixdlt.sargon.extensions
+
+import com.radixdlt.sargon.BagOfBytes
+import com.radixdlt.sargon.Ed25519Signature
+import com.radixdlt.sargon.Exactly64Bytes
+import com.radixdlt.sargon.Exactly65Bytes
+import com.radixdlt.sargon.Secp256k1Signature
+import com.radixdlt.sargon.Signature
+import com.radixdlt.sargon.ed25519SignatureToString
+import com.radixdlt.sargon.newEd25519PublicKeyFromBytes
+import com.radixdlt.sargon.newEd25519SignatureFromBytes
+import com.radixdlt.sargon.newEd25519SignatureFromExactly64Bytes
+import com.radixdlt.sargon.newSecp256k1SignatureFromBytes
+import com.radixdlt.sargon.newSecp256k1SignatureFromExactly65Bytes
+import com.radixdlt.sargon.newSignatureFromBytes
+import com.radixdlt.sargon.secp256k1SignatureToString
+import com.radixdlt.sargon.signatureToBytes
+import com.radixdlt.sargon.signatureToString
+
+@Throws(SargonException::class)
+fun Signature.Companion.init(bytes: BagOfBytes) = newSignatureFromBytes(bytes = bytes)
+
+val Signature.string: String
+    get() = signatureToString(signature = this)
+
+val Signature.bytes: BagOfBytes
+    get() = signatureToBytes(signature = this)
+
+@Throws(SargonException::class)
+fun Signature.Ed25519.Companion.init(bytes: BagOfBytes) = Signature.Ed25519(
+    value = newEd25519SignatureFromBytes(bytes = bytes)
+)
+
+fun Signature.Ed25519.Companion.init(exactly64Bytes: Exactly64Bytes) = Signature.Ed25519(
+    value = newEd25519SignatureFromExactly64Bytes(bytes = exactly64Bytes)
+)
+
+@Throws(SargonException::class)
+fun Signature.Secp256k1.Companion.init(bytes: BagOfBytes) = Signature.Secp256k1(
+    value = newSecp256k1SignatureFromBytes(bytes = bytes)
+)
+
+fun Signature.Secp256k1.Companion.init(exactly65Bytes: Exactly65Bytes) = Signature.Secp256k1(
+    value = newSecp256k1SignatureFromExactly65Bytes(bytes = exactly65Bytes)
+)
+
+@Throws(SargonException::class)
+fun Ed25519Signature.Companion.init(bytes: BagOfBytes) =
+    newEd25519SignatureFromBytes(bytes = bytes)
+
+fun Ed25519Signature.Companion.init(exactly64Bytes: Exactly64Bytes) =
+    newEd25519SignatureFromExactly64Bytes(bytes = exactly64Bytes)
+
+val Ed25519Signature.string: String
+    get() = ed25519SignatureToString(signature = this)
+
+@Throws(SargonException::class)
+fun Secp256k1Signature.Companion.init(bytes: BagOfBytes) =
+    newSecp256k1SignatureFromBytes(bytes = bytes)
+
+fun Secp256k1Signature.Companion.init(exactly65Bytes: Exactly65Bytes) =
+    newSecp256k1SignatureFromExactly65Bytes(bytes = exactly65Bytes)
+
+val Secp256k1Signature.string: String
+    get() = secp256k1SignatureToString(signature = this)
+
+

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/SignatureWithPublicKey.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/SignatureWithPublicKey.kt
@@ -1,0 +1,13 @@
+package com.radixdlt.sargon.extensions
+
+import com.radixdlt.sargon.PublicKey
+import com.radixdlt.sargon.Signature
+import com.radixdlt.sargon.SignatureWithPublicKey
+import com.radixdlt.sargon.signatureWithPublicKeyGetPublicKey
+import com.radixdlt.sargon.signatureWithPublicKeyGetSignature
+
+val SignatureWithPublicKey.signature: Signature
+    get() = signatureWithPublicKeyGetSignature(signatureWithPublicKey = this)
+
+val SignatureWithPublicKey.publicKey: PublicKey
+    get() = signatureWithPublicKeyGetPublicKey(signatureWithPublicKey = this)

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/SignedIntent.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/SignedIntent.kt
@@ -1,0 +1,7 @@
+package com.radixdlt.sargon.extensions
+
+import com.radixdlt.sargon.SignedIntent
+import com.radixdlt.sargon.SignedIntentHash
+import com.radixdlt.sargon.signedIntentHash
+
+fun SignedIntent.hash(): SignedIntentHash = signedIntentHash(signedIntent = this)

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/SignedIntentHash.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/SignedIntentHash.kt
@@ -1,0 +1,8 @@
+package com.radixdlt.sargon.extensions
+
+import com.radixdlt.sargon.SignedIntentHash
+import com.radixdlt.sargon.newSignedIntentHashFromString
+
+@Throws(SargonException::class)
+fun SignedIntentHash.Companion.init(string: String) =
+    newSignedIntentHashFromString(string = string)

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/TransactionIntent.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/TransactionIntent.kt
@@ -1,0 +1,11 @@
+package com.radixdlt.sargon.extensions
+
+import com.radixdlt.sargon.BagOfBytes
+import com.radixdlt.sargon.IntentHash
+import com.radixdlt.sargon.TransactionIntent
+import com.radixdlt.sargon.transactionIntentCompile
+import com.radixdlt.sargon.transactionIntentHash
+
+fun TransactionIntent.hash(): IntentHash = transactionIntentHash(intent = this)
+
+fun TransactionIntent.compile(): BagOfBytes = transactionIntentCompile(intent = this)

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/TransactionManifest.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/TransactionManifest.kt
@@ -2,12 +2,16 @@ package com.radixdlt.sargon.extensions
 
 import com.radixdlt.sargon.AccountAddress
 import com.radixdlt.sargon.AddressOfAccountOrPersona
+import com.radixdlt.sargon.BagOfBytes
 import com.radixdlt.sargon.Blobs
 import com.radixdlt.sargon.Decimal192
+import com.radixdlt.sargon.ManifestSummary
 import com.radixdlt.sargon.NetworkId
 import com.radixdlt.sargon.PerAssetTransfers
 import com.radixdlt.sargon.PerRecipientAssetTransfers
+import com.radixdlt.sargon.PoolAddress
 import com.radixdlt.sargon.PublicKeyHash
+import com.radixdlt.sargon.ResourceAddress
 import com.radixdlt.sargon.StakeClaim
 import com.radixdlt.sargon.ThirdPartyDeposits
 import com.radixdlt.sargon.TokenDefinitionMetadata
@@ -29,8 +33,12 @@ import com.radixdlt.sargon.modifyManifestAddGuarantees
 import com.radixdlt.sargon.modifyManifestLockFee
 import com.radixdlt.sargon.newTransactionManifestFromInstructionsStringAndBlobs
 import com.radixdlt.sargon.transactionManifestBlobs
+import com.radixdlt.sargon.transactionManifestExecutionSummary
 import com.radixdlt.sargon.transactionManifestInstructionsString
+import com.radixdlt.sargon.transactionManifestInvolvedPoolAddresses
+import com.radixdlt.sargon.transactionManifestInvolvedResourceAddresses
 import com.radixdlt.sargon.transactionManifestNetworkId
+import com.radixdlt.sargon.transactionManifestSummary
 import com.radixdlt.sargon.utils.KoverIgnore
 
 @Throws(SargonException::class)
@@ -155,3 +163,16 @@ val TransactionManifest.networkId: NetworkId
 
 val TransactionManifest.blobs: Blobs
     get() = transactionManifestBlobs(manifest = this)
+
+val TransactionManifest.involvedPoolAddresses: List<PoolAddress>
+    get() = transactionManifestInvolvedPoolAddresses(manifest = this)
+
+val TransactionManifest.involvedResourceAddresses: List<ResourceAddress>
+    get() = transactionManifestInvolvedResourceAddresses(manifest = this)
+
+val TransactionManifest.summary: ManifestSummary
+    get() = transactionManifestSummary(manifest = this)
+
+@Throws(SargonException::class)
+fun TransactionManifest.executionSummary(encodedReceipt: BagOfBytes) =
+    transactionManifestExecutionSummary(manifest = this, encodedReceipt = encodedReceipt)

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/BuildInformationSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/BuildInformationSample.kt
@@ -1,0 +1,22 @@
+package com.radixdlt.sargon.samples
+
+import androidx.annotation.VisibleForTesting
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import com.radixdlt.sargon.SargonBuildInformation
+import com.radixdlt.sargon.newSargonBuildInformationSample
+import com.radixdlt.sargon.newSargonBuildInformationSampleOther
+
+@VisibleForTesting
+val SargonBuildInformation.Companion.sample: Sample<SargonBuildInformation>
+    get() = object : Sample<SargonBuildInformation> {
+
+        override fun invoke(): SargonBuildInformation = newSargonBuildInformationSample()
+
+        override fun other(): SargonBuildInformation = newSargonBuildInformationSampleOther()
+    }
+
+class SargonBuildInformationPreviewParameterProvider: PreviewParameterProvider<SargonBuildInformation> {
+    override val values: Sequence<SargonBuildInformation>
+        get() = SargonBuildInformation.sample.all.asSequence()
+
+}

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/CompiledNotarizedIntentSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/CompiledNotarizedIntentSample.kt
@@ -1,0 +1,25 @@
+package com.radixdlt.sargon.samples
+
+import androidx.annotation.VisibleForTesting
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import com.radixdlt.sargon.CompiledNotarizedIntent
+import com.radixdlt.sargon.SargonBuildInformation
+import com.radixdlt.sargon.newCompiledNotarizedIntentSample
+import com.radixdlt.sargon.newCompiledNotarizedIntentSampleOther
+import com.radixdlt.sargon.newSargonBuildInformationSample
+import com.radixdlt.sargon.newSargonBuildInformationSampleOther
+
+@VisibleForTesting
+val CompiledNotarizedIntent.Companion.sample: Sample<CompiledNotarizedIntent>
+    get() = object : Sample<CompiledNotarizedIntent> {
+
+        override fun invoke(): CompiledNotarizedIntent = newCompiledNotarizedIntentSample()
+
+        override fun other(): CompiledNotarizedIntent = newCompiledNotarizedIntentSampleOther()
+    }
+
+class CompiledNotarizedIntentPreviewParameterProvider: PreviewParameterProvider<CompiledNotarizedIntent> {
+    override val values: Sequence<CompiledNotarizedIntent>
+        get() = CompiledNotarizedIntent.sample.all.asSequence()
+
+}

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/HashSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/HashSample.kt
@@ -1,0 +1,28 @@
+package com.radixdlt.sargon.samples
+
+import androidx.annotation.VisibleForTesting
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import com.radixdlt.sargon.Hash
+import com.radixdlt.sargon.IntentSignature
+import com.radixdlt.sargon.SargonBuildInformation
+import com.radixdlt.sargon.newHashSample
+import com.radixdlt.sargon.newHashSampleOther
+import com.radixdlt.sargon.newIntentSignatureSample
+import com.radixdlt.sargon.newIntentSignatureSampleOther
+import com.radixdlt.sargon.newSargonBuildInformationSample
+import com.radixdlt.sargon.newSargonBuildInformationSampleOther
+
+@VisibleForTesting
+val Hash.Companion.sample: Sample<Hash>
+    get() = object : Sample<Hash> {
+
+        override fun invoke(): Hash = newHashSample()
+
+        override fun other(): Hash = newHashSampleOther()
+    }
+
+class HashPreviewParameterProvider: PreviewParameterProvider<Hash> {
+    override val values: Sequence<Hash>
+        get() = Hash.sample.all.asSequence()
+
+}

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/IntentHashSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/IntentHashSample.kt
@@ -1,0 +1,22 @@
+package com.radixdlt.sargon.samples
+
+import androidx.annotation.VisibleForTesting
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import com.radixdlt.sargon.IntentHash
+import com.radixdlt.sargon.newIntentHashSample
+import com.radixdlt.sargon.newIntentHashSampleOther
+
+@VisibleForTesting
+val IntentHash.Companion.sample: Sample<IntentHash>
+    get() = object : Sample<IntentHash> {
+
+        override fun invoke(): IntentHash = newIntentHashSample()
+
+        override fun other(): IntentHash = newIntentHashSampleOther()
+    }
+
+class IntentHashPreviewParameterProvider: PreviewParameterProvider<IntentHash> {
+    override val values: Sequence<IntentHash>
+        get() = IntentHash.sample.all.asSequence()
+
+}

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/IntentSignatureSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/IntentSignatureSample.kt
@@ -1,0 +1,25 @@
+package com.radixdlt.sargon.samples
+
+import androidx.annotation.VisibleForTesting
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import com.radixdlt.sargon.IntentSignature
+import com.radixdlt.sargon.SargonBuildInformation
+import com.radixdlt.sargon.newIntentSignatureSample
+import com.radixdlt.sargon.newIntentSignatureSampleOther
+import com.radixdlt.sargon.newSargonBuildInformationSample
+import com.radixdlt.sargon.newSargonBuildInformationSampleOther
+
+@VisibleForTesting
+val IntentSignature.Companion.sample: Sample<IntentSignature>
+    get() = object : Sample<IntentSignature> {
+
+        override fun invoke(): IntentSignature = newIntentSignatureSample()
+
+        override fun other(): IntentSignature = newIntentSignatureSampleOther()
+    }
+
+class IntentSignaturePreviewParameterProvider: PreviewParameterProvider<IntentSignature> {
+    override val values: Sequence<IntentSignature>
+        get() = IntentSignature.sample.all.asSequence()
+
+}

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/NonceSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/NonceSample.kt
@@ -1,0 +1,29 @@
+package com.radixdlt.sargon.samples
+
+import androidx.annotation.VisibleForTesting
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import com.radixdlt.sargon.IntentSignature
+import com.radixdlt.sargon.Nonce
+import com.radixdlt.sargon.SargonBuildInformation
+import com.radixdlt.sargon.newIntentSignatureSample
+import com.radixdlt.sargon.newIntentSignatureSampleOther
+import com.radixdlt.sargon.newNonceRandom
+import com.radixdlt.sargon.newNonceSample
+import com.radixdlt.sargon.newNonceSampleOther
+import com.radixdlt.sargon.newSargonBuildInformationSample
+import com.radixdlt.sargon.newSargonBuildInformationSampleOther
+
+@VisibleForTesting
+val Nonce.Companion.sample: Sample<Nonce>
+    get() = object : Sample<Nonce> {
+
+        override fun invoke(): Nonce = newNonceSample()
+
+        override fun other(): Nonce = newNonceSampleOther()
+    }
+
+class NoncePreviewParameterProvider: PreviewParameterProvider<Nonce> {
+    override val values: Sequence<Nonce>
+        get() = Nonce.sample.all.asSequence()
+
+}

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/NotarizedTransactionSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/NotarizedTransactionSample.kt
@@ -1,0 +1,28 @@
+package com.radixdlt.sargon.samples
+
+import androidx.annotation.VisibleForTesting
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import com.radixdlt.sargon.CompiledNotarizedIntent
+import com.radixdlt.sargon.NotarizedTransaction
+import com.radixdlt.sargon.SargonBuildInformation
+import com.radixdlt.sargon.newCompiledNotarizedIntentSample
+import com.radixdlt.sargon.newCompiledNotarizedIntentSampleOther
+import com.radixdlt.sargon.newNotarizedTransactionSample
+import com.radixdlt.sargon.newNotarizedTransactionSampleOther
+import com.radixdlt.sargon.newSargonBuildInformationSample
+import com.radixdlt.sargon.newSargonBuildInformationSampleOther
+
+@VisibleForTesting
+val NotarizedTransaction.Companion.sample: Sample<NotarizedTransaction>
+    get() = object : Sample<NotarizedTransaction> {
+
+        override fun invoke(): NotarizedTransaction = newNotarizedTransactionSample()
+
+        override fun other(): NotarizedTransaction = newNotarizedTransactionSampleOther()
+    }
+
+class NotarizedTransactionPreviewParameterProvider: PreviewParameterProvider<NotarizedTransaction> {
+    override val values: Sequence<NotarizedTransaction>
+        get() = NotarizedTransaction.sample.all.asSequence()
+
+}

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/NotarySignatureSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/NotarySignatureSample.kt
@@ -1,0 +1,28 @@
+package com.radixdlt.sargon.samples
+
+import androidx.annotation.VisibleForTesting
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import com.radixdlt.sargon.CompiledNotarizedIntent
+import com.radixdlt.sargon.NotarySignature
+import com.radixdlt.sargon.SargonBuildInformation
+import com.radixdlt.sargon.newCompiledNotarizedIntentSample
+import com.radixdlt.sargon.newCompiledNotarizedIntentSampleOther
+import com.radixdlt.sargon.newNotarySignatureSample
+import com.radixdlt.sargon.newNotarySignatureSampleOther
+import com.radixdlt.sargon.newSargonBuildInformationSample
+import com.radixdlt.sargon.newSargonBuildInformationSampleOther
+
+@VisibleForTesting
+val NotarySignature.Companion.sample: Sample<NotarySignature>
+    get() = object : Sample<NotarySignature> {
+
+        override fun invoke(): NotarySignature = newNotarySignatureSample()
+
+        override fun other(): NotarySignature = newNotarySignatureSampleOther()
+    }
+
+class NotarySignaturePreviewParameterProvider: PreviewParameterProvider<NotarySignature> {
+    override val values: Sequence<NotarySignature>
+        get() = NotarySignature.sample.all.asSequence()
+
+}

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/SignatureSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/SignatureSample.kt
@@ -1,0 +1,58 @@
+package com.radixdlt.sargon.samples
+
+import androidx.annotation.VisibleForTesting
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import com.radixdlt.sargon.Ed25519Signature
+import com.radixdlt.sargon.Secp256k1Signature
+import com.radixdlt.sargon.Signature
+import com.radixdlt.sargon.newEd25519SignatureSample
+import com.radixdlt.sargon.newEd25519SignatureSampleOther
+import com.radixdlt.sargon.newSecp256k1SignatureSample
+import com.radixdlt.sargon.newSecp256k1SignatureSampleOther
+import com.radixdlt.sargon.newSignatureSample
+import com.radixdlt.sargon.newSignatureSampleOther
+
+@VisibleForTesting
+val Signature.Companion.sample: Sample<Signature>
+    get() = object : Sample<Signature> {
+        override fun invoke(): Signature = newSignatureSample()
+
+        override fun other(): Signature = newSignatureSampleOther()
+    }
+
+class SignaturePreviewParameterProvider:
+    PreviewParameterProvider<Signature> {
+    override val values: Sequence<Signature>
+        get() = Signature.sample.all.asSequence()
+
+}
+
+@VisibleForTesting
+val Ed25519Signature.Companion.sample: Sample<Ed25519Signature>
+    get() = object : Sample<Ed25519Signature> {
+        override fun invoke(): Ed25519Signature = newEd25519SignatureSample()
+
+        override fun other(): Ed25519Signature = newEd25519SignatureSampleOther()
+    }
+
+class Ed25519SignaturePreviewParameterProvider:
+    PreviewParameterProvider<Ed25519Signature> {
+    override val values: Sequence<Ed25519Signature>
+        get() = Ed25519Signature.sample.all.asSequence()
+
+}
+
+@VisibleForTesting
+val Secp256k1Signature.Companion.sample: Sample<Secp256k1Signature>
+    get() = object : Sample<Secp256k1Signature> {
+        override fun invoke(): Secp256k1Signature = newSecp256k1SignatureSample()
+
+        override fun other(): Secp256k1Signature = newSecp256k1SignatureSampleOther()
+    }
+
+class Secp256k1SignaturePreviewParameterProvider:
+    PreviewParameterProvider<Secp256k1Signature> {
+    override val values: Sequence<Secp256k1Signature>
+        get() = Secp256k1Signature.sample.all.asSequence()
+
+}

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/SignatureWithPublicKeySample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/SignatureWithPublicKeySample.kt
@@ -1,0 +1,23 @@
+package com.radixdlt.sargon.samples
+
+import androidx.annotation.VisibleForTesting
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import com.radixdlt.sargon.SignatureWithPublicKey
+import com.radixdlt.sargon.newSignatureWithPublicKeySample
+import com.radixdlt.sargon.newSignatureWithPublicKeySampleOther
+
+@VisibleForTesting
+val SignatureWithPublicKey.Companion.sample: Sample<SignatureWithPublicKey>
+    get() = object : Sample<SignatureWithPublicKey> {
+
+        override fun invoke(): SignatureWithPublicKey = newSignatureWithPublicKeySample()
+
+        override fun other(): SignatureWithPublicKey = newSignatureWithPublicKeySampleOther()
+    }
+
+class SignatureWithPublicKeyPreviewParameterProvider:
+    PreviewParameterProvider<SignatureWithPublicKey> {
+    override val values: Sequence<SignatureWithPublicKey>
+        get() = SignatureWithPublicKey.sample.all.asSequence()
+
+}

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/SignedIntentHashSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/SignedIntentHashSample.kt
@@ -1,0 +1,34 @@
+package com.radixdlt.sargon.samples
+
+import androidx.annotation.VisibleForTesting
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import com.radixdlt.sargon.Hash
+import com.radixdlt.sargon.IntentHash
+import com.radixdlt.sargon.IntentSignature
+import com.radixdlt.sargon.SargonBuildInformation
+import com.radixdlt.sargon.SignedIntentHash
+import com.radixdlt.sargon.newHashSample
+import com.radixdlt.sargon.newHashSampleOther
+import com.radixdlt.sargon.newIntentHashSample
+import com.radixdlt.sargon.newIntentHashSampleOther
+import com.radixdlt.sargon.newIntentSignatureSample
+import com.radixdlt.sargon.newIntentSignatureSampleOther
+import com.radixdlt.sargon.newSargonBuildInformationSample
+import com.radixdlt.sargon.newSargonBuildInformationSampleOther
+import com.radixdlt.sargon.newSignedIntentHashSample
+import com.radixdlt.sargon.newSignedIntentHashSampleOther
+
+@VisibleForTesting
+val SignedIntentHash.Companion.sample: Sample<SignedIntentHash>
+    get() = object : Sample<SignedIntentHash> {
+
+        override fun invoke(): SignedIntentHash = newSignedIntentHashSample()
+
+        override fun other(): SignedIntentHash = newSignedIntentHashSampleOther()
+    }
+
+class SignedIntentHashPreviewParameterProvider: PreviewParameterProvider<SignedIntentHash> {
+    override val values: Sequence<SignedIntentHash>
+        get() = SignedIntentHash.sample.all.asSequence()
+
+}

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/SignedIntentSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/SignedIntentSample.kt
@@ -1,0 +1,34 @@
+package com.radixdlt.sargon.samples
+
+import androidx.annotation.VisibleForTesting
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import com.radixdlt.sargon.Hash
+import com.radixdlt.sargon.IntentHash
+import com.radixdlt.sargon.IntentSignature
+import com.radixdlt.sargon.SargonBuildInformation
+import com.radixdlt.sargon.SignedIntent
+import com.radixdlt.sargon.newHashSample
+import com.radixdlt.sargon.newHashSampleOther
+import com.radixdlt.sargon.newIntentHashSample
+import com.radixdlt.sargon.newIntentHashSampleOther
+import com.radixdlt.sargon.newIntentSignatureSample
+import com.radixdlt.sargon.newIntentSignatureSampleOther
+import com.radixdlt.sargon.newSargonBuildInformationSample
+import com.radixdlt.sargon.newSargonBuildInformationSampleOther
+import com.radixdlt.sargon.newSignedIntentSample
+import com.radixdlt.sargon.newSignedIntentSampleOther
+
+@VisibleForTesting
+val SignedIntent.Companion.sample: Sample<SignedIntent>
+    get() = object : Sample<SignedIntent> {
+
+        override fun invoke(): SignedIntent = newSignedIntentSample()
+
+        override fun other(): SignedIntent = newSignedIntentSampleOther()
+    }
+
+class SignedIntentPreviewParameterProvider: PreviewParameterProvider<SignedIntent> {
+    override val values: Sequence<SignedIntent>
+        get() = SignedIntent.sample.all.asSequence()
+
+}

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/TransactionIntentSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/TransactionIntentSample.kt
@@ -1,0 +1,28 @@
+package com.radixdlt.sargon.samples
+
+import androidx.annotation.VisibleForTesting
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import com.radixdlt.sargon.CompiledNotarizedIntent
+import com.radixdlt.sargon.SargonBuildInformation
+import com.radixdlt.sargon.TransactionIntent
+import com.radixdlt.sargon.newCompiledNotarizedIntentSample
+import com.radixdlt.sargon.newCompiledNotarizedIntentSampleOther
+import com.radixdlt.sargon.newSargonBuildInformationSample
+import com.radixdlt.sargon.newSargonBuildInformationSampleOther
+import com.radixdlt.sargon.newTransactionIntentSample
+import com.radixdlt.sargon.newTransactionIntentSampleOther
+
+@VisibleForTesting
+val TransactionIntent.Companion.sample: Sample<TransactionIntent>
+    get() = object : Sample<TransactionIntent> {
+
+        override fun invoke(): TransactionIntent = newTransactionIntentSample()
+
+        override fun other(): TransactionIntent = newTransactionIntentSampleOther()
+    }
+
+class TransactionIntentPreviewParameterProvider: PreviewParameterProvider<TransactionIntent> {
+    override val values: Sequence<TransactionIntent>
+        get() = TransactionIntent.sample.all.asSequence()
+
+}

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/BagOfBytesTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/BagOfBytesTest.kt
@@ -24,6 +24,7 @@ import java.lang.IllegalStateException
 
 class BagOfBytesTest {
 
+    @OptIn(ExperimentalUnsignedTypes::class)
     @Test
     fun test() {
         var a = ubyteArrayOf().toList()

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/CompiledNotarizedIntentTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/CompiledNotarizedIntentTest.kt
@@ -1,0 +1,26 @@
+package com.radixdlt.sargon
+
+import com.radixdlt.sargon.extensions.bytes
+import com.radixdlt.sargon.extensions.hex
+import com.radixdlt.sargon.extensions.init
+import com.radixdlt.sargon.samples.Sample
+import com.radixdlt.sargon.samples.sample
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class CompiledNotarizedIntentTest: SampleTestable<CompiledNotarizedIntent> {
+    override val samples: List<Sample<CompiledNotarizedIntent>>
+        get() = listOf(CompiledNotarizedIntent.sample)
+
+    @Test
+    fun testGetData() {
+        assertEquals(
+            "4d22030221022104210707f20a00000000000000000a0a00000000000000090a0000002200012" +
+                    "007210279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f817980101080" +
+                    "000202200202000220000202200220001210120074101ebfc1f10a3b6ed83531f16249477ab86b7" +
+                    "7ce85980ef330abafbbd758caa98c665f68b8536112b6d1519feddeea01fd8429124dd75121d4bd" +
+                    "88c14a27b68a123",
+            CompiledNotarizedIntent.sample.other().bytes.hex
+        )
+    }
+}

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/Ed25519SignatureTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/Ed25519SignatureTest.kt
@@ -1,0 +1,38 @@
+package com.radixdlt.sargon
+
+import com.radixdlt.sargon.extensions.bytes
+import com.radixdlt.sargon.extensions.init
+import com.radixdlt.sargon.extensions.string
+import com.radixdlt.sargon.samples.Sample
+import com.radixdlt.sargon.samples.sample
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class Ed25519SignatureTest: SampleTestable<Ed25519Signature> {
+    override val samples: List<Sample<Ed25519Signature>>
+        get() = listOf(Ed25519Signature.sample)
+
+    @Test
+    fun testFromExactly64Bytes() {
+        assertEquals(
+            Ed25519Signature.sample(),
+            Ed25519Signature.init(Ed25519Signature.sample().bytes)
+        )
+    }
+
+    @Test
+    fun testFromBytes() {
+        assertEquals(
+            Ed25519Signature.sample(),
+            Ed25519Signature.init(Ed25519Signature.sample().bytes.bytes)
+        )
+    }
+
+    @Test
+    fun testString() {
+        assertEquals(
+            Ed25519Signature.sample().string,
+            Ed25519Signature.init(Ed25519Signature.sample().bytes).string
+        )
+    }
+}

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/HashTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/HashTest.kt
@@ -1,0 +1,24 @@
+package com.radixdlt.sargon
+
+import com.radixdlt.sargon.extensions.hex
+import com.radixdlt.sargon.samples.Sample
+import com.radixdlt.sargon.samples.sample
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class HashTest: SampleTestable<Hash> {
+
+    override val samples: List<Sample<Hash>>
+        get() = listOf(Hash.sample)
+
+    @Test
+    fun test() {
+        val hash = Hash.sample()
+
+        assertEquals(
+            "48f1bd08444b5e713db9e14caac2faae71836786ac94d645b00679728202a935",
+            hash.hex
+        )
+    }
+
+}

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/IntentHashTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/IntentHashTest.kt
@@ -1,0 +1,33 @@
+package com.radixdlt.sargon
+
+import com.radixdlt.sargon.extensions.init
+import com.radixdlt.sargon.samples.Sample
+import com.radixdlt.sargon.samples.sample
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class IntentHashTest: SampleTestable<IntentHash> {
+    override val samples: List<Sample<IntentHash>>
+        get() = listOf(IntentHash.sample)
+
+    @Test
+    fun testNetworkId() {
+        assertEquals(
+            NetworkId.MAINNET,
+            IntentHash.sample().networkId
+        )
+        assertEquals(
+            NetworkId.SIMULATOR,
+            IntentHash.sample.other().networkId
+        )
+    }
+
+    @Test
+    fun testStringRoundtrip() {
+        val txId = "txid_rdx1frcm6zzyfd08z0deu9x24sh64eccxeux4j2dv3dsqeuh9qsz4y6szm3ltd"
+        assertEquals(
+            txId,
+            IntentHash.init(txId).bech32EncodedTxId
+        )
+    }
+}

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/IntentSignatureTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/IntentSignatureTest.kt
@@ -1,0 +1,23 @@
+package com.radixdlt.sargon
+
+import com.radixdlt.sargon.extensions.init
+import com.radixdlt.sargon.extensions.signatureWithPublicKey
+import com.radixdlt.sargon.samples.Sample
+import com.radixdlt.sargon.samples.sample
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class IntentSignatureTest: SampleTestable<IntentSignature> {
+    override val samples: List<Sample<IntentSignature>>
+        get() = listOf(IntentSignature.sample)
+
+    @Test
+    fun test_get_signature_with_public_key() {
+        val signature = SignatureWithPublicKey.sample()
+        assertEquals(
+            signature,
+            IntentSignature.init(signatureWithPublicKey = signature).signatureWithPublicKey
+        )
+    }
+
+}

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/NonFungibleGlobalIdTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/NonFungibleGlobalIdTest.kt
@@ -2,6 +2,7 @@ package com.radixdlt.sargon
 
 import com.radixdlt.sargon.extensions.init
 import com.radixdlt.sargon.extensions.string
+import com.radixdlt.sargon.samples.sample
 import com.radixdlt.sargon.samples.sampleMainnet
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -22,6 +23,14 @@ class NonFungibleGlobalIdTest {
             NonFungibleGlobalId.init(
                 "${NonFungibleResourceAddress.sampleMainnet().string}:#1#"
             )
+        )
+    }
+
+    @Test
+    fun testRoundtrip() {
+        assertEquals(
+            NonFungibleGlobalId.sample(),
+            NonFungibleGlobalId.init(globalId = NonFungibleGlobalId.sample().string)
         )
     }
 

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/NonceTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/NonceTest.kt
@@ -1,0 +1,24 @@
+package com.radixdlt.sargon
+
+import com.radixdlt.sargon.extensions.secureRandom
+import com.radixdlt.sargon.extensions.value
+import com.radixdlt.sargon.samples.Sample
+import com.radixdlt.sargon.samples.sample
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class NonceTest: SampleTestable<Nonce> {
+    override val samples: List<Sample<Nonce>>
+        get() = listOf(Nonce.sample)
+
+    @Test
+    fun test_secure_random() {
+        val n = 10
+        val nonceSet = List(n) {
+            Nonce.secureRandom()
+        }.toSet()
+
+        assertEquals(n, nonceSet.size)
+        assertEquals(n, nonceSet.map { it.value }.size)
+    }
+}

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/NotarizedTransactionTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/NotarizedTransactionTest.kt
@@ -1,0 +1,35 @@
+package com.radixdlt.sargon
+
+import com.radixdlt.sargon.extensions.bytes
+import com.radixdlt.sargon.extensions.compile
+import com.radixdlt.sargon.extensions.hex
+import com.radixdlt.sargon.extensions.init
+import com.radixdlt.sargon.samples.Sample
+import com.radixdlt.sargon.samples.sample
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class NotarizedTransactionTest: SampleTestable<NotarizedTransaction> {
+    override val samples: List<Sample<NotarizedTransaction>>
+        get() = listOf(NotarizedTransaction.sample)
+
+    @Test
+    fun testGetData() {
+        assertEquals(
+            "4d22030221022104210707010a872c0100000000000a912c01000000000009092f24002201012" +
+                    "00720ec172b93ad5e563bf4932c70e1245034c35467ef2efd4d64ebf819683467e2bf010108000" +
+                    "020220441038000d1be9c042f627d98a01383987916d43cf439631ca1d8c8076d6754ab263d0c0" +
+                    "86c6f636b5f6665652101850000fda0c4277708000000000000000000000000000000004103800" +
+                    "0d1be9c042f627d98a01383987916d43cf439631ca1d8c8076d6754ab263d0c087769746864726" +
+                    "177210280005da66318c6318c61f5a61b4c6318c6318cf794aa8d295f14e6318c6318c68500004" +
+                    "43945309a7a48000000000000000000000000000000000280005da66318c6318c61f5a61b4c631" +
+                    "8c6318cf794aa8d295f14e6318c6318c6850000443945309a7a480000000000000000000000000" +
+                    "0000041038000d1127918c16af09af521951adcf3a20ab2cc87c0e72e85814764853ce5e70c147" +
+                    "472795f6465706f7369745f6f725f61626f72742102810000000022000020200022010121020c0" +
+                    "a746578742f706c61696e2200010c0c48656c6c6f2052616469782120220022010121012007408" +
+                    "39ac9c47db45950fc0cd453c5ebbbfa7ae5f7c20753abe2370b5b40fdee89e522c4d810d060e0c" +
+                    "56211d036043fd32b9908e97bf114c1835ca02d74018fdd09",
+            NotarizedTransaction.sample().compile().bytes.hex
+        )
+    }
+}

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/NotarySignatureTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/NotarySignatureTest.kt
@@ -1,0 +1,21 @@
+package com.radixdlt.sargon
+
+import com.radixdlt.sargon.extensions.init
+import com.radixdlt.sargon.extensions.signature
+import com.radixdlt.sargon.samples.Sample
+import com.radixdlt.sargon.samples.sample
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class NotarySignatureTest: SampleTestable<NotarySignature> {
+    override val samples: List<Sample<NotarySignature>>
+        get() = listOf(NotarySignature.sample)
+
+    @Test
+    fun testSignatureRoundtrip() {
+        assertEquals(
+            NotarySignature.sample(),
+            NotarySignature.init(NotarySignature.sample().signature)
+        )
+    }
+}

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/Secp256k1SignatureTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/Secp256k1SignatureTest.kt
@@ -1,0 +1,38 @@
+package com.radixdlt.sargon
+
+import com.radixdlt.sargon.extensions.bytes
+import com.radixdlt.sargon.extensions.init
+import com.radixdlt.sargon.extensions.string
+import com.radixdlt.sargon.samples.Sample
+import com.radixdlt.sargon.samples.sample
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class Secp256k1SignatureTest: SampleTestable<Secp256k1Signature> {
+    override val samples: List<Sample<Secp256k1Signature>>
+        get() = listOf(Secp256k1Signature.sample)
+
+    @Test
+    fun testFromExactly64Bytes() {
+        assertEquals(
+            Secp256k1Signature.sample(),
+            Secp256k1Signature.init(Secp256k1Signature.sample().bytes)
+        )
+    }
+
+    @Test
+    fun testFromBytes() {
+        assertEquals(
+            Secp256k1Signature.sample(),
+            Secp256k1Signature.init(Secp256k1Signature.sample().bytes.bytes)
+        )
+    }
+
+    @Test
+    fun testString() {
+        assertEquals(
+            Secp256k1Signature.sample().string,
+            Secp256k1Signature.init(Secp256k1Signature.sample().bytes).string
+        )
+    }
+}

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/SignatureTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/SignatureTest.kt
@@ -1,0 +1,58 @@
+package com.radixdlt.sargon
+
+import com.radixdlt.sargon.extensions.bytes
+import com.radixdlt.sargon.extensions.init
+import com.radixdlt.sargon.extensions.string
+import com.radixdlt.sargon.samples.Sample
+import com.radixdlt.sargon.samples.sample
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class SignatureTest: SampleTestable<Signature> {
+    override val samples: List<Sample<Signature>>
+        get() = listOf(Signature.sample)
+
+    @Test
+    fun testFromExactly64Bytes() {
+        assertEquals(
+            Signature.sample(),
+            Signature.init(Signature.sample().bytes)
+        )
+
+        assertEquals(
+            Signature.sample(),
+            Signature.Ed25519.init(Ed25519Signature.sample().bytes)
+        )
+
+        assertEquals(
+            Signature.sample(),
+            Signature.Ed25519.init(Ed25519Signature.sample().bytes.bytes)
+        )
+
+        assertEquals(
+            Signature.sample.other(),
+            Signature.Secp256k1.init(Secp256k1Signature.sample().bytes)
+        )
+
+        assertEquals(
+            Signature.sample.other(),
+            Signature.Secp256k1.init(Secp256k1Signature.sample().bytes.bytes)
+        )
+    }
+
+    @Test
+    fun testFromBytes() {
+        assertEquals(
+            Signature.sample(),
+            Signature.init(Signature.sample().bytes)
+        )
+    }
+
+    @Test
+    fun testString() {
+        assertEquals(
+            Signature.sample.other().string,
+            Signature.init(Signature.sample.other().bytes).string
+        )
+    }
+}

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/SignatureWithPublicKeyTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/SignatureWithPublicKeyTest.kt
@@ -1,0 +1,26 @@
+package com.radixdlt.sargon
+
+import com.radixdlt.sargon.extensions.publicKey
+import com.radixdlt.sargon.extensions.signature
+import com.radixdlt.sargon.samples.Sample
+import com.radixdlt.sargon.samples.sample
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class SignatureWithPublicKeyTest: SampleTestable<SignatureWithPublicKey> {
+    override val samples: List<Sample<SignatureWithPublicKey>>
+        get() = listOf(SignatureWithPublicKey.sample)
+
+    @Test
+    fun testSignatureRoundtrip() {
+        Assertions.assertEquals(
+            SignatureWithPublicKey.sample(),
+            with(SignatureWithPublicKey.sample()) {
+                SignatureWithPublicKey.Ed25519(
+                    publicKey = (publicKey as PublicKey.Ed25519).value,
+                    signature = (signature as Signature.Ed25519).value
+                )
+            }
+        )
+    }
+}

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/SignedIntentHashTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/SignedIntentHashTest.kt
@@ -1,0 +1,33 @@
+package com.radixdlt.sargon
+
+import com.radixdlt.sargon.extensions.init
+import com.radixdlt.sargon.samples.Sample
+import com.radixdlt.sargon.samples.sample
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class SignedIntentHashTest: SampleTestable<SignedIntentHash> {
+    override val samples: List<Sample<SignedIntentHash>>
+        get() = listOf(SignedIntentHash.sample)
+
+    @Test
+    fun testNetworkId() {
+        Assertions.assertEquals(
+            NetworkId.MAINNET,
+            SignedIntentHash.sample().networkId
+        )
+        Assertions.assertEquals(
+            NetworkId.SIMULATOR,
+            SignedIntentHash.sample.other().networkId
+        )
+    }
+
+    @Test
+    fun testStringRoundtrip() {
+        val s = "signedintent_rdx1frcm6zzyfd08z0deu9x24sh64eccxeux4j2dv3dsqeuh9qsz4y6sxsk6nl"
+        Assertions.assertEquals(
+            s,
+            SignedIntentHash.init(s).bech32EncodedTxId
+        )
+    }
+}

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/SignedIntentTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/SignedIntentTest.kt
@@ -1,0 +1,22 @@
+package com.radixdlt.sargon
+
+import com.radixdlt.sargon.extensions.hash
+import com.radixdlt.sargon.extensions.init
+import com.radixdlt.sargon.samples.Sample
+import com.radixdlt.sargon.samples.sample
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class SignedIntentTest: SampleTestable<SignedIntent> {
+    override val samples: List<Sample<SignedIntent>>
+        get() = listOf(SignedIntent.sample)
+
+    @Test
+    fun testHash() {
+        val s = "signedintent_sim1ul0kjuvd63sslhxy869zdk4k3vcdg9e9244xwpuck4dyndzx9wnqrhxy5d"
+        Assertions.assertEquals(
+            s,
+            SignedIntent.sample().hash().bech32EncodedTxId
+        )
+    }
+}

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/TransactionIntentTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/TransactionIntentTest.kt
@@ -1,0 +1,42 @@
+package com.radixdlt.sargon
+
+import com.radixdlt.sargon.extensions.compile
+import com.radixdlt.sargon.extensions.hash
+import com.radixdlt.sargon.extensions.hex
+import com.radixdlt.sargon.extensions.init
+import com.radixdlt.sargon.samples.Sample
+import com.radixdlt.sargon.samples.sample
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class TransactionIntentTest: SampleTestable<TransactionIntent> {
+    override val samples: List<Sample<TransactionIntent>>
+        get() = listOf(TransactionIntent.sample)
+
+    @Test
+    fun testHash() {
+        Assertions.assertEquals(
+            "txid_rdx12nnrygyt3p5v5pft5e3vu93v38qp5k7fh9v59kd6vtu8506880nq5vsxx6",
+            TransactionIntent.sample().hash().bech32EncodedTxId
+        )
+    }
+
+    @Test
+    fun testCompile() {
+        val s = "4d220104210707010a872c0100000000000a912c01000000000009092f2400220101200720ec172b93" +
+                "ad5e563bf4932c70e1245034c35467ef2efd4d64ebf819683467e2bf010108000020220441038000d1" +
+                "be9c042f627d98a01383987916d43cf439631ca1d8c8076d6754ab263d0c086c6f636b5f6665652101" +
+                "850000fda0c42777080000000000000000000000000000000041038000d1be9c042f627d98a0138398" +
+                "7916d43cf439631ca1d8c8076d6754ab263d0c087769746864726177210280005da66318c6318c61f5" +
+                "a61b4c6318c6318cf794aa8d295f14e6318c6318c6850000443945309a7a4800000000000000000000" +
+                "0000000000000280005da66318c6318c61f5a61b4c6318c6318cf794aa8d295f14e6318c6318c68500" +
+                "00443945309a7a4800000000000000000000000000000041038000d1127918c16af09af521951adcf3" +
+                "a20ab2cc87c0e72e85814764853ce5e70c147472795f6465706f7369745f6f725f61626f7274210281" +
+                "0000000022000020200022010121020c0a746578742f706c61696e2200010c0c48656c6c6f20526164" +
+                "697821"
+        Assertions.assertEquals(
+            s,
+            TransactionIntent.sample().compile().hex
+        )
+    }
+}

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/TransactionManifestTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/TransactionManifestTest.kt
@@ -398,18 +398,17 @@ class TransactionManifestTest : SampleTestable<TransactionManifest> {
     }
 
     private fun manifest(name: String) = TransactionManifest.init(
-        instructionsString = File(
-            "../../" +
-                    "src/wrapped_radix_engine_toolkit/low_level/" +
-                    "transaction_manifest/execution_summary/$name.rtm"
-        ).readText(),
+        instructionsString = openFile(name, "rtm").readText(),
         networkId = NetworkId.STOKENET
     )
 
-    private fun encodedReceipt(name: String): BagOfBytes = File(
+    private fun encodedReceipt(name: String): BagOfBytes = openFile(name, "dat")
+        .readText()
+        .hexToBagOfBytes()
+
+    private fun openFile(name: String, extension: String) = File(
         "../../" +
                 "src/wrapped_radix_engine_toolkit/low_level/" +
-                "transaction_manifest/execution_summary/$name.dat"
-    ).readText().hexToBagOfBytes()
-
+                "transaction_manifest/execution_summary/$name.$extension"
+    )
 }

--- a/src/bindgen/post_process_kotlin.rs
+++ b/src/bindgen/post_process_kotlin.rs
@@ -8,25 +8,25 @@ pub(crate) fn kotlin_transform(
     needle: &str,
     contents: String,
 ) -> Result<String, BindgenError> {
-    let mut contents = contents;
-
-    // Replace `var` -> `internal val`
-    let stored_props_from = format!("var `{}`", needle);
-    let stored_props_to = format!("internal val `{}`", needle);
-    contents = contents.replace(&stored_props_from, &stored_props_to);
-    println!(
-        "🔮 Post processing Kotlin: Made '{}' properties private and immutable. ✨ ",
-        needle
-    );
-
-    let secret_magic_regex = Regex::new(
+    Regex::new(
         r"(.*class \w+) (\(\n{0,1}.*\n{0,1}.*secretMagic.*\n{0,1}\))",
-    )
-    .unwrap();
-    contents = secret_magic_regex
-        .replace_all(&contents, "$1 internal constructor $2")
-        .to_string();
+    ).map(|regex| {
+        println!("🔮 Post processing Kotlin: Hiding some dangerous initializers. ✨ ");
+        regex.replace_all(&contents, "$1 internal constructor $2")
+    }).map(|modified| {
+        println!(
+            "🔮 Post processing Kotlin: Made '{}' properties private and immutable. ✨ ",
+            needle
+        );
 
-    println!("🔮 Post processing Kotlin: Hid some dangerous initializers. ✨ ");
-    Ok(contents)
+        modified.replace(
+            &format!("var `{}`", needle), 
+            &format!("internal val `{}`", needle)
+        )
+    }).map_err(|e| {
+        BindgenError::WriteFile {
+            path: needle.to_owned(),
+            reason: format!("{:?}", e),
+        }
+    })
 }


### PR DESCRIPTION
* Added missing extensions from latest PRs.
* Used regex in order to make all constructors that include `secretMagic` internal in kotlin post processing.