### PR TITLE
propagate ret errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1959,7 +1959,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "assert-json-diff",
  "bip32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "0.6.5"
+version = "0.6.6"
 edition = "2021"
 build = "build.rs"
 

--- a/apple/Sources/Sargon/Extensions/Methods/Address/AccessControllerAddress+Wrap+Functions.swift
+++ b/apple/Sources/Sargon/Extensions/Methods/Address/AccessControllerAddress+Wrap+Functions.swift
@@ -18,9 +18,6 @@ extension AccessControllerAddress {
 		accessControllerAddressNetworkId(address: self)
 	}
 	
-	public func embed() -> Address {
-		.accessController(self)
-	}
 }
 
 #if DEBUG

--- a/apple/Sources/Sargon/Extensions/Methods/Address/AccountAddress+Wrap+Functions.swift
+++ b/apple/Sources/Sargon/Extensions/Methods/Address/AccountAddress+Wrap+Functions.swift
@@ -54,9 +54,7 @@ extension AccountAddress {
         formatted(AddressFormat.default)
 	}
 	
-	public func embed() -> Address {
-		.account(self)
-	}
+	
 }
 
 #if DEBUG

--- a/apple/Sources/Sargon/Extensions/Methods/Address/AddressOfAccountOrPersona+Wrap+Functions.swift
+++ b/apple/Sources/Sargon/Extensions/Methods/Address/AddressOfAccountOrPersona+Wrap+Functions.swift
@@ -18,12 +18,7 @@ extension AddressOfAccountOrPersona {
 		addressOfAccountOrPersonaFormatted(address: self, format: format)
 	}
 	
-	public func embed() -> Address {
-		switch self {
-		case let .account(accountAddress): Address.account(accountAddress)
-		case let .identity(identityAddress): Address.identity(identityAddress)
-		}
-	}
+
 }
 
 #if DEBUG

--- a/apple/Sources/Sargon/Extensions/Methods/Address/ComponentAddress+Wrap+Functions.swift
+++ b/apple/Sources/Sargon/Extensions/Methods/Address/ComponentAddress+Wrap+Functions.swift
@@ -17,8 +17,15 @@ extension ComponentAddress {
 	public var networkID: NetworkId {
 		componentAddressNetworkId(address: self)
 	}
-	public func embed() -> Address {
-		.component(self)
+
+	/// If the `EntityType == .globalGenericComponent`
+	public var isGlobal: Bool {
+		componentAddressIsGlobal(address: self)
+	}
+	
+	/// If the `EntityType == .InternalGenericComponent`
+	public var isInternal: Bool {
+		componentAddressIsInternal(address: self)
 	}
 }
 

--- a/apple/Sources/Sargon/Extensions/Methods/Address/IdentityAddress+Wrap+Functions.swift
+++ b/apple/Sources/Sargon/Extensions/Methods/Address/IdentityAddress+Wrap+Functions.swift
@@ -25,9 +25,7 @@ extension IdentityAddress {
 		identityAddressNetworkId(address: self)
 	}
 	
-	public func embed() -> Address {
-		.identity(self)
-	}
+
 }
 
 #if DEBUG

--- a/apple/Sources/Sargon/Extensions/Methods/Address/NonFungibleResourceAddress+Wrap+Functions.swift
+++ b/apple/Sources/Sargon/Extensions/Methods/Address/NonFungibleResourceAddress+Wrap+Functions.swift
@@ -22,9 +22,7 @@ extension NonFungibleResourceAddress {
         asResourceAddress.formatted(format)
     }
 	
-	public func embed() -> Address {
-		.resource(asResourceAddress)
-	}
+
 	
 }
 

--- a/apple/Sources/Sargon/Extensions/Methods/Address/PackageAddress+Wrap+Functions.swift
+++ b/apple/Sources/Sargon/Extensions/Methods/Address/PackageAddress+Wrap+Functions.swift
@@ -17,10 +17,6 @@ extension PackageAddress {
 	public var networkID: NetworkId {
 		packageAddressNetworkId(address: self)
 	}
-	
-	public func embed() -> Address {
-		.package(self)
-	}
 }
 
 #if DEBUG

