### PR TITLE
Header + MnemonicWithPassphrase JSON codable | fix SargonObjectCodable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2528,7 +2528,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "0.6.37"
+version = "0.6.38"
 dependencies = [
  "actix-rt",
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "0.6.37"
+version = "0.6.38"
 edition = "2021"
 build = "build.rs"
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,21 +1,21 @@
 {
   "pins" : [
     {
-      "identity" : "anycodable",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Flight-School/AnyCodable",
-      "state" : {
-        "revision" : "862808b2070cd908cb04f9aafe7de83d35f81b05",
-        "version" : "0.6.7"
-      }
-    },
-    {
       "identity" : "swift-custom-dump",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
         "revision" : "f01efb26f3a192a0e88dcdb7c3c391ec2fc25d9c",
         "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swiftyjson",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SwiftyJSON/SwiftyJSON",
+      "state" : {
+        "revision" : "af76cf3ef710b6ca5f8c05f3a31307d44a3c5828",
+        "version" : "5.0.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -50,7 +50,7 @@ let package = Package(
 	],
 	dependencies: [
 		.package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.3.0"),
-		.package(url: "https://github.com/Flight-School/AnyCodable", from: "0.6.7"),
+		.package(url: "https://github.com/SwiftyJSON/SwiftyJSON", from: "5.0.2"),
 	],
 	targets: [
 		binaryTarget,
@@ -63,7 +63,7 @@ let package = Package(
 			name: "Sargon",
 			dependencies: [
 				.target(name: "SargonUniFFI"),
-				"AnyCodable",
+				"SwiftyJSON",
 			],
 			path: "apple/Sources/Sargon",
 			swiftSettings: swiftSettings

--- a/apple/Sources/Sargon/Extensions/Methods/Crypto/Derivation/MnemonicWithPassphrase+Wrap+Functions.swift
+++ b/apple/Sources/Sargon/Extensions/Methods/Crypto/Derivation/MnemonicWithPassphrase+Wrap+Functions.swift
@@ -1,0 +1,19 @@
+//
+//  File.swift
+//  
+//
+//  Created by Alexander Cyon on 2024-04-19.
+//
+
+import Foundation
+import SargonUniFFI
+
+extension MnemonicWithPassphrase {
+	public init(jsonData: some DataProtocol) throws {
+		self = try newMnemonicWithPassphraseFromJsonBytes(jsonBytes: Data(jsonData))
+	}
+	
+	public func jsonData() -> Data {
+		mnemonicWithPassphraseToJsonBytes(mnemonicWithPassphrase: self)
+	}
+}

--- a/apple/Sources/Sargon/Extensions/Methods/Profile/Header+Wrap+Functions.swift
+++ b/apple/Sources/Sargon/Extensions/Methods/Profile/Header+Wrap+Functions.swift
@@ -1,0 +1,19 @@
+//
+//  File.swift
+//
+//
+//  Created by Alexander Cyon on 2024-04-19.
+//
+
+import Foundation
+import SargonUniFFI
+
+extension Header {
+	public init(jsonData: some DataProtocol) throws {
+		self = try newHeaderFromJsonBytes(jsonBytes: Data(jsonData))
+	}
+	
+	public func jsonData() -> Data {
+		headerToJsonBytes(header: self)
+	}
+}

--- a/apple/Sources/Sargon/Extensions/Methods/Profile/Profile+Wrap+Functions.swift
+++ b/apple/Sources/Sargon/Extensions/Methods/Profile/Profile+Wrap+Functions.swift
@@ -3,7 +3,7 @@ import SargonUniFFI
 
 extension Profile {
     public init(json bytes: some DataProtocol) throws {
-		self = try newProfileFromJsonBytes(json: BagOfBytes(bytes))
+		self = try newProfileFromJsonBytes(jsonBytes: Data(bytes))
 	}
 	
 	public init(encrypted bytes: some DataProtocol, decryptionPassword: String) throws {

--- a/apple/Sources/Sargon/Extensions/SampleValues/Crypto/Derivation/MnemonicWithPassphrase+SampleValues.swift
+++ b/apple/Sources/Sargon/Extensions/SampleValues/Crypto/Derivation/MnemonicWithPassphrase+SampleValues.swift
@@ -1,0 +1,16 @@
+//
+//  File.swift
+//  
+//
+//  Created by Alexander Cyon on 2024-04-19.
+//
+
+import Foundation
+import SargonUniFFI
+
+#if DEBUG
+extension MnemonicWithPassphrase {
+	public static let sample: Self = newMnemonicWithPassphraseSample()
+	public static let sampleOther: Self = newMnemonicWithPassphraseSampleOther()
+}
+#endif // DEBUG

--- a/apple/Sources/Sargon/Extensions/SampleValues/Profile/Header+SampleValues.swift
+++ b/apple/Sources/Sargon/Extensions/SampleValues/Profile/Header+SampleValues.swift
@@ -1,0 +1,16 @@
+//
+//  File.swift
+//  
+//
+//  Created by Alexander Cyon on 2024-04-19.
+//
+
+import Foundation
+import SargonUniFFI
+
+#if DEBUG
+extension Header {
+	public static let sample: Self = newHeaderSample()
+	public static let sampleOther: Self = newHeaderSampleOther()
+}
+#endif // DEBUG

--- a/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Derivation/MnemonicWithPassphrase+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Derivation/MnemonicWithPassphrase+Swiftified.swift
@@ -1,0 +1,12 @@
+//
+//  File.swift
+//  
+//
+//  Created by Alexander Cyon on 2024-04-19.
+//
+
+import Foundation
+import SargonUniFFI
+
+extension MnemonicWithPassphrase: SargonModel {}
+extension MnemonicWithPassphrase: SargonObjectCodable {}

--- a/apple/Sources/Sargon/Extensions/Swiftified/Profile/Header+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Profile/Header+Swiftified.swift
@@ -1,0 +1,12 @@
+//
+//  File.swift
+//  
+//
+//  Created by Alexander Cyon on 2024-04-19.
+//
+
+import Foundation
+import SargonUniFFI
+
+extension Header: SargonModel {}
+extension Header: SargonObjectCodable {}

--- a/apple/Sources/Sargon/Util/SargonObjectCodable.swift
+++ b/apple/Sources/Sargon/Util/SargonObjectCodable.swift
@@ -1,5 +1,5 @@
 import Foundation
-import AnyCodable
+import SwiftyJSON
 
 public protocol SargonObjectCodable: Codable {
 	init(jsonData: some DataProtocol) throws
@@ -8,16 +8,14 @@ public protocol SargonObjectCodable: Codable {
 
 extension SargonObjectCodable {
 	public func encode(to encoder: any Encoder) throws {
-		let dict = try JSONSerialization.jsonObject(with: self.jsonData(), options: []) as! NSDictionary
-		let anyEncodable = AnyEncodable(dict)
 		var container = encoder.singleValueContainer()
-		try container.encode(anyEncodable)
+		let json = try JSON(data: jsonData())
+		try container.encode(json)
 	}
 	
 	public init(from decoder: any Decoder) throws {
 		let container = try decoder.singleValueContainer()
-		let anyDecodable = try container.decode(AnyDecodable.self)
-		let jsonData = try JSONSerialization.data(withJSONObject: anyDecodable.value)
-		try self.init(jsonData: jsonData)
+		let json = try container.decode(JSON.self)
+		try self.init(jsonData: json.rawData())
 	}
 }

--- a/apple/Tests/TestCases/Crypto/MnemonicWithPassphraseTests.swift
+++ b/apple/Tests/TestCases/Crypto/MnemonicWithPassphraseTests.swift
@@ -1,0 +1,34 @@
+import CustomDump
+import Foundation
+import Sargon
+import SargonUniFFI
+import XCTest
+
+final class MnemonicWithPassphraseTests: Test<MnemonicWithPassphrase> {
+	
+	func test_not_codable_but_lower_level_json_methods_json_data_roundtrip() throws{
+		let sut = SUT.sample
+		let json = sut.jsonData()
+		try XCTAssertEqual(
+			SUT(jsonData: json),
+			sut
+		)
+	}
+	
+	func test_codable() throws {
+		let raw = """
+		{
+			"mnemonic": "bright club bacon dinner achieve pull grid save ramp cereal blush woman humble limb repeat video sudden possible story mask neutral prize goose mandate",
+			"passphrase": "radix"
+		}
+		""".data(using: .utf8)!
+		
+		// test decoding
+		let sut = try JSONDecoder().decode(SUT.self, from: raw)
+		XCTAssertEqual(sut, SUT.sample)
+		
+		// test encoding
+		let encoded = try JSONEncoder().encode(sut)
+		try XCTAssertEqual(JSONDecoder().decode(SUT.self, from: encoded), sut)
+	}
+}

--- a/apple/Tests/TestCases/Profile/HeaderTests.swift
+++ b/apple/Tests/TestCases/Profile/HeaderTests.swift
@@ -1,0 +1,50 @@
+import CustomDump
+import Foundation
+import Sargon
+import SargonUniFFI
+import XCTest
+
+final class HeaderTests: Test<Header> {
+	
+	func test_not_codable_but_lower_level_json_methods_json_data_roundtrip() throws{
+		let sut = SUT.sample
+		let json = sut.jsonData()
+		try XCTAssertEqual(
+			SUT(jsonData: json),
+			sut
+		)
+	}
+	
+	func test_codable() throws {
+		let raw = """
+		{
+			"snapshotVersion": 100,
+			"id": "12345678-bbbb-cccc-dddd-abcd12345678",
+			"creatingDevice": {
+				"id": "66f07ca2-a9d9-49e5-8152-77aca3d1dd74",
+				"date": "2023-09-11T16:05:56.000Z",
+				"description": "iPhone"
+			},
+			"lastUsedOnDevice": {
+				"id": "66f07ca2-a9d9-49e5-8152-77aca3d1dd74",
+				"date": "2023-09-11T16:05:56.000Z",
+				"description": "iPhone"
+			},
+			"lastModified": "2023-09-11T16:05:56.000Z",
+			"contentHint": {
+				"numberOfAccountsOnAllNetworksInTotal": 4,
+				"numberOfPersonasOnAllNetworksInTotal": 0,
+				"numberOfNetworks": 2
+			}
+		}
+		""".data(using: .utf8)!
+		
+		// test decoding
+		let sut = try JSONDecoder().decode(SUT.self, from: raw)
+		XCTAssertEqual(sut, SUT.sample)
+		
+		// test encoding
+		let encoded = try JSONEncoder().encode(sut)
+		try XCTAssertEqual(JSONDecoder().decode(SUT.self, from: encoded), sut)
+	}
+}

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/Profile.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/Profile.kt
@@ -16,7 +16,7 @@ fun Profile.Companion.init(
 )
 
 @Throws(SargonException::class)
-fun Profile.Companion.init(json: BagOfBytes) = newProfileFromJsonBytes(json = json)
+fun Profile.Companion.init(json: BagOfBytes) = newProfileFromJsonBytes(jsonBytes = json)
 
 @Throws(SargonException::class)
 fun Profile.snapshotJson() = profileToJsonBytes(profile = this)

--- a/src/core/utils/mod.rs
+++ b/src/core/utils/mod.rs
@@ -5,3 +5,21 @@ mod string_utils;
 pub use factory::*;
 pub use logged_panic::*;
 pub use string_utils::*;
+
+pub fn type_name<T>() -> String {
+    std::any::type_name::<T>()
+        .split("::")
+        .last()
+        .unwrap()
+        .to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_typename() {
+        struct GreatStruct {}
+        assert_eq!(type_name::<GreatStruct>(), "GreatStruct");
+    }
+}

--- a/src/gateway_api/client/gateway_client.rs
+++ b/src/gateway_api/client/gateway_client.rs
@@ -171,7 +171,12 @@ mod tests {
         let sut = SUT::new(Arc::new(mock_antenna), NetworkID::Stokenet);
         let req = sut.current_epoch();
         let result = timeout(MAX, req).await.unwrap();
-        assert_eq!(result, Err(CommonError::NetworkResponseJSONDeserialize { into_type: "sargon::gateway_api::models::types::response::transaction::construction::transaction_construction_response::TransactionConstructionResponse".to_owned() }))
+        assert_eq!(
+            result,
+            Err(CommonError::NetworkResponseJSONDeserialize {
+                into_type: "TransactionConstructionResponse".to_owned()
+            })
+        )
     }
 
     #[actix_rt::test]

--- a/src/gateway_api/client/gateway_client_dispatch_request.rs
+++ b/src/gateway_api/client/gateway_client_dispatch_request.rs
@@ -65,7 +65,7 @@ impl GatewayClient {
 
         serde_json::from_slice::<U>(&response.body).map_err(|_| {
             CommonError::NetworkResponseJSONDeserialize {
-                into_type: std::any::type_name::<U>().to_owned(),
+                into_type: type_name::<U>(),
             }
         })
     }

--- a/src/hierarchical_deterministic/derivation/mnemonic_with_passphrase.rs
+++ b/src/hierarchical_deterministic/derivation/mnemonic_with_passphrase.rs
@@ -84,6 +84,34 @@ impl HasSampleValues for MnemonicWithPassphrase {
     }
 }
 
+impl MnemonicWithPassphrase {
+    /// Creates a new `MnemonicWithPassphrase` from json in the form of Vec<u8>.
+    /// This is a temporarily exported method that allows wallet clients to
+    /// integrate Profile in steps.
+    ///
+    /// Should be replaced later with `Wallet`
+    pub fn new_from_json_bytes(json: impl AsRef<[u8]>) -> Result<Self> {
+        let json = json.as_ref();
+        serde_json::from_slice::<Self>(json).map_err(|_| {
+            CommonError::FailedToDeserializeJSONToValue {
+                json_byte_count: json.len() as u64,
+                type_name: "MnemonicWithPassphrase".to_owned(),
+            }
+        })
+    }
+
+    /// Converts this `MnemonicWithPassphrase` to json in the form of `Vec<u8>`
+    /// This is a temporarily exported method that allows wallet clients to
+    /// integrate Profile in steps.
+    ///
+    /// Should be replaced later with `Wallet`
+    pub fn to_json_bytes(&self) -> Vec<u8> {
+        serde_json::to_vec(self).expect(
+            "JSON serialization of MnemonicWithPassphrase should never fail.",
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
 
@@ -101,6 +129,13 @@ mod tests {
     #[test]
     fn inequality() {
         assert_ne!(SUT::sample(), SUT::sample_other());
+    }
+
+    #[test]
+    fn json_bytes_roundtrip() {
+        let sut = SUT::sample();
+        let json_bytes = sut.to_json_bytes();
+        assert_eq!(sut, SUT::new_from_json_bytes(json_bytes).unwrap());
     }
 
     #[test]
@@ -206,20 +241,14 @@ mod tests {
 
     #[test]
     fn json_roundtrip() {
-        let model = SUT::with_passphrase(
-            Mnemonic::from_phrase(
-     "habit special recipe upon giraffe manual evil badge dwarf welcome inspire shrug post arrive van",
-            )
-            .unwrap(),
-            "25th".into(),
-        );
+        let model = SUT::sample();
 
         assert_eq_after_json_roundtrip(
             &model,
             r#"
             {
-                "mnemonic": "habit special recipe upon giraffe manual evil badge dwarf welcome inspire shrug post arrive van",
-                "passphrase": "25th"
+                "mnemonic": "bright club bacon dinner achieve pull grid save ramp cereal blush woman humble limb repeat video sudden possible story mask neutral prize goose mandate",
+                "passphrase": "radix"
             }
             "#,
         );

--- a/src/hierarchical_deterministic/derivation/mnemonic_with_passphrase.rs
+++ b/src/hierarchical_deterministic/derivation/mnemonic_with_passphrase.rs
@@ -84,34 +84,6 @@ impl HasSampleValues for MnemonicWithPassphrase {
     }
 }
 
-impl MnemonicWithPassphrase {
-    /// Creates a new `MnemonicWithPassphrase` from json in the form of Vec<u8>.
-    /// This is a temporarily exported method that allows wallet clients to
-    /// integrate Profile in steps.
-    ///
-    /// Should be replaced later with `Wallet`
-    pub fn new_from_json_bytes(json: impl AsRef<[u8]>) -> Result<Self> {
-        let json = json.as_ref();
-        serde_json::from_slice::<Self>(json).map_err(|_| {
-            CommonError::FailedToDeserializeJSONToValue {
-                json_byte_count: json.len() as u64,
-                type_name: "MnemonicWithPassphrase".to_owned(),
-            }
-        })
-    }
-
-    /// Converts this `MnemonicWithPassphrase` to json in the form of `Vec<u8>`
-    /// This is a temporarily exported method that allows wallet clients to
-    /// integrate Profile in steps.
-    ///
-    /// Should be replaced later with `Wallet`
-    pub fn to_json_bytes(&self) -> Vec<u8> {
-        serde_json::to_vec(self).expect(
-            "JSON serialization of MnemonicWithPassphrase should never fail.",
-        )
-    }
-}
-
 #[cfg(test)]
 mod tests {
 
@@ -129,13 +101,6 @@ mod tests {
     #[test]
     fn inequality() {
         assert_ne!(SUT::sample(), SUT::sample_other());
-    }
-
-    #[test]
-    fn json_bytes_roundtrip() {
-        let sut = SUT::sample();
-        let json_bytes = sut.to_json_bytes();
-        assert_eq!(sut, SUT::new_from_json_bytes(json_bytes).unwrap());
     }
 
     #[test]

--- a/src/hierarchical_deterministic/derivation/mnemonic_with_passphrase_uniffi_fn.rs
+++ b/src/hierarchical_deterministic/derivation/mnemonic_with_passphrase_uniffi_fn.rs
@@ -1,5 +1,7 @@
 use crate::prelude::*;
 
+json_data_convertible!(MnemonicWithPassphrase);
+
 #[uniffi::export]
 pub fn new_mnemonic_with_passphrase_sample() -> MnemonicWithPassphrase {
     MnemonicWithPassphrase::sample()
@@ -10,20 +12,6 @@ pub fn new_mnemonic_with_passphrase_sample_other() -> MnemonicWithPassphrase {
     MnemonicWithPassphrase::sample_other()
 }
 
-#[uniffi::export]
-pub fn new_mnemonic_with_passphrase_from_json_bytes(
-    json_bytes: BagOfBytes,
-) -> Result<MnemonicWithPassphrase> {
-    MnemonicWithPassphrase::new_from_json_bytes(json_bytes)
-}
-
-#[uniffi::export]
-pub fn mnemonic_with_passphrase_to_json_bytes(
-    mnemonic_with_passphrase: &MnemonicWithPassphrase,
-) -> BagOfBytes {
-    mnemonic_with_passphrase.to_json_bytes().into()
-}
-
 #[cfg(test)]
 mod uniffi_test {
 
@@ -31,16 +19,6 @@ mod uniffi_test {
 
     #[allow(clippy::upper_case_acronyms)]
     type SUT = MnemonicWithPassphrase;
-
-    #[test]
-    fn json_bytes_roundtrip() {
-        let sut = SUT::sample();
-        let json_bytes = mnemonic_with_passphrase_to_json_bytes(&sut);
-        assert_eq!(
-            sut,
-            new_mnemonic_with_passphrase_from_json_bytes(json_bytes).unwrap()
-        );
-    }
 
     #[test]
     fn hash_of_samples() {

--- a/src/hierarchical_deterministic/derivation/mnemonic_with_passphrase_uniffi_fn.rs
+++ b/src/hierarchical_deterministic/derivation/mnemonic_with_passphrase_uniffi_fn.rs
@@ -1,0 +1,59 @@
+use crate::prelude::*;
+
+#[uniffi::export]
+pub fn new_mnemonic_with_passphrase_sample() -> MnemonicWithPassphrase {
+    MnemonicWithPassphrase::sample()
+}
+
+#[uniffi::export]
+pub fn new_mnemonic_with_passphrase_sample_other() -> MnemonicWithPassphrase {
+    MnemonicWithPassphrase::sample_other()
+}
+
+#[uniffi::export]
+pub fn new_mnemonic_with_passphrase_from_json_bytes(
+    json_bytes: BagOfBytes,
+) -> Result<MnemonicWithPassphrase> {
+    MnemonicWithPassphrase::new_from_json_bytes(json_bytes)
+}
+
+#[uniffi::export]
+pub fn mnemonic_with_passphrase_to_json_bytes(
+    mnemonic_with_passphrase: &MnemonicWithPassphrase,
+) -> BagOfBytes {
+    mnemonic_with_passphrase.to_json_bytes().into()
+}
+
+#[cfg(test)]
+mod uniffi_test {
+
+    use super::*;
+
+    #[allow(clippy::upper_case_acronyms)]
+    type SUT = MnemonicWithPassphrase;
+
+    #[test]
+    fn json_bytes_roundtrip() {
+        let sut = SUT::sample();
+        let json_bytes = mnemonic_with_passphrase_to_json_bytes(&sut);
+        assert_eq!(
+            sut,
+            new_mnemonic_with_passphrase_from_json_bytes(json_bytes).unwrap()
+        );
+    }
+
+    #[test]
+    fn hash_of_samples() {
+        assert_eq!(
+            HashSet::<SUT>::from_iter([
+                new_mnemonic_with_passphrase_sample(),
+                new_mnemonic_with_passphrase_sample_other(),
+                // duplicates should get removed
+                new_mnemonic_with_passphrase_sample(),
+                new_mnemonic_with_passphrase_sample_other(),
+            ])
+            .len(),
+            2
+        );
+    }
+}

--- a/src/hierarchical_deterministic/derivation/mod.rs
+++ b/src/hierarchical_deterministic/derivation/mod.rs
@@ -4,6 +4,7 @@ mod derivation_path_scheme;
 mod hierarchical_deterministic_private_key;
 mod hierarchical_deterministic_public_key;
 mod mnemonic_with_passphrase;
+mod mnemonic_with_passphrase_uniffi_fn;
 
 pub use derivation::*;
 pub use derivation_path::*;
@@ -11,3 +12,4 @@ pub use derivation_path_scheme::*;
 pub use hierarchical_deterministic_private_key::*;
 pub use hierarchical_deterministic_public_key::*;
 pub use mnemonic_with_passphrase::*;
+pub use mnemonic_with_passphrase_uniffi_fn::*;

--- a/src/profile/v100/header/device_info.rs
+++ b/src/profile/v100/header/device_info.rs
@@ -94,33 +94,6 @@ impl HasSampleValues for DeviceInfo {
     }
 }
 
-impl DeviceInfo {
-    /// Creates a new `DeviceInfo` from json in the form of Vec<u8>.
-    /// This is a temporarily exported method that allows wallet clients to
-    /// integrate Profile in steps.
-    ///
-    /// Should be replaced later with `Wallet`
-    pub fn new_from_json_bytes(json: impl AsRef<[u8]>) -> Result<Self> {
-        let json = json.as_ref();
-        serde_json::from_slice::<Self>(json).map_err(|_| {
-            CommonError::FailedToDeserializeJSONToValue {
-                json_byte_count: json.len() as u64,
-                type_name: "DeviceInfo".to_owned(),
-            }
-        })
-    }
-
-    /// Converts this `DeviceInfo` to json in the form of `Vec<u8>`
-    /// This is a temporarily exported method that allows wallet clients to
-    /// integrate Profile in steps.
-    ///
-    /// Should be replaced later with `Wallet`
-    pub fn to_json_bytes(&self) -> Vec<u8> {
-        serde_json::to_vec(self)
-            .expect("JSON serialization of DeviceInfo should never fail.")
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -182,24 +155,6 @@ mod tests {
     #[test]
     fn date_is_now() {
         assert!(SUT::new_iphone().date.year() >= 2023);
-    }
-
-    #[test]
-    fn json_bytes_roundtrip() {
-        let sut = SUT::sample();
-        let json_bytes = sut.to_json_bytes();
-        assert_eq!(sut, SUT::new_from_json_bytes(json_bytes).unwrap());
-    }
-
-    #[test]
-    fn from_json_bytes_fail() {
-        assert_eq!(
-            SUT::new_from_json_bytes(BagOfBytes::sample()),
-            Err(CommonError::FailedToDeserializeJSONToValue {
-                json_byte_count: 32,
-                type_name: "DeviceInfo".to_owned()
-            })
-        );
     }
 
     #[test]

--- a/src/profile/v100/header/device_info_uniffi_fn.rs
+++ b/src/profile/v100/header/device_info_uniffi_fn.rs
@@ -1,5 +1,7 @@
 use crate::prelude::*;
 
+json_data_convertible!(DeviceInfo);
+
 #[uniffi::export]
 pub fn new_device_info_sample() -> DeviceInfo {
     DeviceInfo::sample()
@@ -17,31 +19,12 @@ pub fn new_device_info_iphone() -> DeviceInfo {
     DeviceInfo::new_iphone()
 }
 
-#[uniffi::export]
-pub fn new_device_info_from_json_bytes(
-    json_bytes: BagOfBytes,
-) -> Result<DeviceInfo> {
-    DeviceInfo::new_from_json_bytes(json_bytes)
-}
-
-#[uniffi::export]
-pub fn device_info_to_json_bytes(device_info: &DeviceInfo) -> BagOfBytes {
-    device_info.to_json_bytes().into()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[allow(clippy::upper_case_acronyms)]
     type SUT = DeviceInfo;
-
-    #[test]
-    fn json_bytes_roundtrip() {
-        let sut = SUT::sample();
-        let json_bytes = device_info_to_json_bytes(&sut);
-        assert_eq!(sut, new_device_info_from_json_bytes(json_bytes).unwrap());
-    }
 
     #[test]
     fn hash_of_samples() {

--- a/src/profile/v100/header/header.rs
+++ b/src/profile/v100/header/header.rs
@@ -119,33 +119,6 @@ impl HasSampleValues for Header {
     }
 }
 
-impl Header {
-    /// Creates a new `Header` from json in the form of Vec<u8>.
-    /// This is a temporarily exported method that allows wallet clients to
-    /// integrate Profile in steps.
-    ///
-    /// Should be replaced later with `Wallet`
-    pub fn new_from_json_bytes(json: impl AsRef<[u8]>) -> Result<Self> {
-        let json = json.as_ref();
-        serde_json::from_slice::<Self>(json).map_err(|_| {
-            CommonError::FailedToDeserializeJSONToValue {
-                json_byte_count: json.len() as u64,
-                type_name: "Header".to_owned(),
-            }
-        })
-    }
-
-    /// Converts this `Header` to json in the form of `Vec<u8>`
-    /// This is a temporarily exported method that allows wallet clients to
-    /// integrate Profile in steps.
-    ///
-    /// Should be replaced later with `Wallet`
-    pub fn to_json_bytes(&self) -> Vec<u8> {
-        serde_json::to_vec(self)
-            .expect("JSON serialization of Header should never fail.")
-    }
-}
-
 #[cfg(test)]
 pub mod tests {
     use super::*;

--- a/src/profile/v100/header/header.rs
+++ b/src/profile/v100/header/header.rs
@@ -38,16 +38,6 @@ pub struct Header {
     pub content_hint: ContentHint,
 }
 
-#[uniffi::export]
-pub fn new_header_sample() -> Header {
-    Header::sample()
-}
-
-#[uniffi::export]
-pub fn new_header_sample_other() -> Header {
-    Header::sample_other()
-}
-
 impl Header {
     /// Instantiates a new `Header` using the default snapshot version and
     /// the specified values, most prominently a creating device (`DeviceInfo`).
@@ -126,6 +116,33 @@ impl HasSampleValues for Header {
             ContentHint::new(),
             date,
         )
+    }
+}
+
+impl Header {
+    /// Creates a new `Header` from json in the form of Vec<u8>.
+    /// This is a temporarily exported method that allows wallet clients to
+    /// integrate Profile in steps.
+    ///
+    /// Should be replaced later with `Wallet`
+    pub fn new_from_json_bytes(json: impl AsRef<[u8]>) -> Result<Self> {
+        let json = json.as_ref();
+        serde_json::from_slice::<Self>(json).map_err(|_| {
+            CommonError::FailedToDeserializeJSONToValue {
+                json_byte_count: json.len() as u64,
+                type_name: "Header".to_owned(),
+            }
+        })
+    }
+
+    /// Converts this `Header` to json in the form of `Vec<u8>`
+    /// This is a temporarily exported method that allows wallet clients to
+    /// integrate Profile in steps.
+    ///
+    /// Should be replaced later with `Wallet`
+    pub fn to_json_bytes(&self) -> Vec<u8> {
+        serde_json::to_vec(self)
+            .expect("JSON serialization of Header should never fail.")
     }
 }
 

--- a/src/profile/v100/header/header_uniffi_fn.rs
+++ b/src/profile/v100/header/header_uniffi_fn.rs
@@ -1,0 +1,67 @@
+use crate::prelude::*;
+
+#[uniffi::export]
+pub fn new_header_sample() -> Header {
+    Header::sample()
+}
+
+#[uniffi::export]
+pub fn new_header_sample_other() -> Header {
+    Header::sample_other()
+}
+
+/// Instantiates a new `Header` with creating and last used on `DeviceInfo` with
+/// "Unknown device" as description, and empty content hint
+#[uniffi::export]
+pub fn new_header_with_creating_device(creating_device: DeviceInfo) -> Header {
+    Header::new(creating_device)
+}
+
+#[uniffi::export]
+pub fn new_header_from_json_bytes(json_bytes: BagOfBytes) -> Result<Header> {
+    Header::new_from_json_bytes(json_bytes)
+}
+
+#[uniffi::export]
+pub fn header_to_json_bytes(header: &Header) -> BagOfBytes {
+    header.to_json_bytes().into()
+}
+
+#[cfg(test)]
+mod uniffi_test {
+
+    use super::*;
+
+    #[allow(clippy::upper_case_acronyms)]
+    type SUT = Header;
+
+    #[test]
+    fn json_bytes_roundtrip() {
+        let sut = SUT::sample();
+        let json_bytes = header_to_json_bytes(&sut);
+        assert_eq!(sut, new_header_from_json_bytes(json_bytes).unwrap());
+    }
+
+    #[test]
+    fn test_new_with_device() {
+        assert_ne!(
+            new_header_with_creating_device(DeviceInfo::sample()),
+            SUT::sample()
+        );
+    }
+
+    #[test]
+    fn hash_of_samples() {
+        assert_eq!(
+            HashSet::<SUT>::from_iter([
+                new_header_sample(),
+                new_header_sample_other(),
+                // duplicates should get removed
+                new_header_sample(),
+                new_header_sample_other(),
+            ])
+            .len(),
+            2
+        );
+    }
+}

--- a/src/profile/v100/header/header_uniffi_fn.rs
+++ b/src/profile/v100/header/header_uniffi_fn.rs
@@ -1,5 +1,7 @@
 use crate::prelude::*;
 
+json_data_convertible!(Header);
+
 #[uniffi::export]
 pub fn new_header_sample() -> Header {
     Header::sample()
@@ -17,16 +19,6 @@ pub fn new_header_with_creating_device(creating_device: DeviceInfo) -> Header {
     Header::new(creating_device)
 }
 
-#[uniffi::export]
-pub fn new_header_from_json_bytes(json_bytes: BagOfBytes) -> Result<Header> {
-    Header::new_from_json_bytes(json_bytes)
-}
-
-#[uniffi::export]
-pub fn header_to_json_bytes(header: &Header) -> BagOfBytes {
-    header.to_json_bytes().into()
-}
-
 #[cfg(test)]
 mod uniffi_test {
 
@@ -34,13 +26,6 @@ mod uniffi_test {
 
     #[allow(clippy::upper_case_acronyms)]
     type SUT = Header;
-
-    #[test]
-    fn json_bytes_roundtrip() {
-        let sut = SUT::sample();
-        let json_bytes = header_to_json_bytes(&sut);
-        assert_eq!(sut, new_header_from_json_bytes(json_bytes).unwrap());
-    }
 
     #[test]
     fn test_new_with_device() {

--- a/src/profile/v100/header/mod.rs
+++ b/src/profile/v100/header/mod.rs
@@ -2,10 +2,12 @@ mod content_hint;
 mod device_info;
 mod device_info_uniffi_fn;
 mod header;
+mod header_uniffi_fn;
 mod profile_id;
 
 pub use content_hint::*;
 pub use device_info::*;
 pub use device_info_uniffi_fn::*;
 pub use header::*;
+pub use header_uniffi_fn::*;
 pub use profile_id::*;

--- a/src/profile/v100/header/profile_id.rs
+++ b/src/profile/v100/header/profile_id.rs
@@ -64,4 +64,9 @@ mod tests {
             })
         );
     }
+
+    #[test]
+    fn from_upper_case_is_ok() {
+        assert!(SUT::from_str("66F07CA2-A9D9-49E5-8152-77ACA3D1DD74").is_ok())
+    }
 }

--- a/src/profile/v100/json_data_convertible.rs
+++ b/src/profile/v100/json_data_convertible.rs
@@ -15,7 +15,7 @@ pub trait JsonDataDeserializing: for<'a> Deserialize<'a> {
 pub trait JsonDataSerializing: Sized + Serialize {
     fn to_json_bytes(&self) -> Vec<u8> {
         serde_json::to_vec(self).unwrap_or_else(|_| {
-            panic!(
+            unreachable!(
                 "JSON serialization of {} should never fail.",
                 type_name::<Self>()
             )

--- a/src/profile/v100/json_data_convertible.rs
+++ b/src/profile/v100/json_data_convertible.rs
@@ -1,0 +1,92 @@
+use crate::prelude::*;
+
+pub trait JsonDataDeserializing: for<'a> Deserialize<'a> {
+    fn new_from_json_bytes(json: impl AsRef<[u8]>) -> Result<Self> {
+        let json = json.as_ref();
+        serde_json::from_slice::<Self>(json).map_err(|_| {
+            CommonError::FailedToDeserializeJSONToValue {
+                json_byte_count: json.len() as u64,
+                type_name: type_name::<Self>(),
+            }
+        })
+    }
+}
+
+pub trait JsonDataSerializing: Sized + Serialize {
+    fn to_json_bytes(&self) -> Vec<u8> {
+        serde_json::to_vec(self).unwrap_or_else(|_| {
+            panic!(
+                "JSON serialization of {} should never fail.",
+                type_name::<Self>()
+            )
+        })
+    }
+}
+
+macro_rules! json_data_convertible {
+    ($type: ty) => {
+        paste! {
+
+            impl JsonDataDeserializing for $type {}
+            impl JsonDataSerializing for $type {}
+
+            #[uniffi::export]
+            pub fn [< new_ $type:snake _from_json_bytes >](
+                json_bytes: BagOfBytes,
+            ) -> Result<$type> {
+                $type::new_from_json_bytes(json_bytes)
+            }
+
+            #[uniffi::export]
+            pub fn [< $type:snake _to_json_bytes >]([< $type:snake >]: &$type) -> BagOfBytes {
+                [< $type:snake >].to_json_bytes().into()
+            }
+
+            #[cfg(test)]
+            mod [< uniffi_test_ $type:snake >] {
+                use super::*;
+
+                #[allow(clippy::upper_case_acronyms)]
+                type SUT = $type;
+
+                #[test]
+                fn json_bytes_roundtrip() {
+                    let sut = SUT::sample();
+                    let json_bytes = [< $type:snake _to_json_bytes >](&sut);
+                    assert_eq!(sut, [< new_ $type:snake _from_json_bytes >](json_bytes).unwrap());
+                }
+            }
+
+            #[cfg(test)]
+            mod [< test_ $type:snake >] {
+                use super::*;
+
+                #[allow(clippy::upper_case_acronyms)]
+                type SUT = $type;
+
+                #[test]
+                fn json_bytes_roundtrip() {
+                    let sut = SUT::sample();
+                    let json_bytes = sut.to_json_bytes();
+                    assert_eq!(sut, SUT::new_from_json_bytes(json_bytes).unwrap());
+                }
+
+                #[test]
+                fn from_json_bytes_fail() {
+                    assert_eq!(
+                        SUT::new_from_json_bytes(BagOfBytes::sample()),
+                        Err(CommonError::FailedToDeserializeJSONToValue {
+                            json_byte_count: 32,
+                            type_name: {{
+                                const STRINGIFIED: &'static str = stringify!($type);
+                                STRINGIFIED
+                            }}.to_owned()
+                        })
+                    );
+                }
+            }
+        }
+    };
+}
+
+pub(crate) use json_data_convertible;

--- a/src/profile/v100/mod.rs
+++ b/src/profile/v100/mod.rs
@@ -6,6 +6,7 @@ mod factors;
 mod header;
 
 mod identified_elements;
+mod json_data_convertible;
 
 mod networks;
 mod profile;
@@ -18,6 +19,7 @@ pub use entity_security_state::*;
 pub use factors::*;
 pub use header::*;
 pub use identified_elements::*;
+pub use json_data_convertible::*;
 pub use networks::*;
 pub use profile::*;
 pub use profile_uniffi_fn::*;

--- a/src/profile/v100/profile.rs
+++ b/src/profile/v100/profile.rs
@@ -105,21 +105,6 @@ impl Profile {
         }
     }
 
-    /// Creates a new `Profile` from json in the form of `BagOfBytes`.
-    /// This is a temporarily exported method that allows wallet clients to
-    /// integrate Profile in steps.
-    ///
-    /// Should be replaced later with `WalletClientStorage`
-    pub fn new_from_json_bytes(json: impl AsRef<[u8]>) -> Result<Self> {
-        let json = json.as_ref();
-        serde_json::from_slice::<Self>(json).map_err(|_| {
-            CommonError::FailedToDeserializeJSONToValue {
-                json_byte_count: json.len() as u64,
-                type_name: "Profile".to_owned(),
-            }
-        })
-    }
-
     pub fn new_from_encryption_bytes(
         json: impl AsRef<[u8]>,
         password: impl AsRef<str>,
@@ -181,16 +166,6 @@ impl Profile {
                     mutate(element).map(|modified| modified.into())
                 })
         })
-    }
-
-    /// Converts this `Profile` to json in the form of `BagOfBytes`
-    /// This is a temporarily exported method that allows wallet clients to
-    /// integrate Profile in steps.
-    ///
-    /// Should be replaced later with `WalletClientStorage`
-    pub fn to_json_bytes(&self) -> Vec<u8> {
-        serde_json::to_vec(self)
-            .expect("JSON serialization of Profile should never fail.")
     }
 }
 

--- a/src/profile/v100/profile_uniffi_fn.rs
+++ b/src/profile/v100/profile_uniffi_fn.rs
@@ -1,5 +1,7 @@
 use crate::prelude::*;
 
+json_data_convertible!(Profile);
+
 #[uniffi::export]
 pub fn new_profile(
     device_factor_source: DeviceFactorSource,
@@ -26,16 +28,6 @@ pub fn profile_to_string(profile: &Profile) -> String {
 #[uniffi::export]
 pub fn profile_to_debug_string(profile: &Profile) -> String {
     format!("{:?}", profile)
-}
-
-#[uniffi::export]
-pub fn profile_to_json_bytes(profile: &Profile) -> BagOfBytes {
-    profile.to_json_bytes().into()
-}
-
-#[uniffi::export]
-pub fn new_profile_from_json_bytes(json: BagOfBytes) -> Result<Profile> {
-    Profile::new_from_json_bytes(json)
 }
 
 #[uniffi::export]


### PR DESCRIPTION
# Rust
UF export JSON data roundtrip for 
- Header
- MnemonicWithPassphrase

# Swift
Fix bug with JSON in Swift, `0` got translated into `false` by NSDictionaryConversion. New solution is bug free and shorter and sweeter, thx to SwiftyJSON

Swift Codable support for:
Header
MnemoncWithPassphrase