### PR TITLE
New slip10 crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1176,6 +1176,7 @@ dependencies = [
  "digest 0.10.7",
  "ed25519-zebra",
  "hmac",
+ "k256",
  "sha2 0.10.8",
  "zeroize",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,6 +179,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
 name = "basic-toml"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -200,24 +206,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "bip32"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e141fb0f8be1c7b45887af94c88b182472b57c96b56773250ae00cd6a14a164"
-dependencies = [
- "bs58",
- "hmac",
- "k256",
- "once_cell",
- "pbkdf2",
- "rand_core 0.6.4",
- "ripemd",
- "sha2 0.10.8",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -296,15 +284,6 @@ checksum = "845141a4fade3f790628b7daaaa298a25b204fb28907eb54febe5142db6ce653"
 dependencies = [
  "num-integer",
  "num-traits",
-]
-
-[[package]]
-name = "bs58"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5353f36341f7451062466f0b755b96ac3a9547e4d7f6b70d603fc721a7d7896"
-dependencies = [
- "sha2 0.10.8",
 ]
 
 [[package]]
@@ -744,6 +723,7 @@ dependencies = [
  "elliptic-curve",
  "rfc6979",
  "signature 2.2.0",
+ "spki",
 ]
 
 [[package]]
@@ -811,6 +791,7 @@ dependencies = [
  "ff",
  "generic-array 0.14.7",
  "group",
+ "pkcs8",
  "rand_core 0.6.4",
  "sec1",
  "subtle",
@@ -1176,7 +1157,7 @@ dependencies = [
  "digest 0.10.7",
  "ed25519-zebra",
  "hmac",
- "k256",
+ "k256 0.13.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.10.8",
  "zeroize",
 ]
@@ -1268,6 +1249,19 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "sha2 0.10.8",
+]
+
+[[package]]
+name = "k256"
+version = "0.13.3"
+source = "git+https://github.com/RustCrypto/elliptic-curves?rev=e158ce5cf0e9acee2fd76aff2a628334f5c771e5#e158ce5cf0e9acee2fd76aff2a628334f5c771e5"
+dependencies = [
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+ "once_cell",
+ "sha2 0.10.8",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -1565,20 +1559,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
-name = "pbkdf2"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
-dependencies = [
- "digest 0.10.7",
- "hmac",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "plain"
@@ -1986,15 +1980,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ripemd"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
-dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2042,7 +2027,6 @@ name = "sargon"
 version = "0.6.11"
 dependencies = [
  "assert-json-diff",
- "bip32",
  "bip39",
  "camino",
  "cargo_toml",
@@ -2057,6 +2041,7 @@ dependencies = [
  "iota-crypto",
  "iso8601-timestamp",
  "itertools 0.12.1",
+ "k256 0.13.3 (git+https://github.com/RustCrypto/elliptic-curves?rev=e158ce5cf0e9acee2fd76aff2a628334f5c771e5)",
  "log",
  "memoize",
  "nutype",
@@ -2254,6 +2239,7 @@ dependencies = [
  "base16ct",
  "der",
  "generic-array 0.14.7",
+ "pkcs8",
  "subtle",
  "zeroize",
 ]
@@ -2466,6 +2452,16 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
 
 [[package]]
 name = "static_assertions"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -21,6 +33,12 @@ checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "android-tzdata"
@@ -191,7 +209,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e141fb0f8be1c7b45887af94c88b182472b57c96b56773250ae00cd6a14a164"
 dependencies = [
  "bs58",
- "hmac 0.12.1",
+ "hmac",
  "k256",
  "once_cell",
  "pbkdf2",
@@ -549,16 +567,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-mac"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58bcd97a54c7ca5ce2f6eb16f6bede5b0ab5f0055fedc17d2f0b4466e21671ca"
-dependencies = [
- "generic-array 0.14.7",
- "subtle",
-]
-
-[[package]]
 name = "curve25519-dalek"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -569,6 +577,34 @@ dependencies = [
  "rand_core 0.5.1",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "platforms",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -720,16 +756,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "signature 2.2.0",
+]
+
+[[package]]
 name = "ed25519-dalek"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
- "curve25519-dalek",
- "ed25519",
+ "curve25519-dalek 3.2.0",
+ "ed25519 1.5.3",
  "rand 0.7.3",
  "serde",
  "sha2 0.9.9",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519-zebra"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d9ce6874da5d4415896cd45ffbc4d1cfc0c4f9c079427bd870742c30f2f65a9"
+dependencies = [
+ "curve25519-dalek 4.1.2",
+ "ed25519 2.2.3",
+ "hashbrown 0.14.3",
+ "hex",
+ "rand_core 0.6.4",
+ "sha2 0.10.8",
  "zeroize",
 ]
 
@@ -855,6 +915,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fiat-crypto"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c007b1ae3abe1cb6f85a16305acd418b7ca6343b953633fee2b76d8f108b830f"
+
+[[package]]
 name = "fixedstr"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -960,7 +1026,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.8",
 ]
 
 [[package]]
@@ -974,6 +1040,10 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+dependencies = [
+ "ahash 0.8.11",
+ "allocator-api2",
+]
 
 [[package]]
 name = "heck"
@@ -994,16 +1064,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "hmac"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deae6d9dbb35ec2c502d62b8f7b1c000a0822c3b0794ba36b3149c0a1c840dff"
-dependencies = [
- "crypto-mac",
- "digest 0.9.0",
 ]
 
 [[package]]
@@ -1106,6 +1166,19 @@ name = "indexmap-nostd"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
+
+[[package]]
+name = "iota-crypto"
+version = "0.23.1"
+source = "git+https://github.com/iotaledger/crypto.rs?rev=47460d64fd0514af136ea1c2c6f3aa29ed89d1b8#47460d64fd0514af136ea1c2c6f3aa29ed89d1b8"
+dependencies = [
+ "autocfg",
+ "digest 0.10.7",
+ "ed25519-zebra",
+ "hmac",
+ "sha2 0.10.8",
+ "zeroize",
+]
 
 [[package]]
 name = "is-terminal"
@@ -1497,7 +1570,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest 0.10.7",
- "hmac 0.12.1",
+ "hmac",
 ]
 
 [[package]]
@@ -1511,6 +1584,12 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "platforms"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db23d408679286588f4d4644f965003d056e3dd5abcaaa938116871d7ce2fee7"
 
 [[package]]
 name = "powerfmt"
@@ -1901,7 +1980,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac 0.12.1",
+ "hmac",
  "subtle",
 ]
 
@@ -1974,6 +2053,7 @@ dependencies = [
  "enum-iterator",
  "hex",
  "identified_vec",
+ "iota-crypto",
  "iso8601-timestamp",
  "itertools 0.12.1",
  "log",
@@ -1996,7 +2076,6 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "serde_with",
- "slip10",
  "strum 0.26.2",
  "thiserror",
  "time-util",
@@ -2367,17 +2446,6 @@ dependencies = [
  "pulldown-cmark",
  "tempfile",
  "walkdir",
-]
-
-[[package]]
-name = "slip10"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28724a6e6f70b0cb115c580891483da6f3aa99e6a353598303a57f89d23aa6bc"
-dependencies = [
- "ed25519-dalek",
- "hmac 0.9.0",
- "sha2 0.9.9",
 ]
 
 [[package]]
@@ -3367,6 +3435,26 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ pretty_assertions = "1.4.0"
 iota-crypto = { git = "https://github.com/iotaledger/crypto.rs", rev = "47460d64fd0514af136ea1c2c6f3aa29ed89d1b8", features = [
     "slip10",
     "ed25519",
+    "secp256k1",
 ] }
 
 memoize = "0.4.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,6 @@ transaction = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "587
 radix-engine-toolkit-json = { git = "https://github.com/radixdlt/radix-engine-toolkit", rev = "1cfe879c7370cfa497857ada7a8973f8a3388abc" }
 radix-engine-toolkit = { git = "https://github.com/radixdlt/radix-engine-toolkit", rev = "1cfe879c7370cfa497857ada7a8973f8a3388abc" }
 enum-iterator = "1.4.1"
-bip32 = "0.5.1" # only need Secp256k1, to do validation of PublicKey
 ed25519-dalek = "1.0.1"
 rand = "0.8.5"
 hex = "0.4.3"
@@ -72,6 +71,9 @@ iota-crypto = { git = "https://github.com/iotaledger/crypto.rs", rev = "47460d64
     "ed25519",
     "secp256k1",
 ] }
+# Transitive dependency of iota_crypto - used to construct PubKey from uncompressed bytes.
+# k256 = "0.13.3"
+k256 = { git = "https://github.com/RustCrypto/elliptic-curves", rev = "e158ce5cf0e9acee2fd76aff2a628334f5c771e5" }
 
 memoize = "0.4.1"
 bip39 = { version = "2.0.0", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,14 @@ nutype = { version = "0.4.0", features = ["serde"] }
 schemars = { version = "0.8.12", features = ["preserve_order"] }
 uniffi = { version = "0.27.0", features = ["cli"] }
 pretty_assertions = "1.4.0"
-slip10 = "0.4.3"
+
+# SLIP10 implementation
+# iota_crypto = "0.23.1"
+iota-crypto = { git = "https://github.com/iotaledger/crypto.rs", rev = "47460d64fd0514af136ea1c2c6f3aa29ed89d1b8", features = [
+    "slip10",
+    "ed25519",
+] }
+
 memoize = "0.4.1"
 bip39 = { version = "2.0.0", features = ["serde"] }
 time-util = { version = "0.3.4", features = ["chrono"] }

--- a/_typos.toml
+++ b/_typos.toml
@@ -18,6 +18,7 @@ package_tdx_2_1p4lftg7zjtmvyw5dwv3fg9cxyumlrya03p5uecqdge9thje4nm5qtk = "package
 account_tdx_2_12yf9gd53yfep7a669fv2t3wm7nz9zeezwd04n02a433ker8vza6rhe = "account_tdx_2_12yf9gd53yfep7a669fv2t3wm7nz9zeezwd04n02a433ker8vza6rhe"
 ec4892a8ba3b86f1 = "ec4892a8ba3b86f1"
 f87611f279e0daa3 = "f87611f279e0daa3"
+fo = "fo"
 imeAction = "imeAction"
 ImeAction = "ImeAction"
 
@@ -27,3 +28,4 @@ hd = "hd"
 imeAction = "imeAction"
 ImeAction = "ImeAction"
 uiu = "uiu"
+fo = "fo"

--- a/src/core/types/decimal192.rs
+++ b/src/core/types/decimal192.rs
@@ -1220,8 +1220,8 @@ mod test_decimal {
         test(0.1, "0.1");
         test(f32::MAX as f64, "340282346638528860000000000000000000000");
         test(123456789.87654321, "123456789.87654321");
-        test(4.01234567890123456789, "4.012345678901235"); // precision lost
-        test(4.012345678901234567895555555, "4.012345678901235"); // Over 18 decimals is OK (precision lost)
+        test(4.012_345_678_901_235, "4.012345678901235"); // precision lost
+        test(4.012_345_678_901_235, "4.012345678901235"); // Over 18 decimals is OK (precision lost)
     }
 
     #[test]
@@ -1234,8 +1234,8 @@ mod test_decimal {
         test(0.1, "0.1");
         test(f32::MAX, "340282350000000000000000000000000000000");
         test(123456789.87654321, "123456790");
-        test(4.01234567890123456789, "4.012346"); // precision lost
-        test(4.012345678901234567895555555, "4.012346"); // Over 18 decimals is OK (precision lost)
+        test(4.012_346, "4.012346"); // precision lost
+        test(4.012_346, "4.012346"); // Over 18 decimals is OK (precision lost)
     }
 
     #[test]

--- a/src/core/types/keys/ed25519/private_key.rs
+++ b/src/core/types/keys/ed25519/private_key.rs
@@ -41,6 +41,14 @@ impl IsPrivateKey<Ed25519PublicKey> for Ed25519PrivateKey {
     fn sign(&self, msg_hash: &Hash) -> Self::Signature {
         self.0.sign(msg_hash).into()
     }
+
+    fn from_bytes(slice: &[u8]) -> Result<Self> {
+        ScryptoEd25519PrivateKey::from_bytes(slice)
+            .map_err(|_| CommonError::InvalidEd25519PrivateKeyFromBytes {
+                bad_value: slice.into(),
+            })
+            .map(Self::from_scrypto)
+    }
 }
 
 impl Ed25519PrivateKey {
@@ -54,14 +62,6 @@ impl Ed25519PrivateKey {
 
     pub fn to_hex(&self) -> String {
         hex_encode(self.to_bytes())
-    }
-
-    pub fn from_bytes(slice: &[u8]) -> Result<Self> {
-        ScryptoEd25519PrivateKey::from_bytes(slice)
-            .map_err(|_| CommonError::InvalidEd25519PrivateKeyFromBytes {
-                bad_value: slice.into(),
-            })
-            .map(Self::from_scrypto)
     }
 
     pub fn from_vec(bytes: Vec<u8>) -> Result<Self> {

--- a/src/core/types/keys/is_private_key.rs
+++ b/src/core/types/keys/is_private_key.rs
@@ -3,6 +3,8 @@ use crate::prelude::*;
 pub trait IsPrivateKey<P: IsPublicKey<Self::Signature>>: Sized {
     type Signature;
 
+    fn from_bytes(slice: &[u8]) -> Result<Self>;
+
     fn curve() -> SLIP10Curve;
 
     fn public_key(&self) -> P;

--- a/src/core/types/keys/private_key.rs
+++ b/src/core/types/keys/private_key.rs
@@ -137,7 +137,7 @@ mod tests {
     #[test]
     fn secp256k1_to_bytes() {
         let bytes = generate_32_bytes();
-        let key = Secp256k1PrivateKey::from(&bytes).unwrap();
+        let key = Secp256k1PrivateKey::from_bytes(&bytes).unwrap();
         let private_key: PrivateKey = key.into();
         assert_eq!(private_key.to_bytes(), bytes);
     }

--- a/src/core/types/keys/secp256k1/public_key.rs
+++ b/src/core/types/keys/secp256k1/public_key.rs
@@ -1,8 +1,6 @@
 use crate::{prelude::*, UniffiCustomTypeConverter};
 
-use bip32::secp256k1::{
-    elliptic_curve::sec1::ToEncodedPoint, PublicKey as BIP32Secp256k1PublicKey,
-}; // the bip32 crate actually does validation of the PublicKey whereas `radix_engine_common` does not.
+use k256::ecdsa::VerifyingKey as K256PublicKey;
 
 /// A `secp256k1` public key used to verify cryptographic signatures (ECDSA signatures).
 #[serde_as]
@@ -77,7 +75,7 @@ impl Secp256k1PublicKey {
     }
 
     pub fn uncompressed(&self) -> Vec<u8> {
-        BIP32Secp256k1PublicKey::from_sec1_bytes(&self.to_bytes())
+        K256PublicKey::from_sec1_bytes(&self.to_bytes())
             .expect("should always be able to create a BIP32 PublicKey")
             .to_encoded_point(false)
             .as_bytes()
@@ -138,7 +136,7 @@ impl TryFrom<Secp256k1PublicKeyUncheckedBytes> for Secp256k1PublicKey {
     fn try_from(
         value: Secp256k1PublicKeyUncheckedBytes,
     ) -> Result<Self, Self::Error> {
-        BIP32Secp256k1PublicKey::from_sec1_bytes(value.as_ref())
+        K256PublicKey::from_sec1_bytes(value.as_ref())
             .map_err(|_| CommonError::InvalidSecp256k1PublicKeyPointNotOnCurve)
             .map(|key| {
                 ScryptoSecp256k1PublicKey::try_from(

--- a/src/core/utils/string_utils.rs
+++ b/src/core/utils/string_utils.rs
@@ -14,6 +14,19 @@ pub fn capitalize(s: impl AsRef<str>) -> String {
     }
 }
 
+pub trait StrExt {
+    fn remove_last(&self) -> &str;
+}
+
+impl StrExt for str {
+    fn remove_last(&self) -> &str {
+        match self.char_indices().next_back() {
+            Some((i, _)) => &self[..i],
+            None => self,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -33,5 +46,16 @@ mod tests {
         assert_eq!(capitalize(""), "");
         assert_eq!(capitalize("g"), "G");
         assert_eq!(capitalize("good"), "Good");
+    }
+
+    #[test]
+    fn remove_last_char() {
+        assert_eq!("".remove_last(), "");
+        assert_eq!("x".remove_last(), "");
+        assert_eq!("X".remove_last(), "");
+        assert_eq!("1".remove_last(), "");
+        assert_eq!("a".remove_last(), "");
+        assert_eq!("fo".remove_last(), "f");
+        assert_eq!("Foobar".remove_last(), "Fooba");
     }
 }

--- a/src/hierarchical_deterministic/bip32/hd_path.rs
+++ b/src/hierarchical_deterministic/bip32/hd_path.rs
@@ -66,13 +66,6 @@ impl HasSampleValues for HDPath {
     }
 }
 
-impl From<Vec<HDPathValue>> for HDPath {
-    fn from(value: Vec<HDPathValue>) -> Self {
-        let vec = value.into_iter().rev().map(Into::into).collect_vec();
-        Self::from_components(vec)
-    }
-}
-
 impl HDPath {
     pub(crate) fn from_components<I>(components: I) -> Self
     where
@@ -213,6 +206,15 @@ mod tests {
     fn from_str() {
         assert_eq!(
             HDPath::from_str("m/44H/1022H").unwrap(),
+            HDPath::harden([44, 1022])
+        );
+    }
+
+
+    #[test]
+    fn from_str_capital_m_is_ok() {
+        assert_eq!(
+            HDPath::from_str("M/44H/1022H").unwrap(),
             HDPath::harden([44, 1022])
         );
     }

--- a/src/hierarchical_deterministic/bip32/hd_path.rs
+++ b/src/hierarchical_deterministic/bip32/hd_path.rs
@@ -210,7 +210,6 @@ mod tests {
         );
     }
 
-
     #[test]
     fn from_str_capital_m_is_ok() {
         assert_eq!(

--- a/src/hierarchical_deterministic/bip32/hd_path.rs
+++ b/src/hierarchical_deterministic/bip32/hd_path.rs
@@ -34,19 +34,22 @@ impl FromStr for HDPath {
             return Err(err);
         }
         let mut path = path;
-        if path.starts_with("m") {
-            path = &path[1..];
+        if path.starts_with("m/") {
+            path = &path[2..];
+        }
+        if path.starts_with("M/") {
+            path = &path[2..];
         }
 
-        let expected_component_count = path.matches("/").count();
-        let replaced = path.replace("/", "\n");
+        let expected_component_count = path.matches('/').count() + 1;
+        let replaced = path.replace('/', "\n");
 
         let components = replaced
             .lines()
             .filter_map(HDPathComponent::try_from_str)
             .collect_vec();
         if components.len() != expected_component_count {
-            return Err(err);
+            Err(err)
         } else {
             Ok(Self::from_components(components))
         }

--- a/src/hierarchical_deterministic/bip32/hd_path_component.rs
+++ b/src/hierarchical_deterministic/bip32/hd_path_component.rs
@@ -1,4 +1,6 @@
-const BIP32_HARDENED: u32 = 2147483648;
+use crate::prelude::*;
+
+pub(crate) const BIP32_HARDENED: u32 = 2147483648;
 
 pub type HDPathValue = u32;
 
@@ -37,6 +39,15 @@ impl HDPathComponent {
 
     pub(crate) fn is_hardened(&self) -> bool {
         self.value >= BIP32_HARDENED
+    }
+
+    pub(crate) fn try_from_str(s: &str) -> Option<Self> {
+        let is_hardened = s.ends_with('H') || s.ends_with('\'');
+        let mut component_str = s;
+        if is_hardened {
+            component_str = component_str.remove_last()
+        }
+        component_str.parse::<HDPathValue>().ok().map(|v| if is_hardened { Self::harden(v) } else { Self::non_hardened(v) })
     }
 
     pub(crate) fn non_hardened(value: HDPathValue) -> Self {

--- a/src/hierarchical_deterministic/bip32/hd_path_component.rs
+++ b/src/hierarchical_deterministic/bip32/hd_path_component.rs
@@ -47,7 +47,13 @@ impl HDPathComponent {
         if is_hardened {
             component_str = component_str.remove_last()
         }
-        component_str.parse::<HDPathValue>().ok().map(|v| if is_hardened { Self::harden(v) } else { Self::non_hardened(v) })
+        component_str.parse::<HDPathValue>().ok().map(|v| {
+            if is_hardened {
+                Self::harden(v)
+            } else {
+                Self::non_hardened(v)
+            }
+        })
     }
 
     pub(crate) fn non_hardened(value: HDPathValue) -> Self {

--- a/src/hierarchical_deterministic/derivation/mnemonic_with_passphrase.rs
+++ b/src/hierarchical_deterministic/derivation/mnemonic_with_passphrase.rs
@@ -82,38 +82,48 @@ impl HasSampleValues for MnemonicWithPassphrase {
 pub type PrivateKeyBytes = [u8; 32];
 
 use crypto::{
-    keys::slip10 as IotaSlip10, signatures::ed25519 as IotaSlip10Ed25519,
+    keys::slip10::{self as IotaSlip10, Hardened as IotaSlip10PathComponent},
+    signatures::ed25519 as IotaSlip10Ed25519,
+    signatures::secp256k1_ecdsa as IotaSlip10Secp256k1,
 };
+
+impl HDPath {
+    fn hardened_chain(&self) -> Vec<IotaSlip10PathComponent> {
+        self.components
+            .iter()
+            .map(|c| c.value)
+            .map(|v| IotaSlip10PathComponent::try_from(v).expect("Should work"))
+            .collect_vec()
+    }
+}
 
 impl MnemonicWithPassphrase {
     pub fn to_seed(&self) -> Seed {
         self.mnemonic.to_seed(&self.passphrase.0)
     }
 
+    fn derive_slip10_private_key<K, I>(
+        seed: &Seed,
+        chain: I,
+    ) -> IotaSlip10::Slip10<K>
+    where
+        K: IotaSlip10::IsSecretKey
+            + IotaSlip10::WithSegment<<I as Iterator>::Item>,
+        I: Iterator,
+        <I as Iterator>::Item: IotaSlip10::Segment,
+    {
+        let seed = IotaSlip10::Seed::from_bytes(seed);
+        seed.derive(chain)
+    }
+
     pub fn derive_ed25519_private_key(
         seed: &Seed,
         path: &HDPath,
     ) -> Ed25519PrivateKey {
-        let seed = IotaSlip10::Seed::from_bytes(seed);
-        // let chain = slip10::BIP32Path::from(
-        //     path.components.iter().map(|c| c.value).collect_vec(),
-        // );
-
-        let low_level_chain: Vec<u32> = path
-            .components
-            .iter()
-            .cloned()
-            .map(|c| c.value)
-            .collect_vec();
-
-        let hardened_chain = low_level_chain
-            .iter()
-            .cloned()
-            .map(|segment| segment.try_into().unwrap());
-
-        let ck: IotaSlip10::Slip10<IotaSlip10Ed25519::SecretKey> =
-            seed.derive(hardened_chain);
-
+        let ck = Self::derive_slip10_private_key::<
+            IotaSlip10Ed25519::SecretKey,
+            _,
+        >(seed, path.hardened_chain().into_iter());
         Ed25519PrivateKey::from_bytes(ck.secret_key().as_slice())
             .expect("Valid Ed25519PrivateKey bytes")
     }
@@ -122,18 +132,13 @@ impl MnemonicWithPassphrase {
         seed: &Seed,
         path: &HDPath,
     ) -> Secp256k1PrivateKey {
-        let chain: bip32::DerivationPath = path
-            .to_string()
-            .replace('H', "'")
-            .parse()
-            .expect("All HDPaths are valid bip32 paths");
-        let child_xprv = bip32::XPrv::derive_from_path(seed, &chain).expect(
-            "To always be able to derive a child key using a valid BIP32 path",
+        let ck = Self::derive_slip10_private_key::<
+            IotaSlip10Secp256k1::SecretKey,
+            _,
+        >(
+            seed, path.components.iter().cloned().map(|c| c.value)
         );
-
-        let private_key_bytes: PrivateKeyBytes =
-            child_xprv.private_key().to_bytes().into();
-        Secp256k1PrivateKey::from(&private_key_bytes)
+        Secp256k1PrivateKey::from_bytes(&*ck.secret_key().to_bytes())
             .expect("Valid Secp256k1PrivateKey bytes")
     }
 

--- a/src/wrapped_radix_engine_toolkit/low_level/compiled_notarized_intent.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/compiled_notarized_intent.rs
@@ -73,6 +73,44 @@ impl HasSampleValues for CompiledNotarizedIntent {
     }
 }
 
+use sbor::ValueKind as ScryptoValueKind;
+#[cfg(test)]
+pub(crate) fn invalid_signed_intent() -> ScryptoSignedIntent {
+    let invalid_value = ScryptoManifestValue::Tuple {
+        fields: vec![ScryptoManifestValue::Array {
+            element_value_kind: ScryptoValueKind::U8,
+            elements: vec![
+                ScryptoManifestValue::U8 { value: 1 },
+                ScryptoManifestValue::U16 { value: 2 },
+            ],
+        }],
+    };
+    let dummy_address = ComponentAddress::with_node_id_bytes(
+        &[0xffu8; 29],
+        NetworkID::Stokenet,
+    );
+    let invalid_instruction = ScryptoInstruction::CallMethod {
+        address: TryInto::<ScryptoDynamicComponentAddress>::try_into(
+            &dummy_address,
+        )
+        .unwrap()
+        .into(),
+        method_name: "dummy".to_owned(),
+        args: invalid_value,
+    };
+    ScryptoSignedIntent {
+        intent: ScryptoIntent {
+            header: TransactionHeader::sample().into(),
+            instructions: ScryptoInstructions(vec![invalid_instruction]),
+            blobs: ScryptoBlobs { blobs: Vec::new() },
+            message: ScryptoMessage::None,
+        },
+        intent_signatures: ScryptoIntentSignatures {
+            signatures: Vec::new(),
+        },
+    }
+}
+
 #[cfg(test)]
 mod tests {
 
@@ -132,43 +170,5 @@ mod tests {
             res,
             Err(CommonError::InvalidNotarizedIntentFailedToEncode { underlying: "MismatchingArrayElementValueKind { element_value_kind: 7, actual_value_kind: 8 }".to_owned() }) 
         );
-    }
-}
-
-use sbor::ValueKind as ScryptoValueKind;
-#[cfg(test)]
-pub(crate) fn invalid_signed_intent() -> ScryptoSignedIntent {
-    let invalid_value = ScryptoManifestValue::Tuple {
-        fields: vec![ScryptoManifestValue::Array {
-            element_value_kind: ScryptoValueKind::U8,
-            elements: vec![
-                ScryptoManifestValue::U8 { value: 1 },
-                ScryptoManifestValue::U16 { value: 2 },
-            ],
-        }],
-    };
-    let dummy_address = ComponentAddress::with_node_id_bytes(
-        &[0xffu8; 29],
-        NetworkID::Stokenet,
-    );
-    let invalid_instruction = ScryptoInstruction::CallMethod {
-        address: TryInto::<ScryptoDynamicComponentAddress>::try_into(
-            &dummy_address,
-        )
-        .unwrap()
-        .into(),
-        method_name: "dummy".to_owned(),
-        args: invalid_value,
-    };
-    ScryptoSignedIntent {
-        intent: ScryptoIntent {
-            header: TransactionHeader::sample().into(),
-            instructions: ScryptoInstructions(vec![invalid_instruction]),
-            blobs: ScryptoBlobs { blobs: Vec::new() },
-            message: ScryptoMessage::None,
-        },
-        intent_signatures: ScryptoIntentSignatures {
-            signatures: Vec::new(),
-        },
     }
 }

--- a/src/wrapped_radix_engine_toolkit/low_level/notarized_transaction.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/notarized_transaction.rs
@@ -178,7 +178,7 @@ mod tests {
                 NetworkID::Stokenet
             ),
             Err(CommonError::InvalidTransactionMaxSBORDepthExceeded {
-                max: 24 as u16
+                max: 24_u16
             })
         );
     }

--- a/src/wrapped_radix_engine_toolkit/low_level/signed_intent.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/signed_intent.rs
@@ -287,7 +287,7 @@ mod tests {
                 NetworkID::Stokenet
             ),
             Err(CommonError::InvalidTransactionMaxSBORDepthExceeded {
-                max: 24 as u16
+                max: 24_u16
             })
         );
     }

--- a/src/wrapped_radix_engine_toolkit/low_level/transaction_intent.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/transaction_intent.rs
@@ -210,7 +210,7 @@ mod tests {
                 NetworkID::Stokenet
             ),
             Err(CommonError::InvalidTransactionMaxSBORDepthExceeded {
-                max: 20 as u16
+                max: 20_u16
             })
         );
     }

--- a/src/wrapped_radix_engine_toolkit/low_level/transaction_manifest/instructions/instructions.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/transaction_manifest/instructions/instructions.rs
@@ -406,7 +406,7 @@ mod tests {
                 NetworkID::Stokenet
             ),
             Err(CommonError::InvalidTransactionMaxSBORDepthExceeded {
-                max: 20 as u16
+                max: 20_u16
             })
         );
     }


### PR DESCRIPTION
Remove `slip10` crate by random dude => replaced with IOTA's which can be deemed trustworthy => which also implements Secp256k1 SLIP10! So we can then also remove `bip32` crate
Add `k256` (already added, as transitive dependency!) explicitly, so that we can crate Secp256k1PublicKey from uncompressed bytes.

This was the "hard part" of the work of making Sargon production ready viz. pinning Dependencies in Cargo.toml. A trivial follow up PR will be made tommorrow pinning the rest.