### PR TITLE
Some more extensions + `@UsesSampleValues`

### DIFF
--- a/jvm/app/src/main/java/com/radixdlt/sargon/android/MainActivity.kt
+++ b/jvm/app/src/main/java/com/radixdlt/sargon/android/MainActivity.kt
@@ -32,7 +32,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import com.radixdlt.sargon.DisplayName
 import com.radixdlt.sargon.NetworkId
@@ -42,16 +41,13 @@ import com.radixdlt.sargon.SecureStorage
 import com.radixdlt.sargon.Wallet
 import com.radixdlt.sargon.WalletClientModel
 import com.radixdlt.sargon.android.ui.theme.SargonAndroidTheme
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.extensions.string
-import com.radixdlt.sargon.samples.ProfilePreviewParameterProvider
+import com.radixdlt.sargon.samples.sample
 import kotlin.random.Random
 
 class MainActivity : ComponentActivity() {
 
-    init {
-        System.setProperty("jna.debug_load.jna", "true")
-        System.setProperty("jna.debug_load", "true")
-    }
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -186,11 +182,10 @@ fun Wallet.Companion.with(
     )
 }
 
+@OptIn(UsesSampleValues::class)
 @Preview(showBackground = true)
 @Composable
-fun NetworkPreview(
-    @PreviewParameter(provider = ProfilePreviewParameterProvider::class, limit = 1)
-    profile: Profile
-) {
+fun NetworkPreview() {
+    val profile = Profile.sample()
     Network(network = profile.networks.first(), onAccountAdd = {})
 }

--- a/jvm/sargon-android/build.gradle.kts
+++ b/jvm/sargon-android/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.gradle.configurationcache.extensions.capitalized
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     alias(libs.plugins.android.library)
@@ -55,11 +56,17 @@ tasks.withType<Test> {
     useJUnitPlatform()
 }
 
+tasks.withType<KotlinCompile>().configureEach {
+    if (name.contains("Test")) {
+        kotlinOptions.freeCompilerArgs += "-Xopt-in=com.radixdlt.sargon.annotation.UsesSampleValues"
+    }
+}
+
 koverReport {
     filters {
         excludes {
             packages("com.radixdlt.sargon.samples")
-            annotatedBy("com.radixdlt.sargon.utils.KoverIgnore")
+            annotatedBy("com.radixdlt.sargon.annotation.KoverIgnore")
         }
         includes {
             packages("com.radixdlt.sargon.extensions")
@@ -77,13 +84,11 @@ dependencies {
     // Cannot use version catalogues for aar. For some reason when published to Maven,
     // the jna dependency cannot be resolved
     implementation("net.java.dev.jna:jna:5.13.0@aar")
-    implementation("androidx.annotation:annotation:1.7.1")
-    implementation("androidx.compose.ui:ui-tooling-preview-android:1.6.2")
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
+    testImplementation(libs.junit)
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testDebugRuntimeOnly(project(":sargon-desktop-debug"))
     testReleaseRuntimeOnly(project(":sargon-desktop-release"))
-    testImplementation(libs.junit)
 }
 
 publishing {

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/annotation/KoverIgnore.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/annotation/KoverIgnore.kt
@@ -1,4 +1,4 @@
-package com.radixdlt.sargon.utils
+package com.radixdlt.sargon.annotation
 
 /**
  * Annotation used to ignore certain elements from being included

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/annotation/UsesSampleValues.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/annotation/UsesSampleValues.kt
@@ -1,0 +1,39 @@
+package com.radixdlt.sargon.annotation
+
+/**
+ * User needs to opt in to this annotation in order to use sample values.
+ *
+ * Tests can be configured to automatically opt-in to this feature by adding the following code
+ * into the `build.gradle`
+ *
+ * In Groovy:
+ * ```
+ * tasks.withType(KotlinCompile).configureEach {
+ *     if (it.name.contains("Test")) {
+ *         kotlinOptions.freeCompilerArgs += '-Xopt-in=com.radixdlt.sargon.annotation.UsesSampleValues'
+ *     }
+ * }
+ * ```
+ * In Kotlin DSL
+ * ```
+ * tasks.withType<KotlinCompile>().configureEach {
+ *     if (name.contains("Test")) {
+ *         kotlinOptions.freeCompilerArgs += "-Xopt-in=com.radixdlt.sargon.annotation.UsesSampleValues"
+ *     }
+ * }
+ * ```
+ *
+ * When in need to be used in composable previews the only solution for now is to use it like this:
+ * ```
+ * @OptIn(UsesSampleValues::class)
+ * @Preview
+ * @Composable
+ * fun SomePreview() {
+ *    val sampleValue = SomeClass.sample()
+ *    ...
+ * }
+ * ```
+ */
+@RequiresOptIn
+@Retention(AnnotationRetention.BINARY)
+annotation class UsesSampleValues

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/CompiledNotarizedIntent.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/CompiledNotarizedIntent.kt
@@ -4,7 +4,7 @@ import com.radixdlt.sargon.BagOfBytes
 import com.radixdlt.sargon.CompiledNotarizedIntent
 import com.radixdlt.sargon.compiledNotarizedIntentGetBytes
 import com.radixdlt.sargon.debugPrintCompiledNotarizedIntent
-import com.radixdlt.sargon.utils.KoverIgnore
+import com.radixdlt.sargon.annotation.KoverIgnore
 
 @KoverIgnore
 fun CompiledNotarizedIntent.debugPrint(): String =

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/FungibleResourceIndicator.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/FungibleResourceIndicator.kt
@@ -1,0 +1,8 @@
+package com.radixdlt.sargon.extensions
+
+import com.radixdlt.sargon.Decimal192
+import com.radixdlt.sargon.FungibleResourceIndicator
+import com.radixdlt.sargon.fungibleResourceIndicatorGetAmount
+
+val FungibleResourceIndicator.amount: Decimal192
+    get() = fungibleResourceIndicatorGetAmount(indicator = this)

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/Message.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/Message.kt
@@ -1,0 +1,12 @@
+package com.radixdlt.sargon.extensions
+
+import com.radixdlt.sargon.Message
+import com.radixdlt.sargon.messageAsPlaintext
+import com.radixdlt.sargon.newMessagePlaintextString
+
+fun Message.Companion.plaintext(string: String): Message = newMessagePlaintextString(
+    string = string
+)
+
+val Message.plaintext: String?
+    get() = messageAsPlaintext(message = this)

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/NonFungibleResourceIndicator.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/NonFungibleResourceIndicator.kt
@@ -1,0 +1,8 @@
+package com.radixdlt.sargon.extensions
+
+import com.radixdlt.sargon.NonFungibleLocalId
+import com.radixdlt.sargon.NonFungibleResourceIndicator
+import com.radixdlt.sargon.nonFungibleResourceIndicatorGetIds
+
+val NonFungibleResourceIndicator.ids: List<NonFungibleLocalId>
+    get() = nonFungibleResourceIndicatorGetIds(indicator = this)

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/ResourceAddress.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/ResourceAddress.kt
@@ -2,10 +2,8 @@ package com.radixdlt.sargon.extensions
 
 import com.radixdlt.sargon.AddressFormat
 import com.radixdlt.sargon.NetworkId
-import com.radixdlt.sargon.PoolAddress
 import com.radixdlt.sargon.ResourceAddress
 import com.radixdlt.sargon.newResourceAddress
-import com.radixdlt.sargon.poolAddressFormatted
 import com.radixdlt.sargon.resourceAddressBech32Address
 import com.radixdlt.sargon.resourceAddressFormatted
 import com.radixdlt.sargon.resourceAddressIsFungible
@@ -31,6 +29,9 @@ val ResourceAddress.isFungible: Boolean
 
 val ResourceAddress.isNonFungible: Boolean
     get() = resourceAddressIsNonFungible(address = this)
+
+val ResourceAddress.isXRD: Boolean
+    get() = this == ResourceAddress.xrd(networkId = networkId)
 
 fun ResourceAddress.formatted(
     format: AddressFormat = AddressFormat.DEFAULT

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/ResourceIndicator.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/ResourceIndicator.kt
@@ -1,0 +1,8 @@
+package com.radixdlt.sargon.extensions
+
+import com.radixdlt.sargon.ResourceAddress
+import com.radixdlt.sargon.ResourceIndicator
+import com.radixdlt.sargon.resourceIndicatorGetAddress
+
+val ResourceIndicator.address: ResourceAddress
+    get() = resourceIndicatorGetAddress(indicator = this)

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/Sargon.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/Sargon.kt
@@ -2,7 +2,7 @@ package com.radixdlt.sargon.extensions
 
 import com.radixdlt.sargon.SargonBuildInformation
 import com.radixdlt.sargon.buildInformation
-import com.radixdlt.sargon.utils.KoverIgnore
+import com.radixdlt.sargon.annotation.KoverIgnore
 
 object Sargon {
 

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/TransactionManifest.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/TransactionManifest.kt
@@ -39,7 +39,6 @@ import com.radixdlt.sargon.transactionManifestInvolvedPoolAddresses
 import com.radixdlt.sargon.transactionManifestInvolvedResourceAddresses
 import com.radixdlt.sargon.transactionManifestNetworkId
 import com.radixdlt.sargon.transactionManifestSummary
-import com.radixdlt.sargon.utils.KoverIgnore
 
 @Throws(SargonException::class)
 fun TransactionManifest.Companion.init(

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/AccessControllerAddressSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/AccessControllerAddressSample.kt
@@ -1,6 +1,6 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.AccessControllerAddress
 import com.radixdlt.sargon.NetworkId
 import com.radixdlt.sargon.newAccessControllerAddressSampleMainnet
@@ -9,7 +9,7 @@ import com.radixdlt.sargon.newAccessControllerAddressRandom
 import com.radixdlt.sargon.newAccessControllerAddressSampleStokenet
 import com.radixdlt.sargon.newAccessControllerAddressSampleStokenetOther
 
-@VisibleForTesting
+@UsesSampleValues
 object AccessControllerAddressSampleMainnet: SampleWithRandomValues<AccessControllerAddress> {
 
     override fun invoke(): AccessControllerAddress =
@@ -24,11 +24,11 @@ object AccessControllerAddressSampleMainnet: SampleWithRandomValues<AccessContro
 
 }
 
-@VisibleForTesting
+@UsesSampleValues
 val AccessControllerAddress.Companion.sampleMainnet: AccessControllerAddressSampleMainnet
     get() = AccessControllerAddressSampleMainnet
 
-@VisibleForTesting
+@UsesSampleValues
 object AccessControllerAddressSampleStokenet: SampleWithRandomValues<AccessControllerAddress> {
 
     override fun invoke(): AccessControllerAddress =
@@ -42,11 +42,11 @@ object AccessControllerAddressSampleStokenet: SampleWithRandomValues<AccessContr
     )
 }
 
-@VisibleForTesting
+@UsesSampleValues
 val AccessControllerAddress.Companion.sampleStokenet: AccessControllerAddressSampleStokenet
     get() = AccessControllerAddressSampleStokenet
 
-@VisibleForTesting
+@UsesSampleValues
 fun AccessControllerAddress.Companion.sampleRandom(
     networkId: NetworkId
 ) = newAccessControllerAddressRandom(networkId = networkId)

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/AccountAddressSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/AccountAddressSample.kt
@@ -1,17 +1,15 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
-import com.radixdlt.sargon.AccessControllerAddress
 import com.radixdlt.sargon.AccountAddress
 import com.radixdlt.sargon.NetworkId
-import com.radixdlt.sargon.newAccessControllerAddressRandom
+import com.radixdlt.sargon.annotation.UsesSampleValues
+import com.radixdlt.sargon.newAccountAddressRandom
 import com.radixdlt.sargon.newAccountAddressSampleMainnet
 import com.radixdlt.sargon.newAccountAddressSampleMainnetOther
-import com.radixdlt.sargon.newAccountAddressRandom
 import com.radixdlt.sargon.newAccountAddressSampleStokenet
 import com.radixdlt.sargon.newAccountAddressSampleStokenetOther
 
-@VisibleForTesting
+@UsesSampleValues
 object AccountAddressSampleMainnet: SampleWithRandomValues<AccountAddress> {
     override fun invoke(): AccountAddress = newAccountAddressSampleMainnet()
 
@@ -20,11 +18,11 @@ object AccountAddressSampleMainnet: SampleWithRandomValues<AccountAddress> {
     override fun random(): AccountAddress = newAccountAddressRandom(networkId = NetworkId.MAINNET)
 }
 
-@VisibleForTesting
+@UsesSampleValues
 val AccountAddress.Companion.sampleMainnet: AccountAddressSampleMainnet
     get() = AccountAddressSampleMainnet
 
-@VisibleForTesting
+@UsesSampleValues
 object AccountAddressSampleStokenet: SampleWithRandomValues<AccountAddress> {
     override fun invoke(): AccountAddress = newAccountAddressSampleStokenet()
 
@@ -33,11 +31,11 @@ object AccountAddressSampleStokenet: SampleWithRandomValues<AccountAddress> {
     override fun  random(): AccountAddress = newAccountAddressRandom(networkId = NetworkId.STOKENET)
 }
 
-@VisibleForTesting
+@UsesSampleValues
 val AccountAddress.Companion.sampleStokenet: AccountAddressSampleStokenet
     get() = AccountAddressSampleStokenet
 
-@VisibleForTesting
+@UsesSampleValues
 fun AccountAddress.Companion.sampleRandom(
     networkId: NetworkId
 ) = newAccountAddressRandom(networkId = networkId)

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/AccountSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/AccountSample.kt
@@ -1,6 +1,6 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.Account
 import com.radixdlt.sargon.newAccountSampleMainnetAlice
 import com.radixdlt.sargon.newAccountSampleMainnetBob
@@ -9,7 +9,7 @@ import com.radixdlt.sargon.newAccountSampleStokenetNadia
 import com.radixdlt.sargon.newAccountSampleStokenetOlivia
 import com.radixdlt.sargon.newAccountSampleStokenetPaige
 
-@VisibleForTesting
+@UsesSampleValues
 object AccountMainnetSample: Sample<Account> {
     override fun invoke(): Account = alice
     override fun other(): Account = bob
@@ -25,11 +25,11 @@ object AccountMainnetSample: Sample<Account> {
 
 }
 
-@VisibleForTesting
+@UsesSampleValues
 val Account.Companion.sampleMainnet: AccountMainnetSample
     get() = AccountMainnetSample
 
-@VisibleForTesting
+@UsesSampleValues
 object AccountStokenetSample: Sample<Account> {
     override fun invoke(): Account = nadia
     override fun other(): Account = olivia
@@ -45,6 +45,6 @@ object AccountStokenetSample: Sample<Account> {
 
 }
 
-@VisibleForTesting
+@UsesSampleValues
 val Account.Companion.sampleStokenet: AccountStokenetSample
     get() = AccountStokenetSample

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/AddressOfAccountOrPersonaSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/AddressOfAccountOrPersonaSample.kt
@@ -1,13 +1,13 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.AddressOfAccountOrPersona
 import com.radixdlt.sargon.newAddressOfAccountOrPersonaSampleMainnet
 import com.radixdlt.sargon.newAddressOfAccountOrPersonaSampleMainnetOther
 import com.radixdlt.sargon.newAddressOfAccountOrPersonaSampleStokenet
 import com.radixdlt.sargon.newAddressOfAccountOrPersonaSampleStokenetOther
 
-@VisibleForTesting
+@UsesSampleValues
 val AddressOfAccountOrPersona.Companion.sampleMainnet: Sample<AddressOfAccountOrPersona>
     get() = object : Sample<AddressOfAccountOrPersona> {
         override fun invoke(): AddressOfAccountOrPersona = newAddressOfAccountOrPersonaSampleMainnet()
@@ -15,7 +15,7 @@ val AddressOfAccountOrPersona.Companion.sampleMainnet: Sample<AddressOfAccountOr
         override fun other(): AddressOfAccountOrPersona = newAddressOfAccountOrPersonaSampleMainnetOther()
     }
 
-@VisibleForTesting
+@UsesSampleValues
 val AddressOfAccountOrPersona.Companion.sampleStokenet: Sample<AddressOfAccountOrPersona>
     get() = object : Sample<AddressOfAccountOrPersona> {
         override fun invoke(): AddressOfAccountOrPersona = newAddressOfAccountOrPersonaSampleStokenet()

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/AppPreferencesSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/AppPreferencesSample.kt
@@ -1,11 +1,11 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.AppPreferences
 import com.radixdlt.sargon.newAppPreferencesSample
 import com.radixdlt.sargon.newAppPreferencesSampleOther
 
-@VisibleForTesting
+@UsesSampleValues
 val AppPreferences.Companion.sample: Sample<AppPreferences>
     get() = object : Sample<AppPreferences> {
 

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/AppearanceIdSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/AppearanceIdSample.kt
@@ -1,11 +1,11 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.AppearanceId
 import com.radixdlt.sargon.newAppearanceIdSample
 import com.radixdlt.sargon.newAppearanceIdSampleOther
 
-@VisibleForTesting
+@UsesSampleValues
 val AppearanceId.Companion.sample: Sample<AppearanceId>
     get() = object : Sample<AppearanceId> {
 

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/BagOfBytesSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/BagOfBytesSample.kt
@@ -1,6 +1,6 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.BagOfBytes
 import com.radixdlt.sargon.bagOfBytesAppendCafe
 import com.radixdlt.sargon.bagOfBytesAppendDeadbeef
@@ -13,38 +13,38 @@ import com.radixdlt.sargon.newBagOfBytesSampleDead
 import com.radixdlt.sargon.newBagOfBytesSampleEcad
 import com.radixdlt.sargon.newBagOfBytesSampleFade
 
-@VisibleForTesting
+@UsesSampleValues
 val acedBagOfBytesSample: BagOfBytes
     get() = newBagOfBytesSampleAced()
 
-@VisibleForTesting
+@UsesSampleValues
 val babeBagOfBytesSample: BagOfBytes
     get() = newBagOfBytesSampleBabe()
 
-@VisibleForTesting
+@UsesSampleValues
 val cafeBagOfBytesSample: BagOfBytes
     get() = newBagOfBytesSampleCafe()
 
-@VisibleForTesting
+@UsesSampleValues
 val deadBagOfBytesSample: BagOfBytes
     get() = newBagOfBytesSampleDead()
 
-@VisibleForTesting
+@UsesSampleValues
 val ecadBagOfBytesSample: BagOfBytes
     get() = newBagOfBytesSampleEcad()
 
-@VisibleForTesting
+@UsesSampleValues
 val fadeBagOfBytesSample: BagOfBytes
     get() = newBagOfBytesSampleFade()
 
-@VisibleForTesting
+@UsesSampleValues
 fun BagOfBytes.appendingCafeSample() = bagOfBytesAppendCafe(to = this)
 
-@VisibleForTesting
+@UsesSampleValues
 fun BagOfBytes.appendingDeadbeefSample() = bagOfBytesAppendDeadbeef(to = this)
 
-@VisibleForTesting
+@UsesSampleValues
 fun BagOfBytes.prependingCafeSample() = bagOfBytesPrependCafe(inFrontOf = this)
 
-@VisibleForTesting
+@UsesSampleValues
 fun BagOfBytes.prependingDeadbeefSample() = bagOfBytesPrependDeadbeef(inFrontOf = this)

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/BlobsSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/BlobsSample.kt
@@ -1,11 +1,11 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.Blobs
 import com.radixdlt.sargon.newBlobsSample
 import com.radixdlt.sargon.newBlobsSampleOther
 
-@VisibleForTesting
+@UsesSampleValues
 val Blobs.Companion.sample: Sample<Blobs>
     get() = object : Sample<Blobs> {
 

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/BuildInformationSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/BuildInformationSample.kt
@@ -1,11 +1,11 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.SargonBuildInformation
 import com.radixdlt.sargon.newSargonBuildInformationSample
 import com.radixdlt.sargon.newSargonBuildInformationSampleOther
 
-@VisibleForTesting
+@UsesSampleValues
 val SargonBuildInformation.Companion.sample: Sample<SargonBuildInformation>
     get() = object : Sample<SargonBuildInformation> {
 

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/CompiledNotarizedIntentSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/CompiledNotarizedIntentSample.kt
@@ -1,11 +1,11 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.CompiledNotarizedIntent
 import com.radixdlt.sargon.newCompiledNotarizedIntentSample
 import com.radixdlt.sargon.newCompiledNotarizedIntentSampleOther
 
-@VisibleForTesting
+@UsesSampleValues
 val CompiledNotarizedIntent.Companion.sample: Sample<CompiledNotarizedIntent>
     get() = object : Sample<CompiledNotarizedIntent> {
 

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/ComponentAddressSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/ComponentAddressSample.kt
@@ -1,13 +1,13 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.ComponentAddress
 import com.radixdlt.sargon.newComponentAddressSampleMainnetGlobal
 import com.radixdlt.sargon.newComponentAddressSampleMainnetInternal
 import com.radixdlt.sargon.newComponentAddressSampleStokenetGlobal
 import com.radixdlt.sargon.newComponentAddressSampleStokenetInternal
 
-@VisibleForTesting
+@UsesSampleValues
 val ComponentAddress.Companion.sampleMainnet: Sample<ComponentAddress>
     get() = object : Sample<ComponentAddress> {
 
@@ -16,7 +16,7 @@ val ComponentAddress.Companion.sampleMainnet: Sample<ComponentAddress>
         override fun other(): ComponentAddress = newComponentAddressSampleMainnetInternal()
     }
 
-@VisibleForTesting
+@UsesSampleValues
 val ComponentAddress.Companion.sampleStokenet: Sample<ComponentAddress>
     get() = object : Sample<ComponentAddress> {
 

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/Decimal192.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/Decimal192.kt
@@ -1,11 +1,11 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.Decimal192
 import com.radixdlt.sargon.extensions.MAX
 import com.radixdlt.sargon.extensions.toDecimal192
 
-@VisibleForTesting
+@UsesSampleValues
 val Decimal192.Companion.sample: Sample<Decimal192>
     get() = object : Sample<Decimal192> {
 

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/DependencyInformationSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/DependencyInformationSample.kt
@@ -1,11 +1,11 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.DependencyInformation
 import com.radixdlt.sargon.newDependencyInformationSample
 import com.radixdlt.sargon.newDependencyInformationSampleOther
 
-@VisibleForTesting
+@UsesSampleValues
 val DependencyInformation.Companion.sample: Sample<DependencyInformation>
     get() = object : Sample<DependencyInformation> {
         override fun invoke(): DependencyInformation = newDependencyInformationSample()

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/DerivationPathSamples.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/DerivationPathSamples.kt
@@ -1,6 +1,6 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.AccountPath
 import com.radixdlt.sargon.Bip44LikePath
 import com.radixdlt.sargon.IdentityPath
@@ -11,7 +11,7 @@ import com.radixdlt.sargon.newBip44LikePathSampleOther
 import com.radixdlt.sargon.newIdentityPathSample
 import com.radixdlt.sargon.newIdentityPathSampleOther
 
-@VisibleForTesting
+@UsesSampleValues
 val AccountPath.Companion.sample: Sample<AccountPath>
     get() = object : Sample<AccountPath> {
         override fun invoke(): AccountPath = newAccountPathSample()
@@ -19,7 +19,7 @@ val AccountPath.Companion.sample: Sample<AccountPath>
         override fun other(): AccountPath = newAccountPathSampleOther()
     }
 
-@VisibleForTesting
+@UsesSampleValues
 val IdentityPath.Companion.sample: Sample<IdentityPath>
     get() = object : Sample<IdentityPath> {
         override fun invoke(): IdentityPath = newIdentityPathSample()
@@ -27,7 +27,7 @@ val IdentityPath.Companion.sample: Sample<IdentityPath>
         override fun other(): IdentityPath = newIdentityPathSampleOther()
     }
 
-@VisibleForTesting
+@UsesSampleValues
 val Bip44LikePath.Companion.sample: Sample<Bip44LikePath>
     get() = object : Sample<Bip44LikePath> {
         override fun invoke(): Bip44LikePath = newBip44LikePathSample()

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/DisplayNameSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/DisplayNameSample.kt
@@ -1,11 +1,11 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.DisplayName
 import com.radixdlt.sargon.newDisplayNameSample
 import com.radixdlt.sargon.newDisplayNameSampleOther
 
-@VisibleForTesting
+@UsesSampleValues
 val DisplayName.Companion.sample: Sample<DisplayName>
     get() = object : Sample<DisplayName> {
 

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/FactorSourceSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/FactorSourceSample.kt
@@ -1,11 +1,11 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.newFactorSourcesSample
 import com.radixdlt.sargon.newFactorSourcesSampleOther
 
-@VisibleForTesting
+@UsesSampleValues
 fun factorSourcesSample() = newFactorSourcesSample()
 
-@VisibleForTesting
+@UsesSampleValues
 fun factorSourcesSampleOther() = newFactorSourcesSampleOther()

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/FungibleResourceIndicatorSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/FungibleResourceIndicatorSample.kt
@@ -1,0 +1,14 @@
+package com.radixdlt.sargon.samples
+
+import com.radixdlt.sargon.FungibleResourceIndicator
+import com.radixdlt.sargon.annotation.UsesSampleValues
+import com.radixdlt.sargon.newFungibleResourceIndicatorSample
+import com.radixdlt.sargon.newFungibleResourceIndicatorSampleOther
+
+@UsesSampleValues
+val FungibleResourceIndicator.Companion.sample: Sample<FungibleResourceIndicator>
+    get() = object: Sample<FungibleResourceIndicator> {
+        override fun invoke(): FungibleResourceIndicator = newFungibleResourceIndicatorSample()
+
+        override fun other(): FungibleResourceIndicator = newFungibleResourceIndicatorSampleOther()
+    }

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/GatewaySample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/GatewaySample.kt
@@ -1,11 +1,11 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.Gateway
 import com.radixdlt.sargon.gatewayMainnet
 import com.radixdlt.sargon.gatewayStokenet
 
-@VisibleForTesting
+@UsesSampleValues
 val Gateway.Companion.sampleMainnet: Sample<Gateway>
     get() = object : Sample<Gateway> {
 
@@ -14,7 +14,7 @@ val Gateway.Companion.sampleMainnet: Sample<Gateway>
         override fun other(): Gateway = invoke()
     }
 
-@VisibleForTesting
+@UsesSampleValues
 val Gateway.Companion.sampleStokenet: Sample<Gateway>
     get() = object : Sample<Gateway> {
 

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/GatewaysSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/GatewaysSample.kt
@@ -1,11 +1,11 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.Gateways
 import com.radixdlt.sargon.newGatewaysSample
 import com.radixdlt.sargon.newGatewaysSampleOther
 
-@VisibleForTesting
+@UsesSampleValues
 val Gateways.Companion.sample: Sample<Gateways>
     get() = object : Sample<Gateways> {
 

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/HashSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/HashSample.kt
@@ -1,11 +1,11 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.Hash
 import com.radixdlt.sargon.newHashSample
 import com.radixdlt.sargon.newHashSampleOther
 
-@VisibleForTesting
+@UsesSampleValues
 val Hash.Companion.sample: Sample<Hash>
     get() = object : Sample<Hash> {
 

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/HeaderSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/HeaderSample.kt
@@ -1,11 +1,11 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.Header
 import com.radixdlt.sargon.newHeaderSample
 import com.radixdlt.sargon.newHeaderSampleOther
 
-@VisibleForTesting
+@UsesSampleValues
 val Header.Companion.sample: Sample<Header>
     get() = object : Sample<Header> {
 

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/IdentityAddressSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/IdentityAddressSample.kt
@@ -1,6 +1,6 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.AccountAddress
 import com.radixdlt.sargon.IdentityAddress
 import com.radixdlt.sargon.NetworkId
@@ -11,7 +11,7 @@ import com.radixdlt.sargon.newIdentityAddressRandom
 import com.radixdlt.sargon.newIdentityAddressSampleStokenet
 import com.radixdlt.sargon.newIdentityAddressSampleStokenetOther
 
-@VisibleForTesting
+@UsesSampleValues
 object IdentityAddressSampleMainnet: SampleWithRandomValues<IdentityAddress> {
     override fun invoke(): IdentityAddress = newIdentityAddressSampleMainnet()
 
@@ -22,11 +22,11 @@ object IdentityAddressSampleMainnet: SampleWithRandomValues<IdentityAddress> {
     )
 }
 
-@VisibleForTesting
+@UsesSampleValues
 val IdentityAddress.Companion.sampleMainnet: IdentityAddressSampleMainnet
     get() = IdentityAddressSampleMainnet
 
-@VisibleForTesting
+@UsesSampleValues
 object IdentityAddressSampleStokenet: SampleWithRandomValues<IdentityAddress> {
     override fun invoke(): IdentityAddress = newIdentityAddressSampleStokenet()
 
@@ -37,11 +37,11 @@ object IdentityAddressSampleStokenet: SampleWithRandomValues<IdentityAddress> {
     )
 }
 
-@VisibleForTesting
+@UsesSampleValues
 val IdentityAddress.Companion.sampleStokenet: IdentityAddressSampleStokenet
     get() = IdentityAddressSampleStokenet
 
-@VisibleForTesting
+@UsesSampleValues
 fun IdentityAddress.Companion.sampleRandom(
     networkId: NetworkId
 ) = newIdentityAddressRandom(networkId = networkId)

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/IntentHashSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/IntentHashSample.kt
@@ -1,11 +1,11 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.IntentHash
 import com.radixdlt.sargon.newIntentHashSample
 import com.radixdlt.sargon.newIntentHashSampleOther
 
-@VisibleForTesting
+@UsesSampleValues
 val IntentHash.Companion.sample: Sample<IntentHash>
     get() = object : Sample<IntentHash> {
 

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/IntentSignatureSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/IntentSignatureSample.kt
@@ -1,11 +1,11 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.IntentSignature
 import com.radixdlt.sargon.newIntentSignatureSample
 import com.radixdlt.sargon.newIntentSignatureSampleOther
 
-@VisibleForTesting
+@UsesSampleValues
 val IntentSignature.Companion.sample: Sample<IntentSignature>
     get() = object : Sample<IntentSignature> {
 

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/LegacyOlympiaAccountAddressSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/LegacyOlympiaAccountAddressSample.kt
@@ -1,11 +1,11 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.LegacyOlympiaAccountAddress
 import com.radixdlt.sargon.newLegacyOlympiaAccountAddressSample
 import com.radixdlt.sargon.newLegacyOlympiaAccountAddressSampleOther
 
-@VisibleForTesting
+@UsesSampleValues
 val LegacyOlympiaAccountAddress.Companion.sample: Sample<LegacyOlympiaAccountAddress>
     get() = object : Sample<LegacyOlympiaAccountAddress> {
         override fun invoke(): LegacyOlympiaAccountAddress = newLegacyOlympiaAccountAddressSample()

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/MessageSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/MessageSample.kt
@@ -1,0 +1,14 @@
+package com.radixdlt.sargon.samples
+
+import com.radixdlt.sargon.Message
+import com.radixdlt.sargon.annotation.UsesSampleValues
+import com.radixdlt.sargon.newMessagePlaintextSample
+import com.radixdlt.sargon.newMessagePlaintextSampleOther
+
+@UsesSampleValues
+val Message.Companion.samplePlaintext: Sample<Message>
+    get() = object: Sample<Message> {
+        override fun invoke(): Message = newMessagePlaintextSample()
+
+        override fun other(): Message = newMessagePlaintextSampleOther()
+    }

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/MnemonicSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/MnemonicSample.kt
@@ -1,11 +1,11 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.Mnemonic
 import com.radixdlt.sargon.newMnemonicSample
 import com.radixdlt.sargon.newMnemonicSampleOther
 
-@VisibleForTesting
+@UsesSampleValues
 val Mnemonic.Companion.sample: Sample<Mnemonic>
     get() = object : Sample<Mnemonic> {
 

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/NetworkIdSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/NetworkIdSample.kt
@@ -1,9 +1,9 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.NetworkId
 
-@VisibleForTesting
+@UsesSampleValues
 val NetworkId.Companion.sample: Sample<NetworkId>
     get() = object : Sample<NetworkId> {
 

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/NonFungibleGlobalIdSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/NonFungibleGlobalIdSample.kt
@@ -1,11 +1,11 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.NonFungibleGlobalId
 import com.radixdlt.sargon.newNonFungibleGlobalIdSample
 import com.radixdlt.sargon.newNonFungibleGlobalIdSampleOther
 
-@VisibleForTesting
+@UsesSampleValues
 val NonFungibleGlobalId.Companion.sample: Sample<NonFungibleGlobalId>
     get() = object : Sample<NonFungibleGlobalId> {
 

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/NonFungibleLocalIdSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/NonFungibleLocalIdSample.kt
@@ -1,11 +1,11 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.NonFungibleLocalId
 import com.radixdlt.sargon.newNonFungibleLocalIdSample
 import com.radixdlt.sargon.newNonFungibleLocalIdSampleOther
 
-@VisibleForTesting
+@UsesSampleValues
 val NonFungibleLocalId.Companion.sample: Sample<NonFungibleLocalId>
     get() = object : Sample<NonFungibleLocalId> {
 

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/NonFungibleLocalIdSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/NonFungibleLocalIdSample.kt
@@ -2,14 +2,17 @@ package com.radixdlt.sargon.samples
 
 import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.NonFungibleLocalId
+import com.radixdlt.sargon.newNonFungibleLocalIdRandom
 import com.radixdlt.sargon.newNonFungibleLocalIdSample
 import com.radixdlt.sargon.newNonFungibleLocalIdSampleOther
 
 @UsesSampleValues
-val NonFungibleLocalId.Companion.sample: Sample<NonFungibleLocalId>
-    get() = object : Sample<NonFungibleLocalId> {
+val NonFungibleLocalId.Companion.sample: SampleWithRandomValues<NonFungibleLocalId>
+    get() = object : SampleWithRandomValues<NonFungibleLocalId> {
 
         override fun invoke(): NonFungibleLocalId = newNonFungibleLocalIdSample()
 
         override fun other(): NonFungibleLocalId = newNonFungibleLocalIdSampleOther()
+
+        override fun random(): NonFungibleLocalId = newNonFungibleLocalIdRandom()
     }

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/NonFungibleResourceAddressSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/NonFungibleResourceAddressSample.kt
@@ -1,13 +1,13 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.NonFungibleResourceAddress
 import com.radixdlt.sargon.newNonFungibleResourceAddressSampleMainnet
 import com.radixdlt.sargon.newNonFungibleResourceAddressSampleMainnetOther
 import com.radixdlt.sargon.newNonFungibleResourceAddressSampleStokenet
 import com.radixdlt.sargon.newNonFungibleResourceAddressSampleStokenetOther
 
-@VisibleForTesting
+@UsesSampleValues
 val NonFungibleResourceAddress.Companion.sampleMainnet: Sample<NonFungibleResourceAddress>
     get() = object : Sample<NonFungibleResourceAddress> {
 
@@ -19,7 +19,7 @@ val NonFungibleResourceAddress.Companion.sampleMainnet: Sample<NonFungibleResour
 
     }
 
-@VisibleForTesting
+@UsesSampleValues
 val NonFungibleResourceAddress.Companion.sampleStokenet: Sample<NonFungibleResourceAddress>
     get() = object : Sample<NonFungibleResourceAddress> {
 

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/NonFungibleResourceIndicatorSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/NonFungibleResourceIndicatorSample.kt
@@ -1,0 +1,16 @@
+package com.radixdlt.sargon.samples
+
+import com.radixdlt.sargon.NonFungibleResourceIndicator
+import com.radixdlt.sargon.annotation.UsesSampleValues
+import com.radixdlt.sargon.newNonFungibleResourceIndicatorSample
+import com.radixdlt.sargon.newNonFungibleResourceIndicatorSampleOther
+
+@UsesSampleValues
+val NonFungibleResourceIndicator.Companion.sample: Sample<NonFungibleResourceIndicator>
+    get() = object : Sample<NonFungibleResourceIndicator> {
+        override fun invoke(): NonFungibleResourceIndicator =
+            newNonFungibleResourceIndicatorSample()
+
+        override fun other(): NonFungibleResourceIndicator =
+            newNonFungibleResourceIndicatorSampleOther()
+    }

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/NonceSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/NonceSample.kt
@@ -1,11 +1,11 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.Nonce
 import com.radixdlt.sargon.newNonceSample
 import com.radixdlt.sargon.newNonceSampleOther
 
-@VisibleForTesting
+@UsesSampleValues
 val Nonce.Companion.sample: Sample<Nonce>
     get() = object : Sample<Nonce> {
 

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/NotarizedTransactionSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/NotarizedTransactionSample.kt
@@ -1,11 +1,11 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.NotarizedTransaction
 import com.radixdlt.sargon.newNotarizedTransactionSample
 import com.radixdlt.sargon.newNotarizedTransactionSampleOther
 
-@VisibleForTesting
+@UsesSampleValues
 val NotarizedTransaction.Companion.sample: Sample<NotarizedTransaction>
     get() = object : Sample<NotarizedTransaction> {
 

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/NotarySignatureSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/NotarySignatureSample.kt
@@ -1,11 +1,11 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.NotarySignature
 import com.radixdlt.sargon.newNotarySignatureSample
 import com.radixdlt.sargon.newNotarySignatureSampleOther
 
-@VisibleForTesting
+@UsesSampleValues
 val NotarySignature.Companion.sample: Sample<NotarySignature>
     get() = object : Sample<NotarySignature> {
 

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/PackageAddressSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/PackageAddressSample.kt
@@ -1,6 +1,6 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.AccountAddress
 import com.radixdlt.sargon.NetworkId
 import com.radixdlt.sargon.PackageAddress
@@ -11,7 +11,7 @@ import com.radixdlt.sargon.newPackageAddressRandom
 import com.radixdlt.sargon.newPackageAddressSampleStokenet
 import com.radixdlt.sargon.newPackageAddressSampleStokenetOther
 
-@VisibleForTesting
+@UsesSampleValues
 object PackageAddressSampleMainnet: SampleWithRandomValues<PackageAddress> {
     override fun invoke(): PackageAddress = newPackageAddressSampleMainnet()
 
@@ -22,11 +22,11 @@ object PackageAddressSampleMainnet: SampleWithRandomValues<PackageAddress> {
     )
 }
 
-@VisibleForTesting
+@UsesSampleValues
 val PackageAddress.Companion.sampleMainnet: PackageAddressSampleMainnet
     get() = PackageAddressSampleMainnet
 
-@VisibleForTesting
+@UsesSampleValues
 object PackageAddressSampleStokenet: SampleWithRandomValues<PackageAddress> {
     override fun invoke(): PackageAddress = newPackageAddressSampleStokenet()
 
@@ -37,11 +37,11 @@ object PackageAddressSampleStokenet: SampleWithRandomValues<PackageAddress> {
     )
 }
 
-@VisibleForTesting
+@UsesSampleValues
 val PackageAddress.Companion.sampleStokenet: PackageAddressSampleStokenet
     get() = PackageAddressSampleStokenet
 
-@VisibleForTesting
+@UsesSampleValues
 fun PackageAddress.Companion.sampleRandom(
     networkId: NetworkId
 ) = newPackageAddressRandom(networkId = networkId)

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/PoolAddressSampleMainnet.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/PoolAddressSampleMainnet.kt
@@ -1,6 +1,6 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.NetworkId
 import com.radixdlt.sargon.PackageAddress
 import com.radixdlt.sargon.PoolAddress
@@ -13,7 +13,7 @@ import com.radixdlt.sargon.newPoolAddressSampleStokenetMulti
 import com.radixdlt.sargon.newPoolAddressSampleStokenetSingle
 import com.radixdlt.sargon.newPoolAddressSampleStokenetTwo
 
-@VisibleForTesting
+@UsesSampleValues
 object PoolAddressSampleMainnet: SampleWithRandomValues<PoolAddress> {
     override fun invoke(): PoolAddress = single
 
@@ -31,7 +31,7 @@ object PoolAddressSampleMainnet: SampleWithRandomValues<PoolAddress> {
         get() = newPoolAddressSampleMainnetMulti()
 }
 
-@VisibleForTesting
+@UsesSampleValues
 object PoolAddressSampleStokenet: SampleWithRandomValues<PoolAddress> {
     override fun invoke(): PoolAddress = single
 
@@ -49,15 +49,15 @@ object PoolAddressSampleStokenet: SampleWithRandomValues<PoolAddress> {
         get() = newPoolAddressSampleStokenetMulti()
 }
 
-@VisibleForTesting
+@UsesSampleValues
 val PoolAddress.Companion.sampleMainnet: PoolAddressSampleMainnet
     get() = PoolAddressSampleMainnet
 
-@VisibleForTesting
+@UsesSampleValues
 val PoolAddress.Companion.sampleStokenet: PoolAddressSampleStokenet
     get() = PoolAddressSampleStokenet
 
-@VisibleForTesting
+@UsesSampleValues
 fun PoolAddress.Companion.sampleRandom(
     networkId: NetworkId
 ) = newPoolAddressRandom(networkId = networkId)

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/ProfileSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/ProfileSample.kt
@@ -1,11 +1,11 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.Profile
 import com.radixdlt.sargon.newProfileSample
 import com.radixdlt.sargon.newProfileSampleOther
 
-@VisibleForTesting
+@UsesSampleValues
 val Profile.Companion.sample: Sample<Profile>
     get() = object : Sample<Profile> {
 

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/PublicKeyHashSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/PublicKeyHashSample.kt
@@ -1,11 +1,11 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.PublicKeyHash
 import com.radixdlt.sargon.newPublicKeyHashSample
 import com.radixdlt.sargon.newPublicKeyHashSampleOther
 
-@VisibleForTesting
+@UsesSampleValues
 val PublicKeyHash.Companion.sample: Sample<PublicKeyHash>
     get() = object : Sample<PublicKeyHash> {
 

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/PublicKeySample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/PublicKeySample.kt
@@ -1,6 +1,6 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.PublicKey
 import com.radixdlt.sargon.newEd25519PublicKeySample
 import com.radixdlt.sargon.newEd25519PublicKeySampleOther
@@ -9,7 +9,7 @@ import com.radixdlt.sargon.newPublicKeySampleOther
 import com.radixdlt.sargon.newSecp256k1PublicKeySample
 import com.radixdlt.sargon.newSecp256k1PublicKeySampleOther
 
-@VisibleForTesting
+@UsesSampleValues
 val PublicKey.Companion.sample: Sample<PublicKey>
     get() = object : Sample<PublicKey> {
 
@@ -18,7 +18,7 @@ val PublicKey.Companion.sample: Sample<PublicKey>
         override fun other(): PublicKey = newPublicKeySampleOther()
     }
 
-@VisibleForTesting
+@UsesSampleValues
 val PublicKey.Ed25519.Companion.sample: Sample<PublicKey.Ed25519>
     get() = object : Sample<PublicKey.Ed25519> {
 
@@ -27,7 +27,7 @@ val PublicKey.Ed25519.Companion.sample: Sample<PublicKey.Ed25519>
         override fun other(): PublicKey.Ed25519 = PublicKey.Ed25519(newEd25519PublicKeySampleOther())
     }
 
-@VisibleForTesting
+@UsesSampleValues
 val PublicKey.Secp256k1.Companion.sample: Sample<PublicKey.Secp256k1>
     get() = object : Sample<PublicKey.Secp256k1> {
 

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/RadixConnectPasswordSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/RadixConnectPasswordSample.kt
@@ -1,11 +1,11 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.RadixConnectPassword
 import com.radixdlt.sargon.newRadixConnectPasswordSample
 import com.radixdlt.sargon.newRadixConnectPasswordSampleOther
 
-@VisibleForTesting
+@UsesSampleValues
 val RadixConnectPassword.Companion.sample: Sample<RadixConnectPassword>
     get() = object : Sample<RadixConnectPassword> {
 

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/ResourceAddressSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/ResourceAddressSample.kt
@@ -1,6 +1,6 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.NetworkId
 import com.radixdlt.sargon.PoolAddress
 import com.radixdlt.sargon.ResourceAddress
@@ -14,7 +14,7 @@ import com.radixdlt.sargon.newResourceAddressSampleStokenetGcTokens
 import com.radixdlt.sargon.newResourceAddressSampleStokenetGum
 import com.radixdlt.sargon.newResourceAddressSampleStokenetXrd
 
-@VisibleForTesting
+@UsesSampleValues
 object ResourceAddressSampleMainnet: SampleWithRandomValues<ResourceAddress> {
     override val all: List<ResourceAddress>
         get() = listOf(
@@ -41,7 +41,7 @@ object ResourceAddressSampleMainnet: SampleWithRandomValues<ResourceAddress> {
         get() = newResourceAddressSampleMainnetNftGcMembership()
 }
 
-@VisibleForTesting
+@UsesSampleValues
 object ResourceAddressSampleStokenet: SampleWithRandomValues<ResourceAddress> {
     override val all: List<ResourceAddress>
         get() = listOf(
@@ -72,15 +72,15 @@ object ResourceAddressSampleStokenet: SampleWithRandomValues<ResourceAddress> {
         get() = newResourceAddressSampleStokenetCandy()
 }
 
-@VisibleForTesting
+@UsesSampleValues
 val ResourceAddress.Companion.sampleMainnet: ResourceAddressSampleMainnet
     get() = ResourceAddressSampleMainnet
 
-@VisibleForTesting
+@UsesSampleValues
 val ResourceAddress.Companion.sampleStokenet: ResourceAddressSampleStokenet
     get() = ResourceAddressSampleStokenet
 
-@VisibleForTesting
+@UsesSampleValues
 fun ResourceAddress.Companion.sampleRandom(
     networkId: NetworkId
 ) = newResourceAddressRandom(networkId = networkId)

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/ResourceIndicatorSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/ResourceIndicatorSample.kt
@@ -1,0 +1,14 @@
+package com.radixdlt.sargon.samples
+
+import com.radixdlt.sargon.ResourceIndicator
+import com.radixdlt.sargon.annotation.UsesSampleValues
+import com.radixdlt.sargon.newResourceIndicatorSample
+import com.radixdlt.sargon.newResourceIndicatorSampleOther
+
+@UsesSampleValues
+val ResourceIndicator.Companion.sample: Sample<ResourceIndicator>
+    get() = object: Sample<ResourceIndicator> {
+        override fun invoke(): ResourceIndicator = newResourceIndicatorSample()
+
+        override fun other(): ResourceIndicator = newResourceIndicatorSampleOther()
+    }

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/Sample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/Sample.kt
@@ -1,8 +1,8 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 
-@VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
+@UsesSampleValues
 interface Sample<T> {
 
     val all: List<T>
@@ -14,6 +14,7 @@ interface Sample<T> {
 
 }
 
+@UsesSampleValues
 interface SampleWithRandomValues<T>: Sample<T> {
 
     override val all: List<T>

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/SignatureSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/SignatureSample.kt
@@ -1,6 +1,6 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.Ed25519Signature
 import com.radixdlt.sargon.Secp256k1Signature
 import com.radixdlt.sargon.Signature
@@ -11,7 +11,7 @@ import com.radixdlt.sargon.newSecp256k1SignatureSampleOther
 import com.radixdlt.sargon.newSignatureSample
 import com.radixdlt.sargon.newSignatureSampleOther
 
-@VisibleForTesting
+@UsesSampleValues
 val Signature.Companion.sample: Sample<Signature>
     get() = object : Sample<Signature> {
         override fun invoke(): Signature = newSignatureSample()
@@ -19,7 +19,7 @@ val Signature.Companion.sample: Sample<Signature>
         override fun other(): Signature = newSignatureSampleOther()
     }
 
-@VisibleForTesting
+@UsesSampleValues
 val Ed25519Signature.Companion.sample: Sample<Ed25519Signature>
     get() = object : Sample<Ed25519Signature> {
         override fun invoke(): Ed25519Signature = newEd25519SignatureSample()
@@ -27,7 +27,7 @@ val Ed25519Signature.Companion.sample: Sample<Ed25519Signature>
         override fun other(): Ed25519Signature = newEd25519SignatureSampleOther()
     }
 
-@VisibleForTesting
+@UsesSampleValues
 val Secp256k1Signature.Companion.sample: Sample<Secp256k1Signature>
     get() = object : Sample<Secp256k1Signature> {
         override fun invoke(): Secp256k1Signature = newSecp256k1SignatureSample()

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/SignatureWithPublicKeySample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/SignatureWithPublicKeySample.kt
@@ -1,11 +1,11 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.SignatureWithPublicKey
 import com.radixdlt.sargon.newSignatureWithPublicKeySample
 import com.radixdlt.sargon.newSignatureWithPublicKeySampleOther
 
-@VisibleForTesting
+@UsesSampleValues
 val SignatureWithPublicKey.Companion.sample: Sample<SignatureWithPublicKey>
     get() = object : Sample<SignatureWithPublicKey> {
 

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/SignedIntentHashSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/SignedIntentHashSample.kt
@@ -1,11 +1,11 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.SignedIntentHash
 import com.radixdlt.sargon.newSignedIntentHashSample
 import com.radixdlt.sargon.newSignedIntentHashSampleOther
 
-@VisibleForTesting
+@UsesSampleValues
 val SignedIntentHash.Companion.sample: Sample<SignedIntentHash>
     get() = object : Sample<SignedIntentHash> {
 

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/SignedIntentSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/SignedIntentSample.kt
@@ -1,11 +1,11 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.SignedIntent
 import com.radixdlt.sargon.newSignedIntentSample
 import com.radixdlt.sargon.newSignedIntentSampleOther
 
-@VisibleForTesting
+@UsesSampleValues
 val SignedIntent.Companion.sample: Sample<SignedIntent>
     get() = object : Sample<SignedIntent> {
 

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/StakeClaimSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/StakeClaimSample.kt
@@ -1,11 +1,11 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.StakeClaim
 import com.radixdlt.sargon.newStakeClaimSample
 import com.radixdlt.sargon.newStakeClaimSampleOther
 
-@VisibleForTesting
+@UsesSampleValues
 val StakeClaim.Companion.sample: Sample<StakeClaim>
     get() = object : Sample<StakeClaim> {
         override fun invoke(): StakeClaim = newStakeClaimSample()

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/ThirdPartyDepositSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/ThirdPartyDepositSample.kt
@@ -1,11 +1,11 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.ThirdPartyDeposits
 import com.radixdlt.sargon.newThirdPartyDepositsSample
 import com.radixdlt.sargon.newThirdPartyDepositsSampleOther
 
-@VisibleForTesting
+@UsesSampleValues
 val ThirdPartyDeposits.Companion.sample: Sample<ThirdPartyDeposits>
     get() = object : Sample<ThirdPartyDeposits> {
         override fun invoke(): ThirdPartyDeposits = newThirdPartyDepositsSample()

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/TransactionIntentSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/TransactionIntentSample.kt
@@ -1,11 +1,11 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.TransactionIntent
 import com.radixdlt.sargon.newTransactionIntentSample
 import com.radixdlt.sargon.newTransactionIntentSampleOther
 
-@VisibleForTesting
+@UsesSampleValues
 val TransactionIntent.Companion.sample: Sample<TransactionIntent>
     get() = object : Sample<TransactionIntent> {
 

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/TransactionManifestSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/TransactionManifestSample.kt
@@ -1,6 +1,6 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.PerAssetTransfers
 import com.radixdlt.sargon.TransactionManifest
 import com.radixdlt.sargon.newPerAssetTransfersSample
@@ -8,7 +8,7 @@ import com.radixdlt.sargon.newPerAssetTransfersSampleOther
 import com.radixdlt.sargon.newTransactionManifestSample
 import com.radixdlt.sargon.newTransactionManifestSampleOther
 
-@VisibleForTesting
+@UsesSampleValues
 val TransactionManifest.Companion.sample: Sample<TransactionManifest>
     get() = object : Sample<TransactionManifest> {
 
@@ -18,7 +18,7 @@ val TransactionManifest.Companion.sample: Sample<TransactionManifest>
 
     }
 
-@VisibleForTesting
+@UsesSampleValues
 val PerAssetTransfers.Companion.sample: Sample<PerAssetTransfers>
     get() = object : Sample<PerAssetTransfers> {
 

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/ValidatorAddressSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/ValidatorAddressSample.kt
@@ -1,6 +1,6 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.NetworkId
 import com.radixdlt.sargon.ResourceAddress
 import com.radixdlt.sargon.ValidatorAddress
@@ -11,7 +11,7 @@ import com.radixdlt.sargon.newValidatorAddressRandom
 import com.radixdlt.sargon.newValidatorAddressSampleStokenet
 import com.radixdlt.sargon.newValidatorAddressSampleStokenetOther
 
-@VisibleForTesting
+@UsesSampleValues
 object ValidatorAddressSampleMainnet: SampleWithRandomValues<ValidatorAddress> {
     override fun invoke(): ValidatorAddress = newValidatorAddressSampleMainnet()
 
@@ -22,11 +22,11 @@ object ValidatorAddressSampleMainnet: SampleWithRandomValues<ValidatorAddress> {
     )
 }
 
-@VisibleForTesting
+@UsesSampleValues
 val ValidatorAddress.Companion.sampleMainnet: ValidatorAddressSampleMainnet
     get() = ValidatorAddressSampleMainnet
 
-@VisibleForTesting
+@UsesSampleValues
 object ValidatorAddressSampleStokenet: SampleWithRandomValues<ValidatorAddress> {
     override fun invoke(): ValidatorAddress = newValidatorAddressSampleStokenet()
 
@@ -37,11 +37,11 @@ object ValidatorAddressSampleStokenet: SampleWithRandomValues<ValidatorAddress> 
     )
 }
 
-@VisibleForTesting
+@UsesSampleValues
 val ValidatorAddress.Companion.sampleStokenet: ValidatorAddressSampleStokenet
     get() = ValidatorAddressSampleStokenet
 
-@VisibleForTesting
+@UsesSampleValues
 fun ValidatorAddress.Companion.sampleRandom(
     networkId: NetworkId
 ) = newValidatorAddressRandom(networkId = networkId)

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/VaultAddressSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/VaultAddressSample.kt
@@ -1,6 +1,6 @@
 package com.radixdlt.sargon.samples
 
-import androidx.annotation.VisibleForTesting
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.NetworkId
 import com.radixdlt.sargon.ValidatorAddress
 import com.radixdlt.sargon.VaultAddress
@@ -11,7 +11,7 @@ import com.radixdlt.sargon.newVaultAddressRandom
 import com.radixdlt.sargon.newVaultAddressSampleStokenetFungible
 import com.radixdlt.sargon.newVaultAddressSampleStokenetNonFungible
 
-@VisibleForTesting
+@UsesSampleValues
 object VaultAddressSampleMainnet: SampleWithRandomValues<VaultAddress> {
     override fun invoke(): VaultAddress = newVaultAddressSampleMainnetFungible()
 
@@ -20,11 +20,11 @@ object VaultAddressSampleMainnet: SampleWithRandomValues<VaultAddress> {
     override fun random(): VaultAddress = newVaultAddressRandom(networkId = NetworkId.MAINNET)
 }
 
-@VisibleForTesting
+@UsesSampleValues
 val VaultAddress.Companion.sampleMainnet: VaultAddressSampleMainnet
     get() = VaultAddressSampleMainnet
 
-@VisibleForTesting
+@UsesSampleValues
 object VaultAddressSampleStokenet: SampleWithRandomValues<VaultAddress> {
     override fun invoke(): VaultAddress = newVaultAddressSampleStokenetFungible()
 
@@ -35,11 +35,11 @@ object VaultAddressSampleStokenet: SampleWithRandomValues<VaultAddress> {
     )
 }
 
-@VisibleForTesting
+@UsesSampleValues
 val VaultAddress.Companion.sampleStokenet: VaultAddressSampleStokenet
     get() = VaultAddressSampleStokenet
 
-@VisibleForTesting
+@UsesSampleValues
 fun VaultAddress.Companion.sampleRandom(
     networkId: NetworkId
 ) = newVaultAddressRandom(networkId = networkId)

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/FungibleResourceIndicatorTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/FungibleResourceIndicatorTest.kt
@@ -1,0 +1,18 @@
+package com.radixdlt.sargon
+
+import com.radixdlt.sargon.extensions.amount
+import com.radixdlt.sargon.extensions.toDecimal192
+import com.radixdlt.sargon.samples.Sample
+import com.radixdlt.sargon.samples.sample
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class FungibleResourceIndicatorTest: SampleTestable<FungibleResourceIndicator> {
+    override val samples: List<Sample<FungibleResourceIndicator>>
+        get() = listOf(FungibleResourceIndicator.sample)
+
+    @Test
+    fun testAmount() {
+        assertEquals(1.toDecimal192(), FungibleResourceIndicator.sample().amount)
+    }
+}

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/MessageTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/MessageTest.kt
@@ -1,0 +1,19 @@
+package com.radixdlt.sargon
+
+import com.radixdlt.sargon.extensions.plaintext
+import com.radixdlt.sargon.samples.Sample
+import com.radixdlt.sargon.samples.samplePlaintext
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class MessageTest: SampleTestable<Message> {
+
+    override val samples: List<Sample<Message>>
+        get() = listOf(Message.samplePlaintext)
+
+    @Test
+    fun testStringRoundtrip() {
+        assertEquals("Hello Radix!", Message.plaintext("Hello Radix!").plaintext)
+    }
+
+}

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/NonFungibleResourceIndicatorTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/NonFungibleResourceIndicatorTest.kt
@@ -1,0 +1,24 @@
+package com.radixdlt.sargon
+
+import com.radixdlt.sargon.extensions.ids
+import com.radixdlt.sargon.extensions.init
+import com.radixdlt.sargon.samples.Sample
+import com.radixdlt.sargon.samples.sample
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class NonFungibleResourceIndicatorTest: SampleTestable<NonFungibleResourceIndicator> {
+    override val samples: List<Sample<NonFungibleResourceIndicator>>
+        get() = listOf(NonFungibleResourceIndicator.sample)
+
+    @Test
+    fun testIds() {
+        assertEquals(
+            listOf(
+                NonFungibleLocalId.init("{deaddeaddeaddead-deaddeaddeaddead-deaddeaddeaddead-deaddeaddeaddead}"),
+                NonFungibleLocalId.init("<foobar>")
+            ),
+            NonFungibleResourceIndicator.sample().ids
+        )
+    }
+}

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/ResourceAddressTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/ResourceAddressTest.kt
@@ -4,6 +4,7 @@ import com.radixdlt.sargon.extensions.formatted
 import com.radixdlt.sargon.extensions.init
 import com.radixdlt.sargon.extensions.isFungible
 import com.radixdlt.sargon.extensions.isNonFungible
+import com.radixdlt.sargon.extensions.isXRD
 import com.radixdlt.sargon.extensions.networkId
 import com.radixdlt.sargon.extensions.string
 import com.radixdlt.sargon.extensions.xrd
@@ -51,6 +52,12 @@ class ResourceAddressTest: SampleTestable<ResourceAddress> {
             addressString,
             address.formatted(format = AddressFormat.RAW)
         )
+    }
+
+    @Test
+    fun testIsXrd() {
+        assertTrue(ResourceAddress.sampleMainnet.xrd.isXRD)
+        assertFalse(ResourceAddress.sampleMainnet.candy.isXRD)
     }
 
 }

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/ResourceIndicatorTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/ResourceIndicatorTest.kt
@@ -1,0 +1,23 @@
+package com.radixdlt.sargon
+
+import com.radixdlt.sargon.extensions.address
+import com.radixdlt.sargon.samples.Sample
+import com.radixdlt.sargon.samples.sample
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Test
+
+class ResourceIndicatorTest: SampleTestable<ResourceIndicator> {
+    override val samples: List<Sample<ResourceIndicator>>
+        get() = listOf(ResourceIndicator.sample)
+
+    @Test
+    fun testIds() {
+        val sample = ResourceIndicator.sample()
+        assertEquals(
+            (sample as ResourceIndicator.Fungible).resourceAddress,
+            sample.address
+        )
+        assertInstanceOf(ResourceIndicator.Fungible::class.java, sample)
+    }
+}


### PR DESCRIPTION
* New annotation named `@UsesSampleValues` which replaces the `@VisibleForTesting`. It is more versatile since if a sample is used by src code it will **fail during compile time** except if we specifically opt-in using them (which we have to do in composable previews). 
* Some more missing extensions and tests