### PR TITLE
Rename into() -> asSpecific and embed() -> asGeneral

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1959,7 +1959,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "0.6.9"
+version = "0.6.10"
 dependencies = [
  "assert-json-diff",
  "bip32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "0.6.9"
+version = "0.6.10"
 edition = "2021"
 build = "build.rs"
 

--- a/apple/Sources/Sargon/Extensions/Swiftified/Address/AccessControllerAddress+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Address/AccessControllerAddress+Swiftified.swift
@@ -1,7 +1,7 @@
 import SargonUniFFI
 
 extension AccessControllerAddress: AddressProtocol {
-	public func embed() -> Address {
+	public var asGeneral: Address {
 		.accessController(self)
 	}
 }

--- a/apple/Sources/Sargon/Extensions/Swiftified/Address/AccountAddress+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Address/AccountAddress+Swiftified.swift
@@ -1,7 +1,7 @@
 import SargonUniFFI
 
 extension AccountAddress: EntityAddressProtocol {
-	public func embed() -> Address {
+	public var asGeneral: Address {
 		.account(self)
 	}
 }

--- a/apple/Sources/Sargon/Extensions/Swiftified/Address/Address+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Address/Address+Swiftified.swift
@@ -2,11 +2,11 @@ import SargonUniFFI
 
 extension Address: AddressProtocol {
 	
-	public func embed() -> Address {
+	public var asGeneral: Address {
 		self
 	}
 	
-	public func into<A: AddressProtocol>(type: A.Type = A.self) throws -> A {
+	public func asSpecific<A: AddressProtocol>(type: A.Type = A.self) throws -> A {
 		try A(validatingAddress: self.address)
 	}
 	
@@ -16,7 +16,7 @@ extension Address: AddressProtocol {
 }
 
 public func == (lhs: Address, rhs: some AddressProtocol) -> Bool {
-	lhs == rhs.embed()
+	lhs == rhs.asGeneral
 }
 
 public func == (lhs: some AddressProtocol, rhs: Address) -> Bool {

--- a/apple/Sources/Sargon/Extensions/Swiftified/Address/AddressOfAccountOrPersona+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Address/AddressOfAccountOrPersona+Swiftified.swift
@@ -1,7 +1,7 @@
 import SargonUniFFI
 
 extension AddressOfAccountOrPersona: AddressProtocol {
-	public func embed() -> Address {
+	public var asGeneral: Address {
 		switch self {
 		case let .account(accountAddress): Address.account(accountAddress)
 		case let .identity(identityAddress): Address.identity(identityAddress)

--- a/apple/Sources/Sargon/Extensions/Swiftified/Address/ComponentAddress+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Address/ComponentAddress+Swiftified.swift
@@ -1,7 +1,7 @@
 import SargonUniFFI
 
 extension ComponentAddress: AddressProtocol {
-	public func embed() -> Address {
+	public var asGeneral: Address {
 		.component(self)
 	}
 }

--- a/apple/Sources/Sargon/Extensions/Swiftified/Address/IdentityAddress+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Address/IdentityAddress+Swiftified.swift
@@ -1,7 +1,7 @@
 import SargonUniFFI
 
 extension IdentityAddress: EntityAddressProtocol {
-	public func embed() -> Address {
+	public var asGeneral: Address {
 		.identity(self)
 	}
 }

--- a/apple/Sources/Sargon/Extensions/Swiftified/Address/NonFungibleResourceAddress+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Address/NonFungibleResourceAddress+Swiftified.swift
@@ -3,7 +3,7 @@ import SargonUniFFI
 extension NonFungibleResourceAddress: AddressProtocol {}
 
 extension NonFungibleResourceAddress {
-	public func embed() -> Address {
+	public var asGeneral: Address {
 		.resource(asResourceAddress)
 	}
 }

--- a/apple/Sources/Sargon/Extensions/Swiftified/Address/PackageAddress+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Address/PackageAddress+Swiftified.swift
@@ -1,7 +1,7 @@
 import SargonUniFFI
 
 extension PackageAddress: AddressProtocol {
-	public func embed() -> Address {
+	public var asGeneral: Address {
 		.package(self)
 	}
 }

--- a/apple/Sources/Sargon/Extensions/Swiftified/Address/PoolAddress+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Address/PoolAddress+Swiftified.swift
@@ -1,7 +1,7 @@
 import SargonUniFFI
 
 extension PoolAddress: AddressProtocol {
-	public func embed() -> Address {
+	public var asGeneral: Address {
 		.pool(self)
 	}
 }

--- a/apple/Sources/Sargon/Extensions/Swiftified/Address/ResourceAddress+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Address/ResourceAddress+Swiftified.swift
@@ -19,7 +19,7 @@ extension ResourceAddress {
 	/// The ResourceAddress of XRD of mainnet
 	public static let mainnetXRD = Self.xrd(on: .mainnet)
 	
-	public func embed() -> Address {
+	public var asGeneral: Address {
 		.resource(self)
 	}
 }

--- a/apple/Sources/Sargon/Extensions/Swiftified/Address/ValidatorAddress+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Address/ValidatorAddress+Swiftified.swift
@@ -1,7 +1,7 @@
 import SargonUniFFI
 
 extension ValidatorAddress: AddressProtocol {
-	public func embed() -> Address {
+	public var asGeneral: Address {
 		.validator(self)
 	}
 }

--- a/apple/Sources/Sargon/Extensions/Swiftified/Address/VaultAddress+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Address/VaultAddress+Swiftified.swift
@@ -1,7 +1,7 @@
 import SargonUniFFI
 
 extension VaultAddress: AddressProtocol {
-	public func embed() -> Address {
+	public var asGeneral: Address {
 		.vault(self)
 	}
 }

--- a/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Derivation/AccountPath+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Derivation/AccountPath+Swiftified.swift
@@ -10,7 +10,7 @@ extension AccountPath {
         }
     }
     
-    public func embed() -> CAP26Path {
+    public var asGeneral: CAP26Path {
         .account(value: self)
     }
 }

--- a/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Derivation/CAP26Path+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Derivation/CAP26Path+Swiftified.swift
@@ -1,7 +1,9 @@
+import SargonUniFFI
+
 public typealias CAP26Path = Cap26Path
 
 extension CAP26Path: SargonModel, CAP26PathProtocol {
-    public func embed() -> CAP26Path {
+    public var asGeneral: CAP26Path {
         self
     }
 }

--- a/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Derivation/IdentityPath+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Derivation/IdentityPath+Swiftified.swift
@@ -10,7 +10,7 @@ extension IdentityPath {
         }
     }
     
-    public func embed() -> CAP26Path {
+    public var asGeneral: CAP26Path {
         .identity(value: self)
     }
 }

--- a/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Keys/Ed25519PublicKey+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Keys/Ed25519PublicKey+Swiftified.swift
@@ -1,5 +1,5 @@
 extension Ed25519PublicKey: PublicKeyProtocol {
-	public func embed() -> PublicKey {
+    public var asGeneral: PublicKey {
 		PublicKey.ed25519(value: self)
 	}
 }

--- a/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Keys/PublicKey+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Keys/PublicKey+Swiftified.swift
@@ -1,5 +1,5 @@
 extension PublicKey: PublicKeyProtocol {
-	public func embed() -> PublicKey {
+    public var asGeneral: PublicKey {
 		self
 	}
 }

--- a/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Keys/Secp256k1PublicKey+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Keys/Secp256k1PublicKey+Swiftified.swift
@@ -1,5 +1,5 @@
 extension Secp256k1PublicKey: PublicKeyProtocol {
-	public func embed() -> PublicKey {
+    public var asGeneral: PublicKey {
 		PublicKey.secp256k1(value: self)
 	}
 }

--- a/apple/Sources/Sargon/Extensions/Swiftified/Prelude/NonFungibleGlobalID+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Prelude/NonFungibleGlobalID+Swiftified.swift
@@ -1,6 +1,12 @@
+import SargonUniFFI
+
 public typealias NonFungibleGlobalID = NonFungibleGlobalId
 
-extension NonFungibleGlobalID: IdentifiableByStringProtocol {}
+extension NonFungibleGlobalID: IdentifiableByStringProtocol {
+    public var localID: NonFungibleLocalID {
+        nonFungibleLocalId
+    }
+}
 
 extension NonFungibleGlobalID {
     public init(

--- a/apple/Sources/Sargon/Protocols/AddressProtocol.swift
+++ b/apple/Sources/Sargon/Protocols/AddressProtocol.swift
@@ -48,7 +48,7 @@ extension BaseAddressProtocol {
 
 public protocol AddressProtocol: BaseAddressProtocol & Identifiable where Self.ID == String {
     func formatted(_ format: AddressFormat) -> String
-	func embed() -> Address
+    var asGeneral: Address { get }
 #if DEBUG
 	static func random(networkID: NetworkID) -> Self
 	func mapTo(networkID: NetworkID) -> Self

--- a/apple/Sources/Sargon/Protocols/CAP26PathProtocol.swift
+++ b/apple/Sources/Sargon/Protocols/CAP26PathProtocol.swift
@@ -1,9 +1,9 @@
 public protocol CAP26PathProtocol: HDPathProtocol {
-    func embed() -> CAP26Path
+    var asGeneral: CAP26Path { get }
 }
 
 extension CAP26PathProtocol {
     public var description: String {
-        embed().toString()
+        asGeneral.toString()
     }
 }

--- a/apple/Sources/Sargon/Protocols/PublicKeyProtocol.swift
+++ b/apple/Sources/Sargon/Protocols/PublicKeyProtocol.swift
@@ -1,9 +1,9 @@
 public protocol PublicKeyProtocol: BinaryProtocol where Digest == PublicKeyHash {
-	func embed() -> PublicKey
+    var asGeneral: PublicKey { get }
 }
 
 extension PublicKeyProtocol {
 	public func hash() -> PublicKeyHash {
-		PublicKeyHash(hashing: embed())
+		PublicKeyHash(hashing: asGeneral)
 	}
 }

--- a/apple/Tests/TestCases/Address/AccountAddressTests.swift
+++ b/apple/Tests/TestCases/Address/AccountAddressTests.swift
@@ -17,7 +17,7 @@ final class AccountAddressTests: AddressTest<AccountAddress> {
     }
 	
 	func test_into_fails_for_wrong_address_type() {
-		XCTAssertThrowsError(try SUT.sample.embed().into(type: IdentityAddress.self))
+		XCTAssertThrowsError(try SUT.sample.asGeneral.asSpecific(type: IdentityAddress.self))
 	}
 	
 	func test_short() {

--- a/apple/Tests/TestCases/Crypto/PublicKeyTests.swift
+++ b/apple/Tests/TestCases/Crypto/PublicKeyTests.swift
@@ -18,6 +18,6 @@ final class PublicKeyTests: PublicKeyTest<PublicKey> {
 	}
 	
 	func test_embed_is_identity() {
-		XCTAssertEqual(SUT.sample, SUT.sample.embed())
+		XCTAssertEqual(SUT.sample, SUT.sample.asGeneral)
 	}
 }

--- a/apple/Tests/TestCases/Prelude/NonFungibleGlobalIDTests.swift
+++ b/apple/Tests/TestCases/Prelude/NonFungibleGlobalIDTests.swift
@@ -10,6 +10,10 @@ final class NonFungibleGlobalIDTests: IdentifiableByStringProtocolTest<NonFungib
         )
     }
     
+    func test_local_id() {
+        XCTAssertEqual(SUT.sample.localID.formatted(), "Member_237")
+    }
+    
     func test_expressible_by_string_literal() {
         XCTAssertEqual(SUT.sample, "resource_rdx1nfyg2f68jw7hfdlg5hzvd8ylsa7e0kjl68t5t62v3ttamtejc9wlxa:<Member_237>")
     }

--- a/apple/Tests/Utils/AddressProtocolTests.swift
+++ b/apple/Tests/Utils/AddressProtocolTests.swift
@@ -56,10 +56,9 @@ class AddressTest<SUT_: AddressProtocol>: BaseAddressTest<SUT_> {
 		XCTAssertNoDifference(SUT.sampleStokenetOther.networkID, .stokenet)
 	}
 	
-	func test_into_self() throws {
+	func test_asSpecific_self() throws {
 		func doTestInto(_ sut: SUT) throws {
-			let embedded = sut.embed()
-			let extracted = try embedded.into(type: SUT.self)
+			let extracted = try sut.asGeneral.asSpecific(type: SUT.self)
 			XCTAssertEqual(extracted, sut)
 		}
 		try SUT.allCases.forEach(doTestInto)
@@ -99,15 +98,15 @@ class AddressTest<SUT_: AddressProtocol>: BaseAddressTest<SUT_> {
 		nonMainnets.map(SUT.random(networkID:)).map(\.isOnMainnet).forEach { XCTAssertFalse($0) }
 	}
 
-	func test_embed() {
+	func test_asGeneral() {
 		func doTest(_ address: SUT) {
 			XCTAssertNoDifference(
-				address.embed().address,
+				address.asGeneral.address,
 				address.address
 			)
 			
 			XCTAssertNoDifference(
-				address.embed().networkID,
+				address.asGeneral.networkID,
 				address.networkID
 			)
 		}
@@ -144,8 +143,8 @@ class AddressTest<SUT_: AddressProtocol>: BaseAddressTest<SUT_> {
 	
 	func test_asymmetric_type_equality() {
 		SUT.allCases.forEach {
-			XCTAssertTrue($0.embed() == $0)
-			XCTAssertTrue($0 == $0.embed())
+			XCTAssertTrue($0.asGeneral == $0)
+			XCTAssertTrue($0 == $0.asGeneral)
 		}
 	}
 	


### PR DESCRIPTION
# Swift only
Rename method on *specific* Addresses which was name ~func embed()~ -> `var asGeneral` (a computed property)

Rename method ~`func into()`~ on `Address` -> `func asSpecific()`