### PR TITLE
Validation public keys

### DIFF
--- a/apple/Sources/Sargon/Extensions/Methods/Crypto/Derivation/Mnemonic+Wrap+Functions.swift
+++ b/apple/Sources/Sargon/Extensions/Methods/Crypto/Derivation/Mnemonic+Wrap+Functions.swift
@@ -16,4 +16,5 @@ extension Mnemonic {
 	public init(words: some Collection<BIP39Word>) throws {
 		self = try newMnemonicFromWords(words: Array(words))
 	}
+
 }

--- a/apple/Sources/Sargon/Extensions/Methods/Crypto/Derivation/MnemonicWithPassphrase+Wrap+Functions.swift
+++ b/apple/Sources/Sargon/Extensions/Methods/Crypto/Derivation/MnemonicWithPassphrase+Wrap+Functions.swift
@@ -16,4 +16,11 @@ extension MnemonicWithPassphrase {
 	public func jsonData() -> Data {
 		mnemonicWithPassphraseToJsonBytes(mnemonicWithPassphrase: self)
 	}
+    
+    
+    public func validate(
+        publicKeys: some Collection<HierarchicalDeterministicPublicKey>
+    ) -> Bool {
+        mnemonicWithPassphraseValidatePublicKeys(mnemonicWithPassphrase: self, hdKeys: Array(publicKeys))
+    }
 }

--- a/apple/Sources/Sargon/Extensions/SampleValues/Crypto/Keys/HierarchicalDeterministicPublicKey+SampleValues.swift
+++ b/apple/Sources/Sargon/Extensions/SampleValues/Crypto/Keys/HierarchicalDeterministicPublicKey+SampleValues.swift
@@ -1,0 +1,17 @@
+//
+//  File.swift
+//  
+//
+//  Created by Alexander Cyon on 2024-04-19.
+//
+
+import Foundation
+import SargonUniFFI
+
+#if DEBUG
+extension HierarchicalDeterministicPublicKey {
+    public static let sample: Self = newHierarchicalDeterministicPublicKeySample()
+    public static let sampleOther: Self = newHierarchicalDeterministicPublicKeySampleOther()
+}
+#endif // DEBUG
+

--- a/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Keys/HierarchicalDeterministicPublicKey+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Crypto/Keys/HierarchicalDeterministicPublicKey+Swiftified.swift
@@ -1,0 +1,11 @@
+//
+//  File.swift
+//  
+//
+//  Created by Alexander Cyon on 2024-04-19.
+//
+
+import Foundation
+import SargonUniFFI
+
+extension HierarchicalDeterministicPublicKey: SargonModel {}

--- a/apple/Tests/TestCases/Crypto/HierarchicalDeterministicPublicKeyTests.swift
+++ b/apple/Tests/TestCases/Crypto/HierarchicalDeterministicPublicKeyTests.swift
@@ -1,0 +1,9 @@
+import CustomDump
+import Foundation
+import Sargon
+import SargonUniFFI
+import XCTest
+
+final class HierarchicalDeterministicPublicKeyTests: Test<HierarchicalDeterministicPublicKey> {
+}
+

--- a/apple/Tests/TestCases/Crypto/MnemonicWithPassphraseTests.swift
+++ b/apple/Tests/TestCases/Crypto/MnemonicWithPassphraseTests.swift
@@ -31,4 +31,9 @@ final class MnemonicWithPassphraseTests: Test<MnemonicWithPassphrase> {
 		let encoded = try JSONEncoder().encode(sut)
 		try XCTAssertEqual(JSONDecoder().decode(SUT.self, from: encoded), sut)
 	}
+    
+    func test_validate() {
+        XCTAssertTrue(SUT.sample.validate(publicKeys: [HierarchicalDeterministicPublicKey.sample]))
+        XCTAssertFalse(SUT.sampleOther.validate(publicKeys: [HierarchicalDeterministicPublicKey.sample]))
+    }
 }

