### PR TITLE
Codable Addresses, Decimal192, NonFunIDs

### DIFF
--- a/apple/Sources/Sargon/Extensions/Methods/Prelude/Decimal192+Wrap+Functions.swift
+++ b/apple/Sources/Sargon/Extensions/Methods/Prelude/Decimal192+Wrap+Functions.swift
@@ -17,6 +17,11 @@ extension Decimal192 {
 	public init(_ value: UInt64) {
 		self = newDecimalFromU64(value: value)
 	}
+	
+	/// Creates the Decimal `10^exponent`
+	public init(exponent: UInt8) {
+		self = newDecimalExponent(exponent: exponent)
+	}
 
 }
 
@@ -142,8 +147,16 @@ extension Decimal192 {
 		decimalClampedToZero(decimal: self)
 	}
 
-	public func isNegative() -> Bool {
+	public var isNegative: Bool {
 		decimalIsNegative(decimal: self)
+	}
+	
+	public var isPositive: Bool {
+		decimalIsPositive(decimal: self)
+	}
+	
+	public var isZero: Bool {
+		decimalIsZero(decimal: self)
 	}
 }
 

--- a/apple/Sources/Sargon/Extensions/Methods/Prelude/NonFungibleGlobalID+Wrap+Functions.swift
+++ b/apple/Sources/Sargon/Extensions/Methods/Prelude/NonFungibleGlobalID+Wrap+Functions.swift
@@ -1,11 +1,11 @@
 import SargonUniFFI
 
 extension NonFungibleGlobalID {
-    public init(string: String) throws {
+    public init(_ string: String) throws {
         self = try newNonFungibleGlobalIdFromString(string: string)
     }
     
-    public func toString() -> String {
+    public func toRawString() -> String {
         nonFungibleGlobalIdToString(globalId: self)
     }
     

--- a/apple/Sources/Sargon/Extensions/Methods/Prelude/NonFungibleLocalID+Wrap+Functions.swift
+++ b/apple/Sources/Sargon/Extensions/Methods/Prelude/NonFungibleLocalID+Wrap+Functions.swift
@@ -1,14 +1,13 @@
 import SargonUniFFI
 
 extension NonFungibleLocalID {
-	public func toString() -> String {
+	public func toRawString() -> String {
 		nonFungibleLocalIdAsStr(id: self)
 	}
 	
 	public init(integer value: UInt64) {
 		self = newNonFungibleLocalIdInt(value: value)
 	}
-    
     
     public func formatted(_ format: AddressFormat = .default) -> String {
         nonFungibleLocalIdFormatted(id: self, format: format)
@@ -24,18 +23,18 @@ extension NonFungibleLocalID {
     /// * ruid
     /// * string
     ///
-    /// Not to be confused with `init(string:)` which tries to decode
-    /// `NonFungibleLocalID.string`
-    public init(localId: String) throws {
-        self = try newNonFungibleLocalIdFromString(localId: localId)
+    /// Not to be confused with `NonFungibleLocalID.stringID` which tries to decode
+	/// a `NonFungibleLocalID.string` variant
+    public init(_ string: String) throws {
+        self = try newNonFungibleLocalIdFromString(localId: string)
     }
     
     /// Tries to decode a `NonFungibleLocalID.string`
     ///
-    /// Not to be confused with `init(localId:)` which tries to decode
-    /// a string into any case of `NonFungibleLocalID` 
-	public init(string: String) throws {
-		self = try newNonFungibleLocalIdString(string: string)
+    /// Not to be confused with `init(:String)` which tries to decode
+    /// a string into any case of `NonFungibleLocalID`
+	public static func stringID(_ string: String) throws -> Self {
+		try newNonFungibleLocalIdString(string: string)
 	}
 	
 	public init(bytes: some DataProtocol) throws {

--- a/apple/Sources/Sargon/Extensions/Swiftified/Address/Address+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Address/Address+Swiftified.swift
@@ -4,5 +4,8 @@ extension Address: AddressProtocol {
 		self
 	}
 	
+	public func into<A: AddressProtocol>(type: A.Type = A.self) throws -> A {
+		try A(validatingAddress: self.address)
+	}
 }
 

--- a/apple/Sources/Sargon/Extensions/Swiftified/Prelude/Decimal192+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Prelude/Decimal192+Swiftified.swift
@@ -82,3 +82,34 @@ extension Decimal192 {
 		lhs.div(rhs: rhs)
 	}
 }
+
+extension Decimal192 {
+	public var asDouble: Double {
+		// this can never fail
+		Double(self.toRawString())!
+	}
+	
+}
+
+
+extension Decimal192 {
+	
+	public func toRawString() -> String {
+		decimalToString(decimal: self)
+	}
+}
+
+extension Decimal192: Codable {
+	@inlinable
+	public func encode(to encoder: Encoder) throws {
+		var container = encoder.singleValueContainer()
+		try container.encode(toRawString())
+	}
+
+	@inlinable
+	public init(from decoder: Decoder) throws {
+		let container = try decoder.singleValueContainer()
+		let string = try container.decode(String.self)
+		try self.init(string)
+	}
+}

--- a/apple/Sources/Sargon/Extensions/Swiftified/Prelude/NonFungibleGlobalID+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Prelude/NonFungibleGlobalID+Swiftified.swift
@@ -1,5 +1,6 @@
 public typealias NonFungibleGlobalID = NonFungibleGlobalId
-extension NonFungibleGlobalID: SargonModel {}
+
+extension NonFungibleGlobalID: IdentifiableByStringProtocol {}
 
 extension NonFungibleGlobalID {
     public init(
@@ -12,24 +13,3 @@ extension NonFungibleGlobalID {
         )
     }
 }
-
-extension NonFungibleGlobalID: CustomStringConvertible {
-    public var description: String {
-        toString()
-    }
-}
-
-extension NonFungibleGlobalID: Identifiable {
-    public typealias ID = String
-    public var id: String {
-        toString()
-    }
-}
-
-#if DEBUG
-extension NonFungibleGlobalID: ExpressibleByStringLiteral {
-    public init(stringLiteral value: String) {
-        try! self.init(string: value)
-    }
-}
-#endif // DEBUG

--- a/apple/Sources/Sargon/Extensions/Swiftified/Prelude/NonFungibleLocalID+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Prelude/NonFungibleLocalID+Swiftified.swift
@@ -1,12 +1,6 @@
 public typealias NonFungibleLocalID = NonFungibleLocalId
 
-extension NonFungibleLocalID: SargonModel {}
-
-extension NonFungibleLocalID: CustomStringConvertible {
-	public var description: String {
-		toString()
-	}
-}
+extension NonFungibleLocalID: IdentifiableByStringProtocol {}
 
 extension NonFungibleLocalID: ExpressibleByIntegerLiteral {
 	public init(integerLiteral value: UInt64) {
@@ -15,14 +9,6 @@ extension NonFungibleLocalID: ExpressibleByIntegerLiteral {
 }
 
 #if DEBUG
-extension NonFungibleLocalID: ExpressibleByStringLiteral {
-	/// Tries to decode an String as NonFungibleLocalID.string
-	/// Crashes for invalid strings.
-	public init(stringLiteral value: StringLiteralType) {
-		try! self.init(string: value)
-	}
-}
-
 extension NonFungibleLocalID: ExpressibleByArrayLiteral {
 	/// Tries to create a `LocalID.bytes`
 	public init(arrayLiteral bytes: UInt8...) {

--- a/apple/Sources/Sargon/Protocols/AddressProtocol.swift
+++ b/apple/Sources/Sargon/Protocols/AddressProtocol.swift
@@ -4,7 +4,7 @@ public protocol BaseBaseAddressProtocol: SargonModel, ExpressibleByStringLiteral
 public protocol BaseBaseAddressProtocol: SargonModel {}
 #endif // DEBUG
 
-public protocol BaseAddressProtocol: BaseBaseAddressProtocol, CustomStringConvertible, CaseIterable where Self.AllCases == [Self] {
+public protocol BaseAddressProtocol: BaseBaseAddressProtocol, Codable, CustomStringConvertible, CaseIterable where Self.AllCases == [Self] {
 	init(validatingAddress bech32String: String) throws
 	var networkID: NetworkID { get }
 	var address: String { get }
@@ -13,6 +13,19 @@ public protocol BaseAddressProtocol: BaseBaseAddressProtocol, CustomStringConver
 extension BaseAddressProtocol {
 	public var description: String {
 		address
+	}
+}
+
+extension BaseAddressProtocol where Self: Codable {
+	public func encode(to encoder: Encoder) throws {
+		var container = encoder.singleValueContainer()
+		try container.encode(self.address)
+	}
+
+	public init(from decoder: Decoder) throws {
+		let container = try decoder.singleValueContainer()
+		let string = try container.decode(String.self)
+		try self.init(validatingAddress: string)
 	}
 }
 

--- a/apple/Sources/Sargon/Protocols/IdentifiableByStringProtocol.swift
+++ b/apple/Sources/Sargon/Protocols/IdentifiableByStringProtocol.swift
@@ -1,0 +1,50 @@
+
+#if DEBUG
+public protocol BaseIdentifiableByStringProtocol: SargonModel & ExpressibleByStringLiteral {}
+#else
+public protocol BaseIdentifiableByStringProtocol: SargonModel {}
+#endif // DEBUG
+
+
+public protocol IdentifiableByStringProtocol: BaseIdentifiableByStringProtocol & Codable & CustomStringConvertible & Identifiable where Self.ID == String {
+	init(_ string: String) throws
+	
+	/// A non user facing, raw, string representation of the value.
+	func toRawString() -> String
+	
+}
+
+extension IdentifiableByStringProtocol {
+	public var description: String {
+		toRawString()
+	}
+}
+
+extension IdentifiableByStringProtocol where Self: Identifiable, Self.ID == String {
+	public var id: String {
+		toRawString()
+	}
+}
+
+extension IdentifiableByStringProtocol where Self: Codable {
+	public func encode(to encoder: Encoder) throws {
+		var container = encoder.singleValueContainer()
+		try container.encode(self.toRawString())
+	}
+
+	public init(from decoder: Decoder) throws {
+		let container = try decoder.singleValueContainer()
+		let string = try container.decode(String.self)
+		try self.init(string)
+	}
+}
+
+
+#if DEBUG
+extension IdentifiableByStringProtocol {
+	public init(stringLiteral value: String) {
+		try! self.init(value)
+	}
+}
+#endif // DEBUG
+

--- a/apple/Tests/TestCases/Address/AccountAddressTests.swift
+++ b/apple/Tests/TestCases/Address/AccountAddressTests.swift
@@ -16,6 +16,10 @@ final class AccountAddressTests: AddressTest<AccountAddress> {
 		)
     }
 	
+	func test_into_fails_for_wrong_address_type() {
+		XCTAssertThrowsError(try SUT.sample.embed().into(type: IdentityAddress.self))
+	}
+	
 	func test_short() {
 		XCTAssertEqual(SUT.sample.shortFormat, "acco...please")
 	}

--- a/apple/Tests/TestCases/Prelude/NonFungibleGlobalIDTests.swift
+++ b/apple/Tests/TestCases/Prelude/NonFungibleGlobalIDTests.swift
@@ -1,11 +1,11 @@
-final class NonFungibleGlobalIDTests: Test<NonFungibleGlobalID> {
+final class NonFungibleGlobalIDTests: IdentifiableByStringProtocolTest<NonFungibleGlobalID> {
     
     func test_from_parts() {
         XCTAssertEqual(
             SUT.sample,
             try SUT(
                 nonFungibleResourceAddress: NonFungibleResourceAddress.sample,
-                localID: .init(string: "Member_237")
+				localID: .stringID("Member_237")
             )
         )
     }
@@ -16,14 +16,14 @@ final class NonFungibleGlobalIDTests: Test<NonFungibleGlobalID> {
     
     func test_valid_from_str() {
         XCTAssertEqual(
-            try SUT(string: "resource_rdx1nfyg2f68jw7hfdlg5hzvd8ylsa7e0kjl68t5t62v3ttamtejc9wlxa:<Member_237>"),
+			try SUT.init("resource_rdx1nfyg2f68jw7hfdlg5hzvd8ylsa7e0kjl68t5t62v3ttamtejc9wlxa:<Member_237>"),
             SUT.sample
         )
     }
     
     func test_invalid_from_str() {
         XCTAssertThrowsError(
-            try SUT(string: "super invalid string!!!!")
+			try SUT.init("super invalid string!!!!")
         )
     }
 	

--- a/apple/Tests/TestCases/Prelude/NonFungibleLocalIDTests.swift
+++ b/apple/Tests/TestCases/Prelude/NonFungibleLocalIDTests.swift
@@ -1,20 +1,22 @@
-final class NonFungibleLocalIDTests: Test<NonFungibleLocalID> {
+import Sargon
+
+final class NonFungibleLocalIDTests: IdentifiableByStringProtocolTest<NonFungibleLocalID> {
 	
     // MARK: LocalID String
     func test_valid_local_id_string_from_string() {
-        XCTAssertEqual(try SUT(localId: "<foo>"), SUT.str(value: "foo"))
+		XCTAssertEqual(try SUT.init("<foo>"), SUT.str(value: "foo"))
     }
     
     func test_valid_local_id_string_from_integer() {
-        XCTAssertEqual(try SUT(localId: "#666#"), SUT.integer(value: 666))
+		XCTAssertEqual(try SUT.init("#666#"), SUT.integer(value: 666))
     }
     
     func test_valid_local_id_string_from_ruid() {
-        XCTAssertEqual(try SUT(localId: "{deaddeaddeaddead-deaddeaddeaddead-deaddeaddeaddead-deaddeaddeaddead}"), SUT.ruid(value: .sample))
+		XCTAssertEqual(try SUT.init("{deaddeaddeaddead-deaddeaddeaddead-deaddeaddeaddead-deaddeaddeaddead}"), SUT.ruid(value: .sample))
     }
     
     func test_valid_local_id_string_from_bytes() {
-        XCTAssertEqual(try SUT(localId: "[acedacedacedacedacedacedacedacedacedacedacedacedacedacedacedaced]"), SUT.bytes(value: NonEmptyMax64Bytes(bagOfBytes: Data.sampleAced)))
+		XCTAssertEqual(try SUT.init("[acedacedacedacedacedacedacedacedacedacedacedacedacedacedacedaced]"), SUT.bytes(value: NonEmptyMax64Bytes(bagOfBytes: Data.sampleAced)))
     }
     
 	// MARK: Integer
@@ -32,29 +34,41 @@ final class NonFungibleLocalIDTests: Test<NonFungibleLocalID> {
 	// MARK: String
 	func test_string_valid_short() {
 		XCTAssertEqual(
-			try SUT(string: "x").description,
+			try SUT.stringID("x").description,
 			"<x>"
 		)
-		XCTAssertEqual(
-			try SUT(string: "x"),
-			"x" as SUT // ExpressibleByStringLiteral
-		)
+	}
+	
+	func test_init_string_fails_when_given_user_facing_string() throws {
+		XCTAssertThrowsError(try SUT.init("x"))
+	}
+	
+	func test_init_string_succeeds_when_given_raw_string() throws {
+		XCTAssertNoThrow(try SUT.init("<x>"))
+	}
+	
+	func test_from_stringID_fails_when_given_raw_string() throws {
+		XCTAssertThrowsError(try SUT.stringID("<x>"))
+	}
+	
+	func test_from_stringID_succeeds_when_given_user_facing_string() throws {
+		XCTAssertNoThrow(try SUT.stringID("x"))
 	}
 	
 	func test_string_valid_max_length() {
 		let s = String(repeating: "z", count: 64)
 		XCTAssertEqual(
-			try SUT(string: s).description,
+			try SUT.stringID(s).description,
 			"<\(s)>"
 		)
 	}
 	
 	func test_string_invalid_too_long() {
-		XCTAssertThrowsError(try SUT(string: "much2longmuch2longmuch2longmuch2longmuch2longmuch2longmuch2longmuch2long"))
+		XCTAssertThrowsError(try SUT.stringID("much2longmuch2longmuch2longmuch2longmuch2longmuch2longmuch2longmuch2long"))
 	}
 	
 	func test_string_invalid_forbidden_chars() {
-		XCTAssertThrowsError(try SUT(string: "#$^"))
+		XCTAssertThrowsError(try SUT.stringID("#$^"))
 	}
 	
 	// MARK: Bytes

--- a/apple/Tests/Utils/AddressProtocolTests.swift
+++ b/apple/Tests/Utils/AddressProtocolTests.swift
@@ -55,6 +55,19 @@ class AddressTest<SUT_: AddressProtocol>: BaseAddressTest<SUT_> {
 	func test_network_id_of_stokenet_sampleOther() {
 		XCTAssertNoDifference(SUT.sampleStokenetOther.networkID, .stokenet)
 	}
+	
+	func test_into_self() throws {
+		func doTestInto(_ sut: SUT) throws {
+			let embedded = sut.embed()
+			let extracted = try embedded.into(type: SUT.self)
+			XCTAssertEqual(extracted, sut)
+		}
+		try SUT.allCases.forEach(doTestInto)
+	}
+	
+	func test_codable_roundtrip() throws {
+		try SUT.allCases.forEach(doTestCodableRoundtrip)
+	}
     
     func test_identifiable() {
         SUT.allCases.forEach {

--- a/apple/Tests/Utils/IdentifiableByStringProtocolTests.swift
+++ b/apple/Tests/Utils/IdentifiableByStringProtocolTests.swift
@@ -1,0 +1,14 @@
+class IdentifiableByStringProtocolTest<SUT_: IdentifiableByStringProtocol>: Test<SUT_> {
+	func test_string_roundtrip_symmetric_with_raw() throws {
+		func doTest(_ sut: SUT) throws {
+			let roundtripped = try SUT(sut.toRawString())
+			XCTAssertEqual(sut, roundtripped)
+		}
+		try SUT.allCases.forEach(doTest)
+	}
+	
+	func test_codable_roundtrip() throws {
+		try SUT.allCases.forEach(doTestCodableRoundtrip)
+	}
+}
+

--- a/apple/Tests/Utils/SargonModelProtocol.swift
+++ b/apple/Tests/Utils/SargonModelProtocol.swift
@@ -9,6 +9,8 @@ class TestCase: XCTestCase {
 	}
 }
 
+
+
 class Test<SUT_: SargonModel>: TestCase {
 	typealias SUT = SUT_
 	
@@ -41,4 +43,14 @@ class Test<SUT_: SargonModel>: TestCase {
 		XCTAssertNoDifference(sampleOther.description, sampleOther.description)
 	}
 	
+}
+
+extension Test where SUT: Codable {
+	func doTestCodableRoundtrip(_ sut: SUT) throws {
+		let jsonEncoder = JSONEncoder()
+		let jsonDecoder = JSONDecoder()
+		let data = try jsonEncoder.encode(sut)
+		let decoded = try jsonDecoder.decode(SUT.self, from: data)
+		XCTAssertEqual(decoded, sut)
+	}
 }


### PR DESCRIPTION
Swift only:
* move Codable impl of `Decimal192`, all addresses and `NonFungible`IDs into Sargon, needed by iOS wallet due to CacheClient 
* add casting methods on Address
* add `asDouble` which seems it cannot fail, so made into computed property. Should be moved into Rust Sargon...