### PR TITLE
Expose deep link parsing in kotlin

### DIFF
--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/antenna/SargonNetworkAntenna.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/antenna/SargonNetworkAntenna.kt
@@ -28,7 +28,7 @@ class SargonNetworkAntenna(
         )
 
         val okHttpRequest = Request.Builder()
-            .url(url = request.url)
+            .url(url = request.url.toURL())
             .headers(request.headers.toHeaders())
             .method(method = request.method.toHttpMethod(), body = requestBody)
             .build()

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/MobileConnectRequest.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/MobileConnectRequest.kt
@@ -1,9 +1,8 @@
 package com.radixdlt.sargon.extensions
 
-import com.radixdlt.sargon.MobileConnectRequest
+import com.radixdlt.sargon.RadixConnectMobileConnectRequest
 import com.radixdlt.sargon.newMobileConnectRequest
 
-@Throws(SargonException::class)
-fun MobileConnectRequest.Companion.parseFrom(url: String) = runCatching {
+fun RadixConnectMobileConnectRequest.Companion.parseFrom(url: String) = runCatching {
     newMobileConnectRequest(url = url)
 }

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/MobileConnectRequest.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/MobileConnectRequest.kt
@@ -1,0 +1,9 @@
+package com.radixdlt.sargon.extensions
+
+import com.radixdlt.sargon.MobileConnectRequest
+import com.radixdlt.sargon.newMobileConnectRequest
+
+@Throws(SargonException::class)
+fun MobileConnectRequest.Companion.parseFrom(url: String) = runCatching {
+    newMobileConnectRequest(url = url)
+}

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/OtherGateways.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/OtherGateways.kt
@@ -1,12 +1,8 @@
 package com.radixdlt.sargon.extensions
 
-import com.radixdlt.sargon.FactorSource
-import com.radixdlt.sargon.FactorSources
 import com.radixdlt.sargon.Gateway
 import com.radixdlt.sargon.OtherGateways
 import com.radixdlt.sargon.Url
-import com.radixdlt.sargon.newFactorSourcesByUpdatingOrAppending
-import com.radixdlt.sargon.newFactorSourcesByUpdatingOrInsertingAtIndex
 import com.radixdlt.sargon.newOtherGateways
 import com.radixdlt.sargon.newOtherGatewaysByAppending
 import com.radixdlt.sargon.newOtherGatewaysByUpdatingOrAppending

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/GatewaysTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/GatewaysTest.kt
@@ -12,7 +12,7 @@ import com.radixdlt.sargon.samples.sampleMainnet
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
-class GatewaysTest: SampleTestable<Gateways> {
+class GatewaysTest : SampleTestable<Gateways> {
 
     override val samples: List<Sample<Gateways>>
         get() = listOf(Gateways.sample)

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/MobileConnectRequestTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/MobileConnectRequestTest.kt
@@ -1,0 +1,33 @@
+package com.radixdlt.sargon
+
+import com.radixdlt.sargon.extensions.SargonException
+import com.radixdlt.sargon.extensions.parseFrom
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class MobileConnectRequestTest {
+
+    @Test
+    fun `test link url`() {
+        val url = "https://d1rxdfxrfmemlj.cloudfront.net/?sessionId=${Uuid.randomUUID()}&origin=radix%3A%2F%2Fapp"
+        val request = MobileConnectRequest.parseFrom(url)
+        assertTrue { request is MobileConnectRequest.Link }
+    }
+
+    @Test
+    fun `test dApp interaction url`() {
+        val url = "https://d1rxdfxrfmemlj.cloudfront.net/?sessionId=${Uuid.randomUUID()}&interactionId=${Uuid.randomUUID()}"
+        val request = MobileConnectRequest.parseFrom(url)
+        assertTrue { request is MobileConnectRequest.DappInteraction }
+    }
+
+    @Test
+    fun `test exception thrown if url parsed incorrectl`() {
+        val url = "https://random.url.net/?randomParam=123"
+        assertThrows<SargonException> {
+            MobileConnectRequest.parseFrom(url)
+        }
+    }
+
+}

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/RadixConnectMobileConnectRequestTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/RadixConnectMobileConnectRequestTest.kt
@@ -6,27 +6,27 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
-class MobileConnectRequestTest {
+class RadixConnectMobileConnectRequestTest {
 
     @Test
     fun `test link url`() {
         val url = "https://d1rxdfxrfmemlj.cloudfront.net/?sessionId=${Uuid.randomUUID()}&origin=radix%3A%2F%2Fapp"
-        val request = MobileConnectRequest.parseFrom(url)
-        assertTrue { request is MobileConnectRequest.Link }
+        val request = RadixConnectMobileConnectRequest.parseFrom(url).getOrNull()
+        assertTrue { request is RadixConnectMobileConnectRequest.Link }
     }
 
     @Test
     fun `test dApp interaction url`() {
         val url = "https://d1rxdfxrfmemlj.cloudfront.net/?sessionId=${Uuid.randomUUID()}&interactionId=${Uuid.randomUUID()}"
-        val request = MobileConnectRequest.parseFrom(url)
-        assertTrue { request is MobileConnectRequest.DappInteraction }
+        val request = RadixConnectMobileConnectRequest.parseFrom(url).getOrNull()
+        assertTrue { request is RadixConnectMobileConnectRequest.DappInteraction }
     }
 
     @Test
     fun `test exception thrown if url parsed incorrectl`() {
         val url = "https://random.url.net/?randomParam=123"
         assertThrows<SargonException> {
-            MobileConnectRequest.parseFrom(url)
+            RadixConnectMobileConnectRequest.parseFrom(url).getOrThrow()
         }
     }
 

--- a/uniffi.toml
+++ b/uniffi.toml
@@ -36,9 +36,9 @@ into_custom = "URL(string: {})!"
 from_custom = "String(describing: {})"
 
 [bindings.kotlin.custom_types.Url]
-type_name = "URL"
-imports = ["java.net.URI", "java.net.URL"]
-into_custom = "URI({}).toURL()"
+type_name = "URI"
+imports = ["java.net.URI"]
+into_custom = "URI({})"
 from_custom = "{}.toString()"
 
 [bindings.swift.custom_types.Timestamp]


### PR DESCRIPTION
- expose deep link parsing in kotlin
- add unit tests
- convert uniffi exported `Url` to `java.net.URI` so that we can handle `RadixMobileConnectRequest.Link` origin property with arbitrary `protocol`, like `radix://xyz`