--- a/apple/Sources/Sargon/Extensions/Methods/Address/PoolAddress+Wrap+Functions.swift
+++ b/apple/Sources/Sargon/Extensions/Methods/Address/PoolAddress+Wrap+Functions.swift
@@ -22,10 +22,7 @@ extension PoolAddress {
 	public var poolKind: PoolKind {
 		poolAddressKind(address: self)
 	}
-	
-	public func embed() -> Address {
-		.pool(self)
-	}
+
 }
 
 #if DEBUG

--- a/apple/Sources/Sargon/Extensions/Methods/Address/ResourceAddress+Wrap+Functions.swift
+++ b/apple/Sources/Sargon/Extensions/Methods/Address/ResourceAddress+Wrap+Functions.swift
@@ -32,10 +32,7 @@ extension ResourceAddress {
 	public static func xrd(on networkID: NetworkID) -> Self {
 		xrdAddressOfNetwork(networkId: networkID)
 	}
-	
-	public func embed() -> Address {
-		.resource(self)
-	}
+
 }
 
 #if DEBUG

--- a/apple/Sources/Sargon/Extensions/Methods/Address/ValidatorAddress+Wrap+Functions.swift
+++ b/apple/Sources/Sargon/Extensions/Methods/Address/ValidatorAddress+Wrap+Functions.swift
@@ -18,9 +18,6 @@ extension ValidatorAddress {
 		validatorAddressNetworkId(address: self)
 	}
 	
-	public func embed() -> Address {
-		.validator(self)
-	}
 }
 
 #if DEBUG

--- a/apple/Sources/Sargon/Extensions/Methods/Address/VaultAddress+Wrap+Functions.swift
+++ b/apple/Sources/Sargon/Extensions/Methods/Address/VaultAddress+Wrap+Functions.swift
@@ -27,10 +27,7 @@ extension VaultAddress {
 	public var isNonFungible: Bool {
 		vaultAddressIsNonFungible(address: self)
 	}
-	
-	public func embed() -> Address {
-		.vault(self)
-	}
+
 }
 
 #if DEBUG

--- a/apple/Sources/Sargon/Extensions/Methods/Prelude/SargonError+Wrap+Functions.swift
+++ b/apple/Sources/Sargon/Extensions/Methods/Prelude/SargonError+Wrap+Functions.swift
@@ -1,0 +1,11 @@
+import SargonUniFFI
+
+extension SargonError {
+	public var errorMessage: String {
+		errorMessageFromError(error: self)
+	}
+	
+	public var errorCode: UInt32 {
+		errorCodeFromError(error: self)
+	}
+}

--- a/apple/Sources/Sargon/Extensions/SampleValues/Prelude/SargonError+SampleValues.swift
+++ b/apple/Sources/Sargon/Extensions/SampleValues/Prelude/SargonError+SampleValues.swift
@@ -1,0 +1,8 @@
+import SargonUniFFI
+
+#if DEBUG
+extension SargonError {
+	public static let sample: Self = .Unknown
+	public static let sampleOther: Self = .BytesEmpty
+}
+#endif // DEBUG

--- a/apple/Sources/Sargon/Extensions/Swiftified/Address/AccessControllerAddress+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Address/AccessControllerAddress+Swiftified.swift
@@ -1,1 +1,7 @@
-extension AccessControllerAddress: AddressProtocol {}
+import SargonUniFFI
+
+extension AccessControllerAddress: AddressProtocol {
+	public func embed() -> Address {
+		.accessController(self)
+	}
+}

--- a/apple/Sources/Sargon/Extensions/Swiftified/Address/AccountAddress+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Address/AccountAddress+Swiftified.swift
@@ -1,1 +1,7 @@
-extension AccountAddress: EntityAddressProtocol {}
+import SargonUniFFI
+
+extension AccountAddress: EntityAddressProtocol {
+	public func embed() -> Address {
+		.account(self)
+	}
+}

