### PR TITLE
Add SwiftFormat config and pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,13 @@ repos:
         entry: cargo fmt -- --check
         pass_filenames: false
 
+      - id: SwiftFormat
+        name: SwiftFormat
+        language: system
+        types: [file, swift]
+        entry: swiftformat .
+        pass_filenames: false
+
       - id: clippy
         name: clippy
         language: system

--- a/.swift-format
+++ b/.swift-format
@@ -1,5 +1,0 @@
-{
-	"indentation": {
-		"tabs": 1
-	}
-}

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,0 +1,13 @@
+--swiftversion 5.9
+
+# format options
+--allman false # Prefer `K&R` https://en.wikipedia.org/wiki/Indentation_style#K&R_style
+--indent tab
+--tabwidth 4
+
+--stripunusedargs closure-only
+--enable marktypes
+--disable redundantNilInit,redundantSelf,extensionAccessControl
+--lineaftermarks false
+--ifdef no-indent
+--header strip


### PR DESCRIPTION
## Changelog
Adds the configuration for Swift formatting and the pre-commit hook.

## Notes
Format changes can be checked in https://github.com/radixdlt/sargon/pull/115, leaving this PR with only the configuration changes.

## Rationale
The project already had an almost empty `.swift-format` file, that would have allowed us to use Apple's [swift-format](https://github.com/apple/swift-format), instead of the [SwiftFormat](https://github.com/nicklockwood/SwiftFormat) developed by [nicklockwood](https://github.com/nicklockwood/). 

Even though I mostly prefer going with native tools, the Apple one doesn't allow as many rules as the selected one. Also, given we are already using it for the iOS Wallet project, it makes sense to use the same tool to easily replicate the same coding standards and styles in both projects.