### PR TITLE
Create SupportedCurves and OtherGateways through macro

### DIFF
--- a/src/core/error/common_error.rs
+++ b/src/core/error/common_error.rs
@@ -430,6 +430,9 @@ pub enum CommonError {
 
     #[error("Submitted transaction was duplicate.")]
     GatewaySubmitDuplicateTX { intent_hash: String } = 10119,
+
+    #[error("SupportedCurves must not be empty.")]
+    SupportedCurvesMustNotBeEmpty = 10120,
 }
 
 #[uniffi::export]

--- a/src/core/types/keys/slip10_curve.rs
+++ b/src/core/types/keys/slip10_curve.rs
@@ -18,6 +18,7 @@ use crate::prelude::*;
     PartialOrd,
     Ord,
     uniffi::Enum,
+    derive_more::Display,
 )]
 #[serde(rename_all = "camelCase")]
 pub enum SLIP10Curve {
@@ -37,6 +38,16 @@ impl Identifiable for SLIP10Curve {
             Self::Curve25519 => "curve25519".to_string(),
             Self::Secp256k1 => "secp256k1".to_string(),
         }
+    }
+}
+
+impl HasSampleValues for SLIP10Curve {
+    fn sample() -> Self {
+        Self::Curve25519
+    }
+
+    fn sample_other() -> Self {
+        Self::Secp256k1
     }
 }
 

--- a/src/profile/v100/app_preferences/gateways/gateway.rs
+++ b/src/profile/v100/app_preferences/gateways/gateway.rs
@@ -80,6 +80,16 @@ impl Gateway {
     }
 }
 