--- a/apple/Sources/Sargon/Extensions/Swiftified/Address/Address+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Address/Address+Swiftified.swift
@@ -1,3 +1,5 @@
+import SargonUniFFI
+
 extension Address: AddressProtocol {
 	
 	public func embed() -> Address {

--- a/apple/Sources/Sargon/Extensions/Swiftified/Address/AddressOfAccountOrPersona+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Address/AddressOfAccountOrPersona+Swiftified.swift
@@ -1,1 +1,10 @@
-extension AddressOfAccountOrPersona: AddressProtocol {}
+import SargonUniFFI
+
+extension AddressOfAccountOrPersona: AddressProtocol {
+	public func embed() -> Address {
+		switch self {
+		case let .account(accountAddress): Address.account(accountAddress)
+		case let .identity(identityAddress): Address.identity(identityAddress)
+		}
+	}
+}

--- a/apple/Sources/Sargon/Extensions/Swiftified/Address/ComponentAddress+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Address/ComponentAddress+Swiftified.swift
@@ -1,1 +1,7 @@
-extension ComponentAddress: AddressProtocol {}
+import SargonUniFFI
+
+extension ComponentAddress: AddressProtocol {
+	public func embed() -> Address {
+		.component(self)
+	}
+}

--- a/apple/Sources/Sargon/Extensions/Swiftified/Address/IdentityAddress+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Address/IdentityAddress+Swiftified.swift
@@ -1,1 +1,7 @@
-extension IdentityAddress: EntityAddressProtocol {}
+import SargonUniFFI
+
+extension IdentityAddress: EntityAddressProtocol {
+	public func embed() -> Address {
+		.identity(self)
+	}
+}

--- a/apple/Sources/Sargon/Extensions/Swiftified/Address/LegacyOlympiaAccountAddress+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Address/LegacyOlympiaAccountAddress+Swiftified.swift
@@ -1,1 +1,3 @@
+import SargonUniFFI
+
 extension LegacyOlympiaAccountAddress: BaseAddressProtocol {}

--- a/apple/Sources/Sargon/Extensions/Swiftified/Address/NonFungibleResourceAddress+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Address/NonFungibleResourceAddress+Swiftified.swift
@@ -1,6 +1,10 @@
+import SargonUniFFI
+
 extension NonFungibleResourceAddress: AddressProtocol {}
 
 extension NonFungibleResourceAddress {
-    
+	public func embed() -> Address {
+		.resource(asResourceAddress)
+	}
 }
 

--- a/apple/Sources/Sargon/Extensions/Swiftified/Address/PackageAddress+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Address/PackageAddress+Swiftified.swift
@@ -1,1 +1,7 @@
-extension PackageAddress: AddressProtocol {}
+import SargonUniFFI
+
+extension PackageAddress: AddressProtocol {
+	public func embed() -> Address {
+		.package(self)
+	}
+}

--- a/apple/Sources/Sargon/Extensions/Swiftified/Address/PoolAddress+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Address/PoolAddress+Swiftified.swift
@@ -1,1 +1,7 @@
-extension PoolAddress: AddressProtocol {}
+import SargonUniFFI
+
+extension PoolAddress: AddressProtocol {
+	public func embed() -> Address {
+		.pool(self)
+	}
+}

--- a/apple/Sources/Sargon/Extensions/Swiftified/Address/ResourceAddress+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Address/ResourceAddress+Swiftified.swift
@@ -1,3 +1,5 @@
+import SargonUniFFI
+
 extension ResourceAddress: AddressProtocol {}
 
 extension ResourceAddress {
@@ -16,4 +18,8 @@ extension ResourceAddress {
 	
 	/// The ResourceAddress of XRD of mainnet
 	public static let mainnetXRD = Self.xrd(on: .mainnet)
+	
+	public func embed() -> Address {
+		.resource(self)
+	}
 }

--- a/apple/Sources/Sargon/Extensions/Swiftified/Address/ValidatorAddress+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Address/ValidatorAddress+Swiftified.swift
@@ -1,1 +1,7 @@
-extension ValidatorAddress: AddressProtocol {}
+import SargonUniFFI
+
+extension ValidatorAddress: AddressProtocol {
+	public func embed() -> Address {
+		.validator(self)
+	}
+}

--- a/apple/Sources/Sargon/Extensions/Swiftified/Address/VaultAddress+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Address/VaultAddress+Swiftified.swift
@@ -1,1 +1,7 @@
-extension VaultAddress: AddressProtocol {}
+import SargonUniFFI
+
+extension VaultAddress: AddressProtocol {
+	public func embed() -> Address {
+		.vault(self)
+	}
+}

--- a/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Derivation/AccountPath+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Derivation/AccountPath+Swiftified.swift
@@ -6,7 +6,7 @@ extension AccountPath {
         case let .account(value):
             self = value
         case .identity, .getId:
-            throw SargonError.WrongEntityKind(message: "Expected Account")
+			throw SargonError.WrongEntityKind(expected: .account, found: .identity)
         }
     }
     

--- a/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Derivation/IdentityPath+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Derivation/IdentityPath+Swiftified.swift
@@ -6,7 +6,7 @@ extension IdentityPath {
         case let .identity(value):
             self = value
         case .account, .getId:
-            throw SargonError.WrongEntityKind(message: "Expected Identity")
+			throw SargonError.WrongEntityKind(expected: .identity, found: .account)
         }
     }
     

--- a/apple/Sources/Sargon/Extensions/Swiftified/Prelude/SargonError+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Prelude/SargonError+Swiftified.swift
@@ -1,10 +1,17 @@
-//
-//  SargonError+Swiftified.swift
-//
-//
-//  Created by Alexander Cyon on 2024-02-16.
-//
-
-import Foundation
+import SargonUniFFI
 
 public typealias SargonError = CommonError
+
+extension SargonError: SargonModel {}
+
+extension SargonError: CustomDebugStringConvertible {
+	public var debugDescription: String {
+		"\(errorCode): \(errorMessage)"
+	}
+}
+
+extension SargonError: CustomStringConvertible {
+	public var description: String {
+		errorMessage
+	}
+}

--- a/apple/Sources/Sargon/Protocols/AddressProtocol.swift
+++ b/apple/Sources/Sargon/Protocols/AddressProtocol.swift
@@ -1,3 +1,5 @@
+import SargonUniFFI
+
 #if DEBUG
 public protocol BaseBaseAddressProtocol: SargonModel, ExpressibleByStringLiteral {}
 #else
@@ -9,6 +11,13 @@ public protocol BaseAddressProtocol: BaseBaseAddressProtocol, Codable, CustomStr
 	var networkID: NetworkID { get }
 	var address: String { get }
 }
