### PR TITLE
Avoid passing mnemonic in ffi

### DIFF
--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/Profile.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/Profile.kt
@@ -1,17 +1,17 @@
 package com.radixdlt.sargon.extensions
 
 import com.radixdlt.sargon.BagOfBytes
-import com.radixdlt.sargon.PrivateHierarchicalDeterministicFactorSource
+import com.radixdlt.sargon.DeviceFactorSource
 import com.radixdlt.sargon.Profile
 import com.radixdlt.sargon.newProfile
 import com.radixdlt.sargon.newProfileFromJsonBytes
 import com.radixdlt.sargon.profileToJsonBytes
 
 fun Profile.Companion.init(
-    privateHdFactorSource: PrivateHierarchicalDeterministicFactorSource,
+    deviceFactorSource: DeviceFactorSource,
     creatingDeviceName: String
 ) = newProfile(
-    privateHdFactorSource = privateHdFactorSource,
+    deviceFactorSource = deviceFactorSource,
     creatingDeviceName = creatingDeviceName
 )
 

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/ProfileTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/ProfileTest.kt
@@ -22,7 +22,8 @@ class ProfileTest: SampleTestable<Profile> {
         )
 
         val profile = Profile.init(
-            privateHdFactorSource = hdFactorSource, creatingDeviceName = "Unit tests"
+            deviceFactorSource = hdFactorSource.factorSource,
+            creatingDeviceName = "Unit tests"
         )
 
         assertEquals("Unit tests - Android", profile.header.creatingDevice.description)

--- a/src/profile/v100/profile.rs
+++ b/src/profile/v100/profile.rs
@@ -68,20 +68,23 @@ impl Profile {
 }
 
 impl Profile {
-    /// Creates a new Profile from the `PrivateHierarchicalDeterministicFactorSource`, without any
+    /// Creates a new Profile from the `DeviceFactorSource`, without any
     /// networks (thus no accounts), with creating device info as "unknown".
     pub fn new(
-        private_device_factor_source: PrivateHierarchicalDeterministicFactorSource,
+        device_factor_source: DeviceFactorSource,
         creating_device_name: &str,
     ) -> Self {
-        let bdfs = private_device_factor_source.factor_source;
         let creating_device = DeviceInfo::with_description(
-            format!("{} - {}", creating_device_name, bdfs.hint.model).as_str(),
+            format!(
+                "{} - {}",
+                creating_device_name, device_factor_source.hint.model
+            )
+            .as_str(),
         );
         let header = Header::new(creating_device);
         Self::with(
             header,
-            FactorSources::with_bdfs(bdfs),
+            FactorSources::with_bdfs(device_factor_source),
             AppPreferences::default(),
             ProfileNetworks::new(),
         )
@@ -394,7 +397,8 @@ mod tests {
                 SUT::new(
                     PrivateHierarchicalDeterministicFactorSource::generate_new(
                         WalletClientModel::Unknown,
-                    ),
+                    )
+                    .factor_source,
                     "Foo",
                 )
             })

--- a/src/profile/v100/profile_uniffi_fn.rs
+++ b/src/profile/v100/profile_uniffi_fn.rs
@@ -2,10 +2,10 @@ use crate::prelude::*;
 
 #[uniffi::export]
 pub fn new_profile(
-    private_hd_factor_source: PrivateHierarchicalDeterministicFactorSource,
+    device_factor_source: DeviceFactorSource,
     creating_device_name: String,
 ) -> Profile {
-    Profile::new(private_hd_factor_source, creating_device_name.as_str())
+    Profile::new(device_factor_source, creating_device_name.as_str())
 }
 
 #[uniffi::export]
@@ -55,7 +55,10 @@ mod uniffi_tests {
     #[test]
     fn new_private_hd() {
         let private = PrivateHierarchicalDeterministicFactorSource::sample();
-        let lhs = super::new_profile(private.clone(), "iPhone".to_string());
+        let lhs = super::new_profile(
+            private.factor_source.clone(),
+            "iPhone".to_string(),
+        );
         assert_eq!(
             lhs.bdfs().factor_source_id(),
             private.factor_source.factor_source_id()

--- a/src/wallet/wallet.rs
+++ b/src/wallet/wallet.rs
@@ -96,7 +96,7 @@ impl Wallet {
             );
 
         let profile = Profile::new(
-            private_hd_factor_source.clone(),
+            private_hd_factor_source.factor_source.clone(),
             wallet_client_name.as_str(),
         );
         let wallet = Self::with_imported_profile(profile, secure_storage);

--- a/src/wallet/wallet_accounts.rs
+++ b/src/wallet/wallet_accounts.rs
@@ -446,7 +446,8 @@ mod tests {
     {
         test_new_account(
             Profile::new(
-                PrivateHierarchicalDeterministicFactorSource::sample(),
+                PrivateHierarchicalDeterministicFactorSource::sample()
+                    .factor_source,
                 "Test",
             ),
             also_save,


### PR DESCRIPTION
* Removed the `PrivateHierarchicalDeterministicFactorSource` as a parameter in Profile initialization and replaced it with just the `DeviceFactorSource`