--- a/src/hierarchical_deterministic/derivation/hierarchical_deterministic_public_key_uniffi_fn.rs
+++ b/src/hierarchical_deterministic/derivation/hierarchical_deterministic_public_key_uniffi_fn.rs
@@ -1,0 +1,36 @@
+use crate::prelude::*;
+
+#[uniffi::export]
+pub fn new_hierarchical_deterministic_public_key_sample(
+) -> HierarchicalDeterministicPublicKey {
+    HierarchicalDeterministicPublicKey::sample()
+}
+
+#[uniffi::export]
+pub fn new_hierarchical_deterministic_public_key_sample_other(
+) -> HierarchicalDeterministicPublicKey {
+    HierarchicalDeterministicPublicKey::sample_other()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[allow(clippy::upper_case_acronyms)]
+    type SUT = HierarchicalDeterministicPublicKey;
+
+    #[test]
+    fn hash_of_samples() {
+        assert_eq!(
+            HashSet::<SUT>::from_iter([
+                new_hierarchical_deterministic_public_key_sample(),
+                new_hierarchical_deterministic_public_key_sample_other(),
+                // duplicates should get removed
+                new_hierarchical_deterministic_public_key_sample(),
+                new_hierarchical_deterministic_public_key_sample_other(),
+            ])
+            .len(),
+            2
+        );
+    }
+}

--- a/src/hierarchical_deterministic/derivation/mnemonic_with_passphrase_uniffi_fn.rs
+++ b/src/hierarchical_deterministic/derivation/mnemonic_with_passphrase_uniffi_fn.rs
@@ -12,6 +12,16 @@ pub fn new_mnemonic_with_passphrase_sample_other() -> MnemonicWithPassphrase {
     MnemonicWithPassphrase::sample_other()
 }
 
+/// Returns `true` if this MnemonicWithPassphrase successfully validates all `hd_keys`, that is to say,
+/// that all the HierarchicalDeterministicPublicKey were indeed crated by this MnemonicWithPassphrase.
+#[uniffi::export]
+pub fn mnemonic_with_passphrase_validate_public_keys(
+    mnemonic_with_passphrase: &MnemonicWithPassphrase,
+    hd_keys: Vec<HierarchicalDeterministicPublicKey>,
+) -> bool {
+    mnemonic_with_passphrase.validate_public_keys(hd_keys)
+}
+
 #[cfg(test)]
 mod uniffi_test {
 
@@ -33,5 +43,13 @@ mod uniffi_test {
             .len(),
             2
         );
+    }
+
+    #[test]
+    fn validate() {
+        assert!(!mnemonic_with_passphrase_validate_public_keys(
+            &SUT::sample_other(),
+            vec![HierarchicalDeterministicPublicKey::sample()]
+        ));
     }
 }

--- a/src/hierarchical_deterministic/derivation/mod.rs
+++ b/src/hierarchical_deterministic/derivation/mod.rs
@@ -3,6 +3,7 @@ mod derivation_path;
 mod derivation_path_scheme;
 mod hierarchical_deterministic_private_key;
 mod hierarchical_deterministic_public_key;
+mod hierarchical_deterministic_public_key_uniffi_fn;
 mod mnemonic_with_passphrase;
 mod mnemonic_with_passphrase_uniffi_fn;
 
@@ -11,5 +12,6 @@ pub use derivation_path::*;
 pub use derivation_path_scheme::*;
 pub use hierarchical_deterministic_private_key::*;
 pub use hierarchical_deterministic_public_key::*;
+pub use hierarchical_deterministic_public_key_uniffi_fn::*;
 pub use mnemonic_with_passphrase::*;
 pub use mnemonic_with_passphrase_uniffi_fn::*;


### PR DESCRIPTION
# Rust
Add a new method on `MnemoncWithPassphrase` to validate HD public keys, this is step 1/3 to try to avoid UniFFI exporting `to_seed` method on `MnemoncWithPassphrase`, all three being:
1) derive new public key
2) validate keys (actually using the above...)
3) signing - we will be able to do `mnemonicWithPass.sign(derivationPath, hash)` in Swift and Kotlin, calling that UF expose function in Sargon, which will allows us to not UF export `to_seed`. 

Will follow up with signing later...

# Swift
Add `sample` and `sampleOther` on HD PubKeys, and swiftify the new `validate` method.