### PR TITLE
Add AddressFormat.Middle support

### DIFF
--- a/apple/Tests/TestCases/Address/AccountAddressTests.swift
+++ b/apple/Tests/TestCases/Address/AccountAddressTests.swift
@@ -29,6 +29,10 @@ final class AccountAddressTests: AddressTest<AccountAddress> {
 	func test_short() {
 		XCTAssertEqual(SUT.sample.shortFormat, "acco...nvjdwr")
 	}
+	
+	func test_middle() {
+		XCTAssertEqual(SUT.sample.formatted(.middle), "unt_rdx128y6j78mt0aqv6372evz28hrxp8mn06ccddkr7xppc88hyvy")
+	}
     
     func test_from_bech32_on_stokenet() throws {
         let address = try SUT(

--- a/apple/Tests/TestCases/Address/LegacyOlympiaAccountAddressTests.swift
+++ b/apple/Tests/TestCases/Address/LegacyOlympiaAccountAddressTests.swift
@@ -30,6 +30,7 @@ final class LegacyOlympiaAccountAddressTests: BaseAddressTest<LegacyOlympiaAccou
     func test_formatted() {
         XCTAssertNoDifference(SUT.sampleOther.formatted(.default), "rdx...0xqm2ylge")
         XCTAssertNoDifference(SUT.sampleOther.formatted(.raw), "rdx1qsp8n0nx0muaewav2ksx99wwsu9swq5mlndjmn3gm9vl9q2mzmup0xqm2ylge")
+		XCTAssertNoDifference(SUT.sampleOther.formatted(.middle), "1qsp8n0nx0muaewav2ksx99wwsu9swq5mlndjmn3gm9vl9q2mzmup")
     }
 }
 

--- a/src/profile/v100/address/account_address.rs
+++ b/src/profile/v100/address/account_address.rs
@@ -288,6 +288,14 @@ mod tests {
     }
 
     #[test]
+    fn formatted_hidden() {
+        assert_eq!(
+            SUT::sample().formatted(AddressFormat::Hidden),
+            "unt_rdx128y6j78mt0aqv6372evz28hrxp8mn06ccddkr7xppc88hyvy"
+        );
+    }
+
+    #[test]
     fn invalid() {
         assert_eq!(
             SUT::try_from_bech32("x"),

--- a/src/profile/v100/address/account_address.rs
+++ b/src/profile/v100/address/account_address.rs
@@ -288,9 +288,9 @@ mod tests {
     }
 
     #[test]
-    fn formatted_hidden() {
+    fn formatted_middle() {
         assert_eq!(
-            SUT::sample().formatted(AddressFormat::Hidden),
+            SUT::sample().formatted(AddressFormat::Middle),
             "unt_rdx128y6j78mt0aqv6372evz28hrxp8mn06ccddkr7xppc88hyvy"
         );
     }

--- a/src/profile/v100/address/address_format.rs
+++ b/src/profile/v100/address/address_format.rs
@@ -14,4 +14,5 @@ pub enum AddressFormat {
     Full,
     Raw,
     Default,
+    Hidden,
 }

--- a/src/profile/v100/address/address_format.rs
+++ b/src/profile/v100/address/address_format.rs
@@ -14,5 +14,5 @@ pub enum AddressFormat {
     Full,
     Raw,
     Default,
-    Hidden,
+    Middle,
 }

--- a/src/profile/v100/address/legacy_olympia_account_address.rs
+++ b/src/profile/v100/address/legacy_olympia_account_address.rs
@@ -118,6 +118,7 @@ impl LegacyOlympiaAccountAddress {
         match format {
             AddressFormat::Default => format_string(self.to_string(), 3, 9),
             AddressFormat::Full | AddressFormat::Raw => self.to_string(),
+            AddressFormat::Hidden => trim_string(self.to_string(), 3, 9),
         }
     }
 }
@@ -227,6 +228,14 @@ mod tests {
         assert_eq!(
             SUT::sample_other().formatted(AddressFormat::Raw),
             "rdx1qsp8n0nx0muaewav2ksx99wwsu9swq5mlndjmn3gm9vl9q2mzmup0xqm2ylge"
+        );
+    }
+
+    #[test]
+    fn formatted_hidden() {
+        assert_eq!(
+            SUT::sample_other().formatted(AddressFormat::Hidden),
+            "1qsp8n0nx0muaewav2ksx99wwsu9swq5mlndjmn3gm9vl9q2mzmup"
         );
     }
 

--- a/src/profile/v100/address/legacy_olympia_account_address.rs
+++ b/src/profile/v100/address/legacy_olympia_account_address.rs
@@ -118,7 +118,7 @@ impl LegacyOlympiaAccountAddress {
         match format {
             AddressFormat::Default => format_string(self.to_string(), 3, 9),
             AddressFormat::Full | AddressFormat::Raw => self.to_string(),
-            AddressFormat::Hidden => trim_string(self.to_string(), 3, 9),
+            AddressFormat::Middle => trim_string(self.to_string(), 3, 9),
         }
     }
 }
@@ -232,9 +232,9 @@ mod tests {
     }
 
     #[test]
-    fn formatted_hidden() {
+    fn formatted_middle() {
         assert_eq!(
-            SUT::sample_other().formatted(AddressFormat::Hidden),
+            SUT::sample_other().formatted(AddressFormat::Middle),
             "1qsp8n0nx0muaewav2ksx99wwsu9swq5mlndjmn3gm9vl9q2mzmup"
         );
     }

--- a/src/profile/v100/address/non_fungible_global_id.rs
+++ b/src/profile/v100/address/non_fungible_global_id.rs
@@ -162,7 +162,7 @@ impl NonFungibleGlobalId {
         match format {
             AddressFormat::Default
             | AddressFormat::Full
-            | AddressFormat::Hidden => format!(
+            | AddressFormat::Middle => format!(
                 "{}:{}",
                 self.resource_address.formatted(format),
                 self.non_fungible_local_id.formatted(format)
@@ -305,9 +305,9 @@ mod tests {
     }
 
     #[test]
-    fn formatted_hidden() {
+    fn formatted_middle() {
         assert_eq!(
-            SUT::sample_ruid().formatted(AddressFormat::Hidden),
+            SUT::sample_ruid().formatted(AddressFormat::Middle),
             "urce_rdx1nfyg2f68jw7hfdlg5hzvd8ylsa7e0kjl68t5t62v3ttamtej:beef12345678-babecafe87654321-fadedeaf01234567-ecadabba7654"
         );
     }

--- a/src/profile/v100/address/non_fungible_global_id.rs
+++ b/src/profile/v100/address/non_fungible_global_id.rs
@@ -160,7 +160,9 @@ impl NonFungibleGlobalId {
 
     pub fn formatted(&self, format: AddressFormat) -> String {
         match format {
-            AddressFormat::Default | AddressFormat::Full => format!(
+            AddressFormat::Default
+            | AddressFormat::Full
+            | AddressFormat::Hidden => format!(
                 "{}:{}",
                 self.resource_address.formatted(format),
                 self.non_fungible_local_id.formatted(format)
@@ -299,6 +301,14 @@ mod tests {
         assert_eq!(
             SUT::sample_ruid().formatted(AddressFormat::Full),
             "resource_rdx1nfyg2f68jw7hfdlg5hzvd8ylsa7e0kjl68t5t62v3ttamtejc9wlxa:deadbeef12345678-babecafe87654321-fadedeaf01234567-ecadabba76543210"
+        );
+    }
+
+    #[test]
+    fn formatted_hidden() {
+        assert_eq!(
+            SUT::sample_ruid().formatted(AddressFormat::Hidden),
+            "urce_rdx1nfyg2f68jw7hfdlg5hzvd8ylsa7e0kjl68t5t62v3ttamtej:beef12345678-babecafe87654321-fadedeaf01234567-ecadabba7654"
         );
     }
 

--- a/src/profile/v100/address/non_fungible_local_id.rs
+++ b/src/profile/v100/address/non_fungible_local_id.rs
@@ -64,6 +64,12 @@ impl NonFungibleLocalId {
             },
             AddressFormat::Full => self.to_user_facing_string(),
             AddressFormat::Raw => self.to_string(),
+            AddressFormat::Hidden => match self {
+                NonFungibleLocalId::Ruid { value: _ } => {
+                    trim_string(self.to_user_facing_string(), 4, 4)
+                }
+                _ => self.to_user_facing_string(),
+            },
         }
     }
     pub fn to_user_facing_string(&self) -> String {
@@ -335,6 +341,36 @@ mod tests {
         assert_eq!( SUT::ruid(
             hex_decode("deadbeef12345678babecafe87654321fadedeaf01234567ecadabba76543210").unwrap()
         ).unwrap().formatted(AddressFormat::Full), "deadbeef12345678-babecafe87654321-fadedeaf01234567-ecadabba76543210");
+    }
+
+    #[test]
+    fn formatted_hidden_variant_string() {
+        assert_eq!(
+            SUT::string("foo").unwrap().formatted(AddressFormat::Hidden),
+            "foo"
+        );
+    }
+
+    #[test]
+    fn formatted_hidden_variant_integer() {
+        assert_eq!(SUT::integer(1234).formatted(AddressFormat::Hidden), "1234");
+    }
+
+    #[test]
+    fn formatted_hidden_variant_bytes() {
+        assert_eq!(
+            SUT::bytes([0xde, 0xad])
+                .unwrap()
+                .formatted(AddressFormat::Hidden),
+            "dead"
+        );
+    }
+
+    #[test]
+    fn formatted_hidden_variant_ruid() {
+        assert_eq!( SUT::ruid(
+            hex_decode("deadbeef12345678babecafe87654321fadedeaf01234567ecadabba76543210").unwrap()
+        ).unwrap().formatted(AddressFormat::Hidden), "beef12345678-babecafe87654321-fadedeaf01234567-ecadabba7654");
     }
 
     #[test]

--- a/src/profile/v100/address/non_fungible_local_id.rs
+++ b/src/profile/v100/address/non_fungible_local_id.rs
@@ -64,7 +64,7 @@ impl NonFungibleLocalId {
             },
             AddressFormat::Full => self.to_user_facing_string(),
             AddressFormat::Raw => self.to_string(),
-            AddressFormat::Hidden => match self {
+            AddressFormat::Middle => match self {
                 NonFungibleLocalId::Ruid { value: _ } => {
                     trim_string(self.to_user_facing_string(), 4, 4)
                 }
@@ -344,33 +344,33 @@ mod tests {
     }
 
     #[test]
-    fn formatted_hidden_variant_string() {
+    fn formatted_middle_variant_string() {
         assert_eq!(
-            SUT::string("foo").unwrap().formatted(AddressFormat::Hidden),
+            SUT::string("foo").unwrap().formatted(AddressFormat::Middle),
             "foo"
         );
     }
 
     #[test]
-    fn formatted_hidden_variant_integer() {
-        assert_eq!(SUT::integer(1234).formatted(AddressFormat::Hidden), "1234");
+    fn formatted_middle_variant_integer() {
+        assert_eq!(SUT::integer(1234).formatted(AddressFormat::Middle), "1234");
     }
 
     #[test]
-    fn formatted_hidden_variant_bytes() {
+    fn formatted_middle_variant_bytes() {
         assert_eq!(
             SUT::bytes([0xde, 0xad])
                 .unwrap()
-                .formatted(AddressFormat::Hidden),
+                .formatted(AddressFormat::Middle),
             "dead"
         );
     }
 
     #[test]
-    fn formatted_hidden_variant_ruid() {
+    fn formatted_middle_variant_ruid() {
         assert_eq!( SUT::ruid(
             hex_decode("deadbeef12345678babecafe87654321fadedeaf01234567ecadabba76543210").unwrap()
-        ).unwrap().formatted(AddressFormat::Hidden), "beef12345678-babecafe87654321-fadedeaf01234567-ecadabba7654");
+        ).unwrap().formatted(AddressFormat::Middle), "beef12345678-babecafe87654321-fadedeaf01234567-ecadabba7654");
     }
 
     #[test]

--- a/src/profile/v100/address/resource_address.rs
+++ b/src/profile/v100/address/resource_address.rs
@@ -332,9 +332,9 @@ mod tests {
     }
 
     #[test]
-    fn formatted_hidden() {
+    fn formatted_middle() {
         assert_eq!(
-            SUT::sample().formatted(AddressFormat::Hidden),
+            SUT::sample().formatted(AddressFormat::Middle),
             "urce_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxx"
         );
     }

--- a/src/profile/v100/address/resource_address.rs
+++ b/src/profile/v100/address/resource_address.rs
@@ -332,6 +332,14 @@ mod tests {
     }
 
     #[test]
+    fn formatted_hidden() {
+        assert_eq!(
+            SUT::sample().formatted(AddressFormat::Hidden),
+            "urce_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxx"
+        );
+    }
+
+    #[test]
     fn display() {
         let s = "resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd";
         let a = SUT::try_from_bech32(s).unwrap();

--- a/src/profile/v100/address/wrap_ret_address.rs
+++ b/src/profile/v100/address/wrap_ret_address.rs
@@ -205,7 +205,7 @@ macro_rules! decl_ret_wrapped_address {
                     match format {
                         AddressFormat::Default => format_string(self.address(), 4, 6),
                         AddressFormat::Full | AddressFormat::Raw => self.address(),
-                        AddressFormat::Hidden => trim_string(self.address(), 4, 6),
+                        AddressFormat::Middle => trim_string(self.address(), 4, 6),
                     }
                 }
 

--- a/src/profile/v100/address/wrap_ret_address.rs
+++ b/src/profile/v100/address/wrap_ret_address.rs
@@ -38,6 +38,17 @@ pub(crate) fn format_string(
     format!("{}...{}", prefix, suffix)
 }
 
+pub(crate) fn trim_string(
+    s: impl AsRef<str>,
+    prefix: usize,
+    suffix: usize,
+) -> String {
+    let s = s.as_ref();
+    let start = prefix;
+    let end = s.len() - suffix;
+    s[start..end].to_string()
+}
+
 pub trait IntoScryptoAddress: IsNetworkAware {
     fn scrypto(&self) -> ScryptoGlobalAddress;
 }
@@ -172,6 +183,8 @@ macro_rules! decl_ret_wrapped_address {
                 }
             }
 
+
+
             impl [< $address_type:camel Address >] {
 
                 pub fn random(network_id: NetworkID) -> Self {
@@ -192,9 +205,9 @@ macro_rules! decl_ret_wrapped_address {
                     match format {
                         AddressFormat::Default => format_string(self.address(), 4, 6),
                         AddressFormat::Full | AddressFormat::Raw => self.address(),
+                        AddressFormat::Hidden => trim_string(self.address(), 4, 6),
                     }
                 }
-
 
                 pub(crate) fn scrypto(&self) -> ScryptoGlobalAddress {
                     ScryptoGlobalAddress::try_from(self.node_id())

--- a/src/wrapped_radix_engine_toolkit/low_level/transaction_hashes/transaction_hashes.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/transaction_hashes/transaction_hashes.rs
@@ -62,6 +62,7 @@ macro_rules! decl_tx_hash {
                     assert_eq!(sut.formatted(AddressFormat::Default), [< $struct_name:snake _formatted>](&sut, AddressFormat::Default));
                     assert_eq!(sut.formatted(AddressFormat::Raw), [< $struct_name:snake _formatted>](&sut, AddressFormat::Raw));
                     assert_eq!(sut.formatted(AddressFormat::Full), [< $struct_name:snake _formatted>](&sut, AddressFormat::Full));
+                    assert_eq!(sut.formatted(AddressFormat::Hidden), [< $struct_name:snake _formatted>](&sut, AddressFormat::Hidden));
                 }
             }
         }
@@ -100,6 +101,7 @@ macro_rules! decl_tx_hash {
                 match format {
                     AddressFormat::Default => format_string(self.bech32_encoded_tx_id.to_string(), 4, 6),
                     AddressFormat::Full | AddressFormat::Raw => self.bech32_encoded_tx_id.to_string(),
+                    AddressFormat::Hidden => trim_string(self.bech32_encoded_tx_id.to_string(), 4, 6),
                 }
             }
         }

--- a/src/wrapped_radix_engine_toolkit/low_level/transaction_hashes/transaction_hashes.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/transaction_hashes/transaction_hashes.rs
@@ -62,7 +62,7 @@ macro_rules! decl_tx_hash {
                     assert_eq!(sut.formatted(AddressFormat::Default), [< $struct_name:snake _formatted>](&sut, AddressFormat::Default));
                     assert_eq!(sut.formatted(AddressFormat::Raw), [< $struct_name:snake _formatted>](&sut, AddressFormat::Raw));
                     assert_eq!(sut.formatted(AddressFormat::Full), [< $struct_name:snake _formatted>](&sut, AddressFormat::Full));
-                    assert_eq!(sut.formatted(AddressFormat::Hidden), [< $struct_name:snake _formatted>](&sut, AddressFormat::Hidden));
+                    assert_eq!(sut.formatted(AddressFormat::Middle), [< $struct_name:snake _formatted>](&sut, AddressFormat::Middle));
                 }
             }
         }
@@ -101,7 +101,7 @@ macro_rules! decl_tx_hash {
                 match format {
                     AddressFormat::Default => format_string(self.bech32_encoded_tx_id.to_string(), 4, 6),
                     AddressFormat::Full | AddressFormat::Raw => self.bech32_encoded_tx_id.to_string(),
-                    AddressFormat::Hidden => trim_string(self.bech32_encoded_tx_id.to_string(), 4, 6),
+                    AddressFormat::Middle => trim_string(self.bech32_encoded_tx_id.to_string(), 4, 6),
                 }
             }
         }


### PR DESCRIPTION
## Changelog
The wallet apps will need to colorise the part of an address that is normally hidden. The new `AddressFormat::Middle` will return such part of a given address.

## Related issues
[ABW-3212](https://radixdlt.atlassian.net/browse/ABW-3212)

[ABW-3212]: https://radixdlt.atlassian.net/browse/ABW-3212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