+impl HasSampleValues for Gateway {
+    fn sample() -> Self {
+        Gateway::mainnet()
+    }
+
+    fn sample_other() -> Self {
+        Gateway::stokenet()
+    }
+}
+
 #[uniffi::export]
 pub fn gateway_mainnet() -> Gateway {
     Gateway::mainnet()

--- a/src/profile/v100/app_preferences/gateways/gateways.rs
+++ b/src/profile/v100/app_preferences/gateways/gateways.rs
@@ -14,7 +14,7 @@ pub struct Gateways {
     /// Other by user added or predefined Gateways the user can switch to.
     /// It might be Gateways with different URLs on the SAME network, or
     /// other networks, the identifier of a Gateway is the URL.
-    pub other: IdentifiedVecVia<Gateway>,
+    pub other: OtherGateways,
 }
 
 /// Constructs `Gateways` with `current` set as active Gateway.
@@ -103,7 +103,7 @@ impl Gateways {
     pub fn new(current: Gateway) -> Self {
         Self {
             current,
-            other: IdentifiedVecVia::new(),
+            other: OtherGateways::default(),
         }
     }
 
@@ -111,7 +111,7 @@ impl Gateways {
     where
         I: IntoIterator<Item = Gateway>,
     {
-        let other = IdentifiedVecVia::from_iter(other);
+        let other = OtherGateways::from_iter(other);
         if other.contains(&current) {
             return Err(
                 CommonError::GatewaysDiscrepancyOtherShouldNotContainCurrent,
@@ -175,6 +175,16 @@ impl HasSampleValues for Gateways {
     }
 }
 
+impl HasSampleValues for OtherGateways {
+    fn sample() -> Self {
+        OtherGateways::from_iter([Gateway::stokenet()])
+    }
+
+    fn sample_other() -> Self {
+        OtherGateways::from_iter([Gateway::stokenet(), Gateway::hammunet()])
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::prelude::*;
@@ -212,7 +222,7 @@ mod tests {
     fn change_throw_gateways_discrepancy_other_should_not_contain_current() {
         let mut impossible = Gateways {
             current: Gateway::mainnet(),
-            other: IdentifiedVecVia::from_iter([Gateway::mainnet()]),
+            other: OtherGateways::from_iter([Gateway::mainnet()]),
         };
         assert_eq!(
             impossible.change_current(Gateway::stokenet()),

--- a/src/profile/v100/factors/factor_source_crypto_parameters.rs
+++ b/src/profile/v100/factors/factor_source_crypto_parameters.rs
@@ -84,6 +84,20 @@ impl Default for FactorSourceCryptoParameters {
     }
 }
 
+impl HasSampleValues for SupportedCurves {
+    fn sample() -> Self {
+        SupportedCurves::just(SLIP10Curve::Curve25519)
+    }
+
+    fn sample_other() -> Self {
+        SupportedCurves::from_iter([
+            SLIP10Curve::Curve25519,
+            SLIP10Curve::Secp256k1,
+        ])
+        .unwrap()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::prelude::*;

--- a/src/profile/v100/factors/factor_sources/factor_sources.rs
+++ b/src/profile/v100/factors/factor_sources/factor_sources.rs
@@ -14,7 +14,7 @@ impl FactorSources {
     /// AND marked "main".
     pub fn with_bdfs(device_factor_source: DeviceFactorSource) -> Self {
         assert!(device_factor_source.is_main_bdfs());
-        Self::with_factor_source(device_factor_source.into())
+        Self::just(device_factor_source.into())
     }
 }
 

--- a/src/profile/v100/identified_elements.rs
+++ b/src/profile/v100/identified_elements.rs
@@ -8,8 +8,8 @@ macro_rules! decl_identified_array_of {
         $(
             #[doc = $expr: expr]
         )*
-        $element_type: ty,
 		$struct_type: ident,
+        $element_type: ty,
 		$collection_type: ty
     ) => {
         paste! {
@@ -39,7 +39,7 @@ macro_rules! decl_identified_array_of {
                 }
             }
 
-            impl [< $element_type s >] {
+            impl $struct_type {
                 /// Returns a reference to the element identified by `id`, if it exists.
                 pub fn [< get_ $element_type:snake _by_id>](
                     &self,
@@ -123,14 +123,14 @@ macro_rules! decl_identified_array_of {
 }
 
 /// Impl rules for identified_array_of implementations which can be empty
-macro_rules! dec_can_be_empty_impl {
+macro_rules! decl_can_be_empty_impl {
     (
-        $element_type: ty,
         $struct_type: ty,
+        $element_type: ty,
         $secret_magic: ty
     ) => {
         paste! {
-            impl [< $element_type s >] {
+            impl $struct_type {
 
                 #[allow(clippy::should_implement_trait)]
                 pub fn from_iter<I>([<  $struct_type:lower >]: I) -> Self
@@ -142,15 +142,8 @@ macro_rules! dec_can_be_empty_impl {
                     }
                 }
 
-                pub fn [< with_ $struct_type:snake >]<I>([< $struct_type:snake >]: I) -> Self
-                where
-                    I: IntoIterator<Item = $element_type>,
-                {
-                    Self::from_iter([< $struct_type:snake >])
-                }
-
-                pub fn [< with_ $element_type:snake >]([< $element_type:snake >]: $element_type) -> Self {
-                    Self::[< with_ $struct_type:snake >]([[< $element_type:snake >]])
+                pub fn just([< $element_type:snake >]: $element_type) -> Self {
+                    Self::from_iter([[< $element_type:snake >]])
                 }
             }
 
@@ -158,7 +151,7 @@ macro_rules! dec_can_be_empty_impl {
             impl Default for $struct_type {
                 /// Instantiates a new empty collection.
                 fn default() -> Self {
-                    Self::[< with_ $struct_type:snake >]([])
+                    Self::from_iter([])
                 }
             }
 
@@ -196,14 +189,14 @@ macro_rules! dec_can_be_empty_impl {
 }
 
 /// Impl rules for identified_array_of implementations which must not be empty
-macro_rules! dec_never_empty_impl {
+macro_rules! decl_never_empty_impl {
     (
-        $element_type: ty,
         $struct_type: ty,
+        $element_type: ty,
         $secret_magic: ty
     ) => {
         paste! {
-            impl [< $element_type s >] {
+            impl $struct_type {
 
                 #[allow(clippy::should_implement_trait)]
                 pub fn from_iter<I>([<  $struct_type:snake >]: I) -> Result<Self>
@@ -220,15 +213,8 @@ macro_rules! dec_never_empty_impl {
                     }
                 }
 
-                pub fn [< with_ $struct_type:snake >]<I>([< $struct_type:snake >]: I) -> Result<Self>
-                where
-                    I: IntoIterator<Item = $element_type>,
-                {
-                    Self::from_iter([< $struct_type:snake >])
-                }
-
-                pub fn [< with_ $element_type:snake >]([< $element_type:snake >]: $element_type) -> Self {
-                    Self::[< with_ $struct_type:snake >]([[< $element_type:snake >]]).unwrap()
+                pub fn just([< $element_type:snake >]: $element_type) -> Self {
+                    Self::from_iter([[< $element_type:snake >]]).unwrap()
                 }
             }
 
@@ -267,6 +253,7 @@ macro_rules! decl_can_be_empty_identified_array_of {
         $(
             #[doc = $expr: expr]
         )*
+        $struct_type: ty,
         $element_type: ty
     ) => {
         paste! {
@@ -274,15 +261,15 @@ macro_rules! decl_can_be_empty_identified_array_of {
 				$(
                     #[doc = $expr]
                 )*
+				$struct_type,
 				$element_type,
-				[< $element_type s >],
 				IdentifiedVecVia<$element_type>
 			);
 
-            dec_can_be_empty_impl!(
+            decl_can_be_empty_impl!(
+                $struct_type,
                 $element_type,
-                [< $element_type s >],
-                [< $element_type s SecretMagic >]
+                [< $struct_type SecretMagic >]
             );
 		}
 	};
@@ -293,6 +280,7 @@ macro_rules! decl_never_empty_identified_array_of {
         $(
             #[doc = $expr: expr]
         )*
+        $struct_type: ty,
         $element_type: ty
     ) => {
         paste! {
@@ -300,15 +288,15 @@ macro_rules! decl_never_empty_identified_array_of {
 				$(
                     #[doc = $expr]
                 )*
+				$struct_type,
 				$element_type,
-				[< $element_type s >],
 				IdentifiedVecVia<$element_type>
 			);
 
-            dec_never_empty_impl!(
+            decl_never_empty_impl!(
+                $struct_type,
                 $element_type,
-                [< $element_type s >],
-                [< $element_type s SecretMagic >]
+                [< $struct_type SecretMagic >]
             );
 		}
 	};
@@ -318,21 +306,40 @@ decl_can_be_empty_identified_array_of!(
     /// An ordered set of [`Account`]s on a specific network, most commonly
     /// the set is non-empty, since wallets guide user to create a first
     /// Account.
+    Accounts,
     Account
 );
 
 decl_can_be_empty_identified_array_of!(
     /// An ordered set of [`Persona`]s on a specific network.
+    Personas,
     Persona
 );
 
 decl_can_be_empty_identified_array_of!(
     /// An ordered set of ['AuthorizedDapp`]s on a specific network.
+    AuthorizedDapps,
     AuthorizedDapp
 );
 
 decl_never_empty_identified_array_of!(
     /// A collection of [`FactorSource`]s generated by a wallet or manually added by user.
     /// MUST never be empty.
+    FactorSources,
     FactorSource
+);
+
+decl_can_be_empty_identified_array_of!(
+    /// Other by user added or predefined Gateways the user can switch to.
+    /// It might be Gateways with different URLs on the SAME network, or
+    /// other networks, the identifier of a Gateway is the URL.
+    OtherGateways,
+    Gateway
+);
+
+decl_never_empty_identified_array_of!(
+    /// A collection of [`SLIP10Curve`]s that a factor source supports.
+    /// MUST never be empty.
+    SupportedCurves,
+    SLIP10Curve
 );

--- a/src/profile/v100/networks/network/accounts.rs
+++ b/src/profile/v100/networks/network/accounts.rs
@@ -17,7 +17,7 @@ impl HasSampleValues for Accounts {
 impl Accounts {
     /// A sample used to facilitate unit tests.
     pub fn sample_mainnet() -> Self {
-        Self::with_accounts([
+        Self::from_iter([
             Account::sample_mainnet(),
             Account::sample_mainnet_other(),
         ])
@@ -25,7 +25,7 @@ impl Accounts {
 
     /// A sample used to facilitate unit tests.
     pub fn sample_stokenet() -> Self {
-        Self::with_accounts([
+        Self::from_iter([
             Account::sample_stokenet_nadia(),
             Account::sample_stokenet_olivia(),
         ])
@@ -58,17 +58,15 @@ mod tests {
     #[test]
     fn duplicates_are_prevented() {
         assert_eq!(
-            SUT::with_accounts(
-                [Account::sample(), Account::sample()].into_iter()
-            )
-            .len(),
+            SUT::from_iter([Account::sample(), Account::sample()].into_iter())
+                .len(),
             1
         )
     }
 
     #[test]
     fn with_one() {
-        assert_eq!(SUT::with_account(Account::sample()).len(), 1)
+        assert_eq!(SUT::just(Account::sample()).len(), 1)
     }
 
     #[test]
@@ -84,7 +82,7 @@ mod tests {
             DisplayName::default(),
             AppearanceID::default(),
         );
-        let accounts = SUT::with_account(account.clone());
+        let accounts = SUT::just(account.clone());
         assert_eq!(accounts.get_account_by_id(&address), Some(&account));
     }
 

--- a/src/profile/v100/networks/network/authorized_dapps.rs
+++ b/src/profile/v100/networks/network/authorized_dapps.rs
@@ -15,7 +15,7 @@ impl HasSampleValues for AuthorizedDapps {
 impl AuthorizedDapps {
     /// A sample used to facilitate unit tests.
     pub fn sample_mainnet() -> Self {
-        Self::with_authorized_dapps([
+        Self::from_iter([
             AuthorizedDapp::sample_mainnet_dashboard(),
             AuthorizedDapp::sample_mainnet_gumballclub(),
         ])
@@ -23,7 +23,7 @@ impl AuthorizedDapps {
 
     /// A sample used to facilitate unit tests.
     pub fn sample_stokenet() -> Self {
-        Self::with_authorized_dapps([
+        Self::from_iter([
             AuthorizedDapp::sample_stokenet_devconsole(),
             AuthorizedDapp::sample_stokenet_sandbox(),
         ])
@@ -56,7 +56,7 @@ mod tests {
     #[test]
     fn duplicates_are_prevented() {
         assert_eq!(
-            AuthorizedDapps::with_authorized_dapps(
+            AuthorizedDapps::from_iter(
                 [AuthorizedDapp::sample(), AuthorizedDapp::sample()]
                     .into_iter()
             )
@@ -67,11 +67,7 @@ mod tests {
 
     #[test]
     fn with_one() {
-        assert_eq!(
-            AuthorizedDapps::with_authorized_dapp(AuthorizedDapp::sample())
-                .len(),
-            1
-        )
+        assert_eq!(AuthorizedDapps::just(AuthorizedDapp::sample()).len(), 1)
     }
 
     #[test]
@@ -83,8 +79,7 @@ mod tests {
     fn get_by_address() {
         let authorized_dapp = AuthorizedDapp::sample();
         let address = authorized_dapp.dapp_definition_address;
-        let authorized_dapps =
-            AuthorizedDapps::with_authorized_dapp(authorized_dapp.clone());
+        let authorized_dapps = AuthorizedDapps::just(authorized_dapp.clone());
         assert_eq!(
             authorized_dapps.get_authorized_dapp_by_id(&address),
             Some(&authorized_dapp)

--- a/src/profile/v100/networks/network/personas.rs
+++ b/src/profile/v100/networks/network/personas.rs
@@ -15,7 +15,7 @@ impl HasSampleValues for Personas {
 impl Personas {
     /// A sample used to facilitate unit tests.
     pub fn sample_mainnet() -> Self {
-        Self::with_personas([
+        Self::from_iter([
             Persona::sample_mainnet_satoshi(),
             Persona::sample_mainnet_batman(),
         ])
@@ -23,7 +23,7 @@ impl Personas {
 
     /// A sample used to facilitate unit tests.
     pub fn sample_stokenet() -> Self {
-        Self::with_personas([
+        Self::from_iter([
             Persona::sample_stokenet_leia_skywalker(),
             Persona::sample_stokenet_hermione(),
         ])
@@ -53,7 +53,7 @@ mod tests {
     #[test]
     fn duplicates_are_prevented() {
         assert_eq!(
-            Personas::with_personas(
+            Personas::from_iter(
                 [Persona::sample(), Persona::sample()].into_iter()
             )
             .len(),
@@ -63,7 +63,7 @@ mod tests {
 
     #[test]
     fn with_one() {
-        assert_eq!(Personas::with_persona(Persona::sample()).len(), 1)
+        assert_eq!(Personas::just(Persona::sample()).len(), 1)
     }
 
     #[test]
@@ -75,7 +75,7 @@ mod tests {
     fn get_by_address() {
         let persona = Persona::sample();
         let address = persona.address;
-        let personas = Personas::with_persona(persona.clone());
+        let personas = Personas::just(persona.clone());
         assert_eq!(personas.get_persona_by_id(&address), Some(&persona));
     }
 

--- a/src/profile/v100/networks/network/profile_network.rs
+++ b/src/profile/v100/networks/network/profile_network.rs
@@ -176,7 +176,7 @@ mod tests {
         assert_eq!(
             ProfileNetwork::new(
                 NetworkID::Mainnet,
-                Accounts::with_accounts(
+                Accounts::from_iter(
                     [Account::sample(), Account::sample()].into_iter()
                 ),
                 Personas::default(),
@@ -195,7 +195,7 @@ mod tests {
     fn panic_when_network_id_mismatch_between_accounts_and_value() {
         ProfileNetwork::new(
             NetworkID::Mainnet,
-            Accounts::with_account(Account::sample_stokenet()),
+            Accounts::just(Account::sample_stokenet()),
             Personas::default(),
             AuthorizedDapps::default(),
         );
@@ -209,7 +209,7 @@ mod tests {
         ProfileNetwork::new(
             NetworkID::Mainnet,
             Accounts::sample_mainnet(),
-            Personas::with_persona(Persona::sample_stokenet()),
+            Personas::just(Persona::sample_stokenet()),
             AuthorizedDapps::default(),
         );
     }
@@ -223,9 +223,7 @@ mod tests {
             NetworkID::Mainnet,
             Accounts::sample_mainnet(),
             Personas::sample_mainnet(),
-            AuthorizedDapps::with_authorized_dapp(
-                AuthorizedDapp::sample_stokenet(),
-            ),
+            AuthorizedDapps::just(AuthorizedDapp::sample_stokenet()),
         );
     }
 

--- a/src/profile/v100/networks/profile_networks.rs
+++ b/src/profile/v100/networks/profile_networks.rs
@@ -211,7 +211,7 @@ mod tests {
     fn with_network() {
         let network = ProfileNetwork::new(
             NetworkID::Mainnet,
-            Accounts::with_account(Account::sample_mainnet()),
+            Accounts::just(Account::sample_mainnet()),
             Personas::default(),
             AuthorizedDapps::default(),
         );


### PR DESCRIPTION
* Identified array of `[SLIP10Curve]` can now be referred to as `SLIP10Curves`
* `other: IdentifiedVecVia<Gateway>` is now called as `OtherGateways`. Could not refer to it as `Gateways` since Gateways is another struct with current inside. So I had to change the `decl_...` api a bit.
* The `impl` methods has a small renaming. For structs like `SLIP10Curve` the method that was creating the struct with just one curve would be named `with_s_l_i_p_10_curve()`. IMHO the name `just` for a method that instantiates an array with just one element inside was easier to remember. Also I just kept `from_iter` instead of redefining another method since it was doing the same thing.