+
+extension AddressProtocol {
+	public var isOnMainnet: Bool {
+		self.networkID == .mainnet
+	}
+}
+
 
 extension BaseAddressProtocol {
 	public var description: String {

--- a/apple/Tests/TestCases/Address/ComponentAddressTests.swift
+++ b/apple/Tests/TestCases/Address/ComponentAddressTests.swift
@@ -1,2 +1,12 @@
 final class ComponentAddressTests: AddressTest<ComponentAddress> {
+	
+	func test_is_global() {
+		XCTAssertTrue(SUT.sampleMainnet.isGlobal)
+		XCTAssertFalse(SUT.sampleMainnetOther.isGlobal)
+	}
+	
+	func test_is_internal() {
+		XCTAssertTrue(SUT.sampleMainnetOther.isInternal)
+		XCTAssertFalse(SUT.sampleMainnet.isInternal)
+	}
 }

--- a/apple/Tests/TestCases/Prelude/SargonErrorTests.swift
+++ b/apple/Tests/TestCases/Prelude/SargonErrorTests.swift
@@ -1,0 +1,20 @@
+final class SargonErrorTests: Test<SargonError> {
+	
+	func test_error_code() {
+		XCTAssertEqual(SUT.UnknownNetworkForId(badValue: 99).errorCode, 10049)
+	}
+	
+	func test_error_message() {
+		XCTAssertEqual(SUT.UnknownNetworkForId(badValue: 99).errorMessage, "No network found with id: '99'")
+	}
+	
+	func test_description() {
+		let sut = SUT.UnknownNetworkForId(badValue: 99)
+		XCTAssertEqual(sut.description, sut.errorMessage)
+	}
+	
+	func test_debug_description() {
+		let sut = SUT.UnknownNetworkForId(badValue: 99)
+		XCTAssertEqual(sut.debugDescription, "10049: No network found with id: '99'")
+	}
+}

--- a/apple/Tests/Utils/AddressProtocolTests.swift
+++ b/apple/Tests/Utils/AddressProtocolTests.swift
@@ -87,7 +87,17 @@ class AddressTest<SUT_: AddressProtocol>: BaseAddressTest<SUT_> {
 		XCTAssertEqual(SUT.sampleStokenet.xrdOnSameNetwork, ResourceAddress.sampleStokenetXRD)
 		XCTAssertEqual(SUT.sampleStokenetOther.xrdOnSameNetwork, ResourceAddress.sampleStokenetXRD)
 	}
-
+	
+	func test_is_on_mainnet() {
+		XCTAssertTrue(SUT.sampleMainnet.isOnMainnet)
+		XCTAssertTrue(SUT.sampleMainnetOther.isOnMainnet)
+		
+		XCTAssertFalse(SUT.sampleStokenet.isOnMainnet)
+		XCTAssertFalse(SUT.sampleStokenetOther.isOnMainnet)
+		
+		let nonMainnets = Set(NetworkID.allCases).subtracting(Set([NetworkID.mainnet]))
+		nonMainnets.map(SUT.random(networkID:)).map(\.isOnMainnet).forEach { XCTAssertFalse($0) }
+	}
 
 	func test_embed() {
 		func doTest(_ address: SUT) {

--- a/src/core/error/common_error.rs
+++ b/src/core/error/common_error.rs
@@ -334,9 +334,9 @@ pub enum CommonError {
     InvalidInstructionsString { underlying: String } = 10090,
 
     #[error(
-        "Failed to get execution summary from TransactionManifest using RET"
+        "Failed to get execution summary from TransactionManifest using RET {underlying}"
     )]
-    FailedToGetRetExecutionSummaryFromManifest = 10091,
+    ExecutionSummaryFail { underlying: String } = 10091,
 
     #[error("Failed to get TransactionReceipt from encoded bytes.")]
     FailedToDecodeEncodedReceipt = 10092,

--- a/src/core/error/common_error.rs
+++ b/src/core/error/common_error.rs
@@ -6,7 +6,6 @@ pub type Result<T, E = CommonError> = std::result::Result<T, E>;
 
 #[repr(u32)]
 #[derive(Clone, Debug, ThisError, PartialEq, uniffi::Error)]
-#[uniffi(flat_error)]
 pub enum CommonError {
     #[error("Unknown Error")]
     Unknown = 10000,
@@ -408,8 +407,8 @@ pub enum CommonError {
     )]
     InvalidInstructionsFailedToDecompile { underlying: String } = 10110,
 
-    #[error("Invalid Transaction, max SBOR depth exceeded: '{0}'")]
-    InvalidTransactionMaxSBORDepthExceeded(usize) = 10111,
+    #[error("Invalid Transaction, max SBOR depth exceeded: '{max}'")]
+    InvalidTransactionMaxSBORDepthExceeded { max: u16 } = 10111,
 
     #[error("Invalid Signed Intent, failed to encode, reason: '{underlying}'")]
     InvalidSignedIntentFailedToEncode { underlying: String } = 10112,
@@ -420,12 +419,20 @@ pub enum CommonError {
     InvalidNotarizedIntentFailedToEncode { underlying: String } = 10113,
 }
 
-/*
-// FIXME: We want this! We want to be able to get the error description
-of an error, but we get some strange uniffi error!
 #[uniffi::export]
 pub fn error_message_from_error(error: &CommonError) -> String {
-    format!("{}", error)
+    error.to_string()
+}
+
+impl CommonError {
+    pub fn error_code(&self) -> u32 {
+        unsafe { *<*const _>::from(self).cast::<u32>() }
+    }
+}
+
+#[uniffi::export]
+pub fn error_code_from_error(error: &CommonError) -> u32 {
+    error.error_code()
 }
 
 #[cfg(test)]
@@ -435,7 +442,15 @@ mod tests {
     #[test]
     fn error_message() {
         let sut = CommonError::UnknownNetworkForID { bad_value: 0 };
-        // assert_eq!(error_message_from_error(&sut), "Unknown network ID '0'");
+        assert_eq!(
+            error_message_from_error(&sut),
+            "No network found with id: '0'"
+        );
+    }
+
+    #[test]
+    fn error_code() {
+        let sut = CommonError::UnknownNetworkForID { bad_value: 0 };
+        assert_eq!(error_code_from_error(&sut), 10049);
     }
 }
-*/

--- a/src/profile/v100/address/component_address.rs
+++ b/src/profile/v100/address/component_address.rs
@@ -1,6 +1,18 @@
 use crate::prelude::*;
 
 impl ComponentAddress {
+    pub fn is_global(&self) -> bool {
+        self.secret_magic.entity_type()
+            == ScryptoEntityType::GlobalGenericComponent
+    }
+
+    pub fn is_internal(&self) -> bool {
+        self.secret_magic.entity_type()
+            == ScryptoEntityType::InternalGenericComponent
+    }
+}
+
+impl ComponentAddress {
     pub(crate) fn sample_mainnet() -> Self {
         Self::sample_mainnet_global()
     }
@@ -16,6 +28,18 @@ impl ComponentAddress {
     pub(crate) fn sample_stokenet_other() -> Self {
         Self::sample_stokenet_internal()
     }
+}
+
+/// Returns `true` if the ComponentAddress is `global` (i.e. not `internal`)
+#[uniffi::export]
+pub fn component_address_is_global(address: &ComponentAddress) -> bool {
+    address.is_global()
+}
+
+/// Returns `true` if the ComponentAddress is `internal` (i.e. not `global`)
+#[uniffi::export]
+pub fn component_address_is_internal(address: &ComponentAddress) -> bool {
+    address.is_internal()
 }
 
 /// Sample to a mainnet ComponentAddress (global)
@@ -108,6 +132,22 @@ mod tests {
             SUT::sample_mainnet_internal()
         );
         assert_ne!(SUT::sample_stokenet_global(), SUT::sample_mainnet_global());
+    }
+
+    #[test]
+    fn is_internal() {
+        assert!(SUT::sample_stokenet_internal().is_internal());
+        assert!(SUT::sample_mainnet_internal().is_internal());
+        assert!(!SUT::sample_mainnet_global().is_internal());
+        assert!(!SUT::sample_stokenet_global().is_internal());
+    }
+
+    #[test]
+    fn is_global() {
+        assert!(SUT::sample_mainnet_global().is_global());
+        assert!(SUT::sample_stokenet_global().is_global());
+        assert!(!SUT::sample_stokenet_internal().is_global());
+        assert!(!SUT::sample_mainnet_internal().is_global());
     }
 
     #[test]
@@ -233,5 +273,31 @@ mod uniffi_tests {
             .len(),
             4
         );
+    }
+
+    #[test]
+    fn test_component_address_is_global() {
+        assert!(component_address_is_global(&SUT::sample_mainnet_global()));
+        assert!(component_address_is_global(&SUT::sample_stokenet_global()));
+
+        assert!(!component_address_is_global(
+            &SUT::sample_stokenet_internal()
+        ));
+        assert!(!component_address_is_global(&SUT::sample_mainnet_internal()));
+    }
+
+    #[test]
+    fn test_component_address_is_internal() {
+        assert!(component_address_is_internal(
+            &SUT::sample_stokenet_internal()
+        ));
+        assert!(component_address_is_internal(
+            &SUT::sample_mainnet_internal()
+        ));
+
+        assert!(!component_address_is_internal(&SUT::sample_mainnet_global()));
+        assert!(!component_address_is_internal(
+            &SUT::sample_stokenet_global()
+        ));
     }
 }

--- a/src/wrapped_radix_engine_toolkit/low_level/compiled_notarized_intent.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/compiled_notarized_intent.rs
@@ -43,7 +43,9 @@ pub(crate) fn compile_notarized_intent(
     RET_compile_notarized_tx(&scrypto_notarized_intent)
         .map_err(|e| match e {
             sbor::EncodeError::MaxDepthExceeded(max) => {
-                CommonError::InvalidTransactionMaxSBORDepthExceeded(max)
+                CommonError::InvalidTransactionMaxSBORDepthExceeded {
+                    max: max as u16,
+                }
             }
             _ => CommonError::InvalidNotarizedIntentFailedToEncode {
                 underlying: format!("{:?}", e),

--- a/src/wrapped_radix_engine_toolkit/low_level/notarized_transaction.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/notarized_transaction.rs
@@ -177,7 +177,9 @@ mod tests {
                 SUT::MAX_SBOR_DEPTH + 1,
                 NetworkID::Stokenet
             ),
-            Err(CommonError::InvalidTransactionMaxSBORDepthExceeded(24))
+            Err(CommonError::InvalidTransactionMaxSBORDepthExceeded {
+                max: 24 as u16
+            })
         );
     }
 }

--- a/src/wrapped_radix_engine_toolkit/low_level/signed_intent.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/signed_intent.rs
@@ -60,7 +60,9 @@ fn compile_signed_intent(
     RET_signed_intent_compile(&scrypto_signed_intent)
         .map_err(|e| match e {
             sbor::EncodeError::MaxDepthExceeded(max) => {
-                CommonError::InvalidTransactionMaxSBORDepthExceeded(max)
+                CommonError::InvalidTransactionMaxSBORDepthExceeded {
+                    max: max as u16,
+                }
             }
             _ => CommonError::InvalidSignedIntentFailedToEncode {
                 underlying: format!("{:?}", e),
@@ -284,7 +286,9 @@ mod tests {
                 SUT::MAX_SBOR_DEPTH + 1,
                 NetworkID::Stokenet
             ),
-            Err(CommonError::InvalidTransactionMaxSBORDepthExceeded(24))
+            Err(CommonError::InvalidTransactionMaxSBORDepthExceeded {
+                max: 24 as u16
+            })
         );
     }
 

--- a/src/wrapped_radix_engine_toolkit/low_level/transaction_intent.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/transaction_intent.rs
@@ -209,7 +209,9 @@ mod tests {
                 SUT::MAX_SBOR_DEPTH + 1,
                 NetworkID::Stokenet
             ),
-            Err(CommonError::InvalidTransactionMaxSBORDepthExceeded(20))
+            Err(CommonError::InvalidTransactionMaxSBORDepthExceeded {
+                max: 20 as u16
+            })
         );
     }
 

--- a/src/wrapped_radix_engine_toolkit/low_level/transaction_manifest/execution_summary/transaction_manifest_execution_summary.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/transaction_manifest/execution_summary/transaction_manifest_execution_summary.rs
@@ -22,7 +22,9 @@ impl TransactionManifest {
                     "Failed to get execution summary from RET, error: {:?}",
                     e
                 );
-                CommonError::FailedToGetRetExecutionSummaryFromManifest
+                CommonError::ExecutionSummaryFail {
+                    underlying: format!("{:?}", e),
+                }
             })?;
 
         Ok(ExecutionSummary::from((
@@ -65,7 +67,9 @@ mod tests {
         assert_eq!(
             TransactionManifest::sample()
                 .execution_summary_with_receipt(wrong_receipt),
-            Err(CommonError::FailedToGetRetExecutionSummaryFromManifest)
+            Err(CommonError::ExecutionSummaryFail {
+                underlying: "InvalidReceipt".to_owned()
+            })
         );
     }
 

--- a/src/wrapped_radix_engine_toolkit/low_level/transaction_manifest/instructions/instructions.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/transaction_manifest/instructions/instructions.rs
@@ -165,7 +165,9 @@ fn extract_error_from_error(
             },
         },
         ScryptoCompileError::ParserError(MaxDepthExceeded(max)) => {
-            CommonError::InvalidTransactionMaxSBORDepthExceeded(max)
+            CommonError::InvalidTransactionMaxSBORDepthExceeded {
+                max: max as u16,
+            }
         }
         _ => CommonError::InvalidInstructionsString {
             underlying: format!("{:?}", err),
@@ -403,7 +405,9 @@ mod tests {
                 SUT::MAX_SBOR_DEPTH + 1,
                 NetworkID::Stokenet
             ),
-            Err(CommonError::InvalidTransactionMaxSBORDepthExceeded(20))
+            Err(CommonError::InvalidTransactionMaxSBORDepthExceeded {
+                max: 20 as u16
+            })
         );
     }
 }


### PR DESCRIPTION
- **Carry over ExecutionSummary error**
- **Export CommonError's errorCode and errorMessage**
- **export is global and is internal on `ComponentAddress`**