### PR TITLE
Sargon 0.7.1 | Rust Analyzer is FAST again, thx to bumping Scrypto (and RET)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1724,14 +1724,26 @@ dependencies = [
 
 [[package]]
 name = "native-sdk"
-version = "1.0.2-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=587d5988cd4ca3c5193ddf37027ff4e4ecd637dc#587d5988cd4ca3c5193ddf37027ff4e4ecd637dc"
+version = "1.1.2"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
 dependencies = [
- "radix-engine-common",
- "radix-engine-derive",
- "radix-engine-interface",
- "sbor",
- "utils",
+ "radix-engine-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
+ "radix-engine-derive 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
+ "radix-engine-interface 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
+ "sbor 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
+ "utils 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
+]
+
+[[package]]
+name = "native-sdk"
+version = "1.1.2"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
+dependencies = [
+ "radix-engine-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "radix-engine-derive 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "radix-engine-interface 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "sbor 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "utils 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
 ]
 
 [[package]]
@@ -2061,8 +2073,8 @@ dependencies = [
 
 [[package]]
 name = "radix-engine"
-version = "1.0.2-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=587d5988cd4ca3c5193ddf37027ff4e4ecd637dc#587d5988cd4ca3c5193ddf37027ff4e4ecd637dc"
+version = "1.1.2"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
 dependencies = [
  "bitflags 1.3.2",
  "colored",
@@ -2070,20 +2082,50 @@ dependencies = [
  "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static",
  "moka",
- "native-sdk",
+ "native-sdk 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
  "num-traits",
  "paste 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "radix-engine-common",
- "radix-engine-interface",
- "radix-engine-macros",
- "radix-engine-store-interface",
- "resources-tracker-macro",
- "sbor",
+ "radix-engine-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
+ "radix-engine-interface 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
+ "radix-engine-macros 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
+ "radix-engine-store-interface 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
+ "resources-tracker-macro 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
+ "sbor 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
  "serde_json 1.0.113",
  "strum 0.24.1",
  "syn 1.0.93",
- "transaction",
- "utils",
+ "transaction 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
+ "utils 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
+ "wasm-instrument",
+ "wasmi",
+ "wasmparser 0.107.0",
+]
+
+[[package]]
+name = "radix-engine"
+version = "1.1.2"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
+dependencies = [
+ "bitflags 1.3.2",
+ "colored",
+ "const-sha1",
+ "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static",
+ "moka",
+ "native-sdk 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "num-traits",
+ "paste 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "radix-engine-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "radix-engine-interface 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "radix-engine-macros 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "radix-engine-store-interface 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "resources-tracker-macro 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "sbor 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "serde_json 1.0.113",
+ "strum 0.24.1",
+ "syn 1.0.93",
+ "transaction 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "utils 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
  "wasm-instrument",
  "wasmi",
  "wasmparser 0.107.0",
@@ -2091,8 +2133,8 @@ dependencies = [
 
 [[package]]
 name = "radix-engine-common"
-version = "1.0.2-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=587d5988cd4ca3c5193ddf37027ff4e4ecd637dc#587d5988cd4ca3c5193ddf37027ff4e4ecd637dc"
+version = "1.1.2"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
 dependencies = [
  "bech32",
  "blake2",
@@ -2105,158 +2147,250 @@ dependencies = [
  "num-integer",
  "num-traits",
  "paste 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "radix-engine-derive",
- "sbor",
+ "radix-engine-derive 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
+ "sbor 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
  "secp256k1",
  "serde",
  "sha3",
  "strum 0.24.1",
- "utils",
+ "utils 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
+]
+
+[[package]]
+name = "radix-engine-common"
+version = "1.1.2"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
+dependencies = [
+ "bech32",
+ "blake2",
+ "blst",
+ "bnum",
+ "ed25519-dalek",
+ "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "paste 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "radix-engine-derive 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "sbor 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "secp256k1",
+ "serde",
+ "sha3",
+ "strum 0.24.1",
+ "utils 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
 ]
 
 [[package]]
 name = "radix-engine-derive"
-version = "1.0.2-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=587d5988cd4ca3c5193ddf37027ff4e4ecd637dc#587d5988cd4ca3c5193ddf37027ff4e4ecd637dc"
+version = "1.1.2"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
 dependencies = [
  "proc-macro2",
  "quote",
- "sbor-derive-common",
+ "sbor-derive-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
+ "syn 1.0.93",
+]
+
+[[package]]
+name = "radix-engine-derive"
+version = "1.1.2"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sbor-derive-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
  "syn 1.0.93",
 ]
 
 [[package]]
 name = "radix-engine-interface"
-version = "1.0.2-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=587d5988cd4ca3c5193ddf37027ff4e4ecd637dc#587d5988cd4ca3c5193ddf37027ff4e4ecd637dc"
+version = "1.1.2"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
 dependencies = [
  "bitflags 1.3.2",
  "const-sha1",
  "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static",
  "paste 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "radix-engine-common",
- "radix-engine-derive",
- "radix-engine-macros",
+ "radix-engine-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
+ "radix-engine-derive 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
+ "radix-engine-macros 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
  "regex 1.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sbor",
- "scrypto-schema",
+ "sbor 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
+ "scrypto-schema 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
  "serde",
  "serde_json 1.0.113",
  "strum 0.24.1",
- "utils",
+ "utils 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
+]
+
+[[package]]
+name = "radix-engine-interface"
+version = "1.1.2"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
+dependencies = [
+ "bitflags 1.3.2",
+ "const-sha1",
+ "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static",
+ "paste 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "radix-engine-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "radix-engine-derive 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "radix-engine-macros 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "regex 1.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sbor 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "scrypto-schema 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "serde",
+ "serde_json 1.0.113",
+ "strum 0.24.1",
+ "utils 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
 ]
 
 [[package]]
 name = "radix-engine-macros"
-version = "1.0.2-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=587d5988cd4ca3c5193ddf37027ff4e4ecd637dc#587d5988cd4ca3c5193ddf37027ff4e4ecd637dc"
+version = "1.1.2"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
 dependencies = [
  "paste 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2",
  "quote",
- "radix-engine-common",
+ "radix-engine-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
+ "syn 1.0.93",
+]
+
+[[package]]
+name = "radix-engine-macros"
+version = "1.1.2"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
+dependencies = [
+ "paste 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2",
+ "quote",
+ "radix-engine-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
  "syn 1.0.93",
 ]
 
 [[package]]
 name = "radix-engine-profiling"
-version = "1.0.2-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=587d5988cd4ca3c5193ddf37027ff4e4ecd637dc#587d5988cd4ca3c5193ddf37027ff4e4ecd637dc"
+version = "1.1.2"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
+dependencies = [
+ "fixedstr",
+]
+
+[[package]]
+name = "radix-engine-profiling"
+version = "1.1.2"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
 dependencies = [
  "fixedstr",
 ]
 
 [[package]]
 name = "radix-engine-queries"
-version = "1.0.2-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=587d5988cd4ca3c5193ddf37027ff4e4ecd637dc#587d5988cd4ca3c5193ddf37027ff4e4ecd637dc"
+version = "1.1.2"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
 dependencies = [
  "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.10.5",
  "paste 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "radix-engine",
- "radix-engine-interface",
- "radix-engine-store-interface",
- "sbor",
- "transaction",
- "utils",
+ "radix-engine 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "radix-engine-interface 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "radix-engine-store-interface 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "sbor 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "transaction 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "utils 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
 ]
 
 [[package]]
 name = "radix-engine-store-interface"
-version = "1.0.2-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=587d5988cd4ca3c5193ddf37027ff4e4ecd637dc#587d5988cd4ca3c5193ddf37027ff4e4ecd637dc"
+version = "1.1.2"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
 dependencies = [
  "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.10.5",
- "radix-engine-common",
- "radix-engine-derive",
- "radix-engine-interface",
- "sbor",
- "utils",
+ "radix-engine-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
+ "radix-engine-derive 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
+ "radix-engine-interface 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
+ "sbor 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
+ "utils 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
+]
+
+[[package]]
+name = "radix-engine-store-interface"
+version = "1.1.2"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
+dependencies = [
+ "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.10.5",
+ "radix-engine-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "radix-engine-derive 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "radix-engine-interface 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "sbor 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "utils 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
 ]
 
 [[package]]
 name = "radix-engine-stores"
-version = "1.0.2-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=587d5988cd4ca3c5193ddf37027ff4e4ecd637dc#587d5988cd4ca3c5193ddf37027ff4e4ecd637dc"
+version = "1.1.2"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
 dependencies = [
  "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.10.5",
- "radix-engine-common",
- "radix-engine-derive",
- "radix-engine-store-interface",
- "sbor",
- "utils",
+ "radix-engine-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "radix-engine-derive 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "radix-engine-store-interface 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "sbor 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "utils 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
 ]
 
 [[package]]
 name = "radix-engine-toolkit"
-version = "1.0.10"
-source = "git+https://github.com/radixdlt/radix-engine-toolkit?rev=1cfe879c7370cfa497857ada7a8973f8a3388abc#1cfe879c7370cfa497857ada7a8973f8a3388abc"
+version = "2.0.1"
+source = "git+https://github.com/radixdlt/radix-engine-toolkit?rev=566632afb4f1e292453950797bbf4329b37a04b0#566632afb4f1e292453950797bbf4329b37a04b0"
 dependencies = [
  "bech32",
  "cargo_toml 0.15.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "extend",
  "lazy_static",
  "paste 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "radix-engine",
- "radix-engine-common",
- "radix-engine-interface",
+ "radix-engine 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "radix-engine-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "radix-engine-interface 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
  "radix-engine-queries",
- "radix-engine-store-interface",
+ "radix-engine-store-interface 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
  "radix-engine-stores",
  "regex 1.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sbor",
+ "sbor 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
  "sbor-json",
  "scrypto",
  "serde_json 1.0.113",
  "serde_with 3.6.1",
- "transaction",
+ "transaction 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
 ]
 
 [[package]]
 name = "radix-engine-toolkit-json"
-version = "1.0.10"
-source = "git+https://github.com/radixdlt/radix-engine-toolkit?rev=1cfe879c7370cfa497857ada7a8973f8a3388abc#1cfe879c7370cfa497857ada7a8973f8a3388abc"
+version = "2.0.1"
+source = "git+https://github.com/radixdlt/radix-engine-toolkit?rev=566632afb4f1e292453950797bbf4329b37a04b0#566632afb4f1e292453950797bbf4329b37a04b0"
 dependencies = [
  "bech32",
  "indexmap 1.9.3",
  "jni",
  "paste 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "radix-engine",
- "radix-engine-common",
- "radix-engine-interface",
+ "radix-engine 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "radix-engine-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "radix-engine-interface 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
  "radix-engine-queries",
  "radix-engine-toolkit",
- "sbor",
+ "sbor 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
  "schemars",
  "scrypto",
  "serde",
  "serde_json 1.0.113",
  "serde_with 3.6.1",
- "transaction",
+ "transaction 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
  "typeshare",
  "walkdir",
 ]
@@ -2442,12 +2576,23 @@ dependencies = [
 
 [[package]]
 name = "resources-tracker-macro"
-version = "1.0.2-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=587d5988cd4ca3c5193ddf37027ff4e4ecd637dc#587d5988cd4ca3c5193ddf37027ff4e4ecd637dc"
+version = "1.1.2"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
 dependencies = [
  "proc-macro2",
  "quote",
- "radix-engine-profiling",
+ "radix-engine-profiling 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
+ "syn 1.0.93",
+]
+
+[[package]]
+name = "resources-tracker-macro"
+version = "1.1.2"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "radix-engine-profiling 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
  "syn 1.0.93",
 ]
 
@@ -2553,23 +2698,23 @@ dependencies = [
  "paste 1.0.14 (git+https://github.com/dtolnay/paste?rev=1e0cc1025af5388397c67fa4389ad7ad24814df8)",
  "pretty_assertions",
  "pretty_env_logger",
- "radix-engine",
- "radix-engine-common",
- "radix-engine-derive",
- "radix-engine-interface",
+ "radix-engine 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
+ "radix-engine-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
+ "radix-engine-derive 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
+ "radix-engine-interface 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
  "radix-engine-toolkit",
  "radix-engine-toolkit-json",
  "rand 0.8.5",
  "regex 1.9.3 (git+https://github.com/rust-lang/regex/?rev=72f889ef3cca59ebac6a026f3646e8d92f056d88)",
  "reqwest",
- "sbor",
+ "sbor 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
  "serde",
  "serde_json 1.0.108",
  "serde_repr",
  "serde_with 3.4.0",
  "strum 0.26.1",
  "thiserror 1.0.50",
- "transaction",
+ "transaction 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
  "uniffi",
  "url",
  "uuid 1.6.1",
@@ -2578,31 +2723,66 @@ dependencies = [
 
 [[package]]
 name = "sbor"
-version = "1.0.2-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=587d5988cd4ca3c5193ddf37027ff4e4ecd637dc#587d5988cd4ca3c5193ddf37027ff4e4ecd637dc"
+version = "1.1.2"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
 dependencies = [
  "const-sha1",
  "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static",
  "paste 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "sbor-derive",
+ "sbor-derive 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
  "serde",
- "utils",
+ "utils 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
+]
+
+[[package]]
+name = "sbor"
+version = "1.1.2"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
+dependencies = [
+ "const-sha1",
+ "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static",
+ "paste 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sbor-derive 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "serde",
+ "utils 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
 ]
 
 [[package]]
 name = "sbor-derive"
-version = "1.0.2-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=587d5988cd4ca3c5193ddf37027ff4e4ecd637dc#587d5988cd4ca3c5193ddf37027ff4e4ecd637dc"
+version = "1.1.2"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
 dependencies = [
  "proc-macro2",
- "sbor-derive-common",
+ "sbor-derive-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
+]
+
+[[package]]
+name = "sbor-derive"
+version = "1.1.2"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
+dependencies = [
+ "proc-macro2",
+ "sbor-derive-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
 ]
 
 [[package]]
 name = "sbor-derive-common"
-version = "1.0.2-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=587d5988cd4ca3c5193ddf37027ff4e4ecd637dc#587d5988cd4ca3c5193ddf37027ff4e4ecd637dc"
+version = "1.1.2"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
+dependencies = [
+ "const-sha1",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.93",
+]
+
+[[package]]
+name = "sbor-derive-common"
+version = "1.1.2"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
 dependencies = [
  "const-sha1",
  "itertools 0.10.5",
@@ -2613,14 +2793,14 @@ dependencies = [
 
 [[package]]
 name = "sbor-json"
-version = "1.0.10"
-source = "git+https://github.com/radixdlt/radix-engine-toolkit?rev=1cfe879c7370cfa497857ada7a8973f8a3388abc#1cfe879c7370cfa497857ada7a8973f8a3388abc"
+version = "2.0.1"
+source = "git+https://github.com/radixdlt/radix-engine-toolkit?rev=566632afb4f1e292453950797bbf4329b37a04b0#566632afb4f1e292453950797bbf4329b37a04b0"
 dependencies = [
  "bech32",
- "radix-engine-common",
- "radix-engine-interface",
+ "radix-engine-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "radix-engine-interface 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
  "regex 1.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sbor",
+ "sbor 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
  "serde",
  "serde_json 1.0.113",
  "serde_with 3.6.1",
@@ -2697,8 +2877,8 @@ dependencies = [
 
 [[package]]
 name = "scrypto"
-version = "1.0.2-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=587d5988cd4ca3c5193ddf37027ff4e4ecd637dc#587d5988cd4ca3c5193ddf37027ff4e4ecd637dc"
+version = "1.1.2"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
 dependencies = [
  "bech32",
  "const-sha1",
@@ -2706,28 +2886,28 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "paste 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "radix-engine-common",
- "radix-engine-derive",
- "radix-engine-interface",
- "sbor",
+ "radix-engine-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "radix-engine-derive 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "radix-engine-interface 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "sbor 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
  "scrypto-derive",
- "scrypto-schema",
+ "scrypto-schema 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
  "serde",
  "strum 0.24.1",
- "utils",
+ "utils 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
 ]
 
 [[package]]
 name = "scrypto-derive"
-version = "1.0.2-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=587d5988cd4ca3c5193ddf37027ff4e4ecd637dc#587d5988cd4ca3c5193ddf37027ff4e4ecd637dc"
+version = "1.1.2"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
 dependencies = [
  "proc-macro2",
  "quote",
- "radix-engine-common",
+ "radix-engine-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
  "regex 1.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sbor",
- "scrypto-schema",
+ "sbor 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "scrypto-schema 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
  "serde",
  "serde_json 1.0.113",
  "syn 1.0.93",
@@ -2735,12 +2915,23 @@ dependencies = [
 
 [[package]]
 name = "scrypto-schema"
-version = "1.0.2-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=587d5988cd4ca3c5193ddf37027ff4e4ecd637dc#587d5988cd4ca3c5193ddf37027ff4e4ecd637dc"
+version = "1.1.2"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
 dependencies = [
  "bitflags 1.3.2",
- "radix-engine-common",
- "sbor",
+ "radix-engine-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
+ "sbor 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
+ "serde",
+]
+
+[[package]]
+name = "scrypto-schema"
+version = "1.1.2"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
+dependencies = [
+ "bitflags 1.3.2",
+ "radix-engine-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "sbor 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
  "serde",
 ]
 
@@ -3423,17 +3614,32 @@ dependencies = [
 
 [[package]]
 name = "transaction"
-version = "1.0.2-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=587d5988cd4ca3c5193ddf37027ff4e4ecd637dc#587d5988cd4ca3c5193ddf37027ff4e4ecd637dc"
+version = "1.1.2"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
 dependencies = [
  "bech32",
  "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static",
- "radix-engine-common",
- "radix-engine-interface",
- "sbor",
+ "radix-engine-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
+ "radix-engine-interface 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
+ "sbor 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
  "strum 0.24.1",
- "utils",
+ "utils 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
+]
+
+[[package]]
+name = "transaction"
+version = "1.1.2"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
+dependencies = [
+ "bech32",
+ "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static",
+ "radix-engine-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "radix-engine-interface 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "sbor 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "strum 0.24.1",
+ "utils 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
 ]
 
 [[package]]
@@ -3678,8 +3884,17 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "utils"
-version = "1.0.2-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=587d5988cd4ca3c5193ddf37027ff4e4ecd637dc#587d5988cd4ca3c5193ddf37027ff4e4ecd637dc"
+version = "1.1.2"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
+dependencies = [
+ "indexmap 2.0.0-pre",
+ "serde",
+]
+
+[[package]]
+name = "utils"
+version = "1.1.2"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
 dependencies = [
  "indexmap 2.0.0-pre",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1725,25 +1725,13 @@ dependencies = [
 [[package]]
 name = "native-sdk"
 version = "1.1.2"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
-dependencies = [
- "radix-engine-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
- "radix-engine-derive 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
- "radix-engine-interface 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
- "sbor 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
- "utils 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
-]
-
-[[package]]
-name = "native-sdk"
-version = "1.1.2"
 source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
 dependencies = [
- "radix-engine-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
- "radix-engine-derive 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
- "radix-engine-interface 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
- "sbor 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
- "utils 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "radix-engine-common",
+ "radix-engine-derive",
+ "radix-engine-interface",
+ "sbor",
+ "utils",
 ]
 
 [[package]]
@@ -2074,36 +2062,6 @@ dependencies = [
 [[package]]
 name = "radix-engine"
 version = "1.1.2"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
-dependencies = [
- "bitflags 1.3.2",
- "colored",
- "const-sha1",
- "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static",
- "moka",
- "native-sdk 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
- "num-traits",
- "paste 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "radix-engine-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
- "radix-engine-interface 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
- "radix-engine-macros 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
- "radix-engine-store-interface 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
- "resources-tracker-macro 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
- "sbor 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
- "serde_json 1.0.113",
- "strum 0.24.1",
- "syn 1.0.93",
- "transaction 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
- "utils 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
- "wasm-instrument",
- "wasmi",
- "wasmparser 0.107.0",
-]
-
-[[package]]
-name = "radix-engine"
-version = "1.1.2"
 source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
 dependencies = [
  "bitflags 1.3.2",
@@ -2112,48 +2070,23 @@ dependencies = [
  "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static",
  "moka",
- "native-sdk 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "native-sdk",
  "num-traits",
  "paste 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "radix-engine-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
- "radix-engine-interface 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
- "radix-engine-macros 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
- "radix-engine-store-interface 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
- "resources-tracker-macro 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
- "sbor 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "radix-engine-common",
+ "radix-engine-interface",
+ "radix-engine-macros",
+ "radix-engine-store-interface",
+ "resources-tracker-macro",
+ "sbor",
  "serde_json 1.0.113",
  "strum 0.24.1",
  "syn 1.0.93",
- "transaction 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
- "utils 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "transaction",
+ "utils",
  "wasm-instrument",
  "wasmi",
  "wasmparser 0.107.0",
-]
-
-[[package]]
-name = "radix-engine-common"
-version = "1.1.2"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
-dependencies = [
- "bech32",
- "blake2",
- "blst",
- "bnum",
- "ed25519-dalek",
- "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static",
- "num-bigint",
- "num-integer",
- "num-traits",
- "paste 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "radix-engine-derive 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
- "sbor 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
- "secp256k1",
- "serde",
- "sha3",
- "strum 0.24.1",
- "utils 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
 ]
 
 [[package]]
@@ -2172,24 +2105,13 @@ dependencies = [
  "num-integer",
  "num-traits",
  "paste 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "radix-engine-derive 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
- "sbor 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "radix-engine-derive",
+ "sbor",
  "secp256k1",
  "serde",
  "sha3",
  "strum 0.24.1",
- "utils 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
-]
-
-[[package]]
-name = "radix-engine-derive"
-version = "1.1.2"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
-dependencies = [
- "proc-macro2",
- "quote",
- "sbor-derive-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
- "syn 1.0.93",
+ "utils",
 ]
 
 [[package]]
@@ -2199,30 +2121,8 @@ source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3a
 dependencies = [
  "proc-macro2",
  "quote",
- "sbor-derive-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "sbor-derive-common",
  "syn 1.0.93",
-]
-
-[[package]]
-name = "radix-engine-interface"
-version = "1.1.2"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
-dependencies = [
- "bitflags 1.3.2",
- "const-sha1",
- "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static",
- "paste 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "radix-engine-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
- "radix-engine-derive 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
- "radix-engine-macros 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
- "regex 1.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sbor 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
- "scrypto-schema 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
- "serde",
- "serde_json 1.0.113",
- "strum 0.24.1",
- "utils 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
 ]
 
 [[package]]
@@ -2235,28 +2135,16 @@ dependencies = [
  "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static",
  "paste 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "radix-engine-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
- "radix-engine-derive 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
- "radix-engine-macros 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "radix-engine-common",
+ "radix-engine-derive",
+ "radix-engine-macros",
  "regex 1.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sbor 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
- "scrypto-schema 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "sbor",
+ "scrypto-schema",
  "serde",
  "serde_json 1.0.113",
  "strum 0.24.1",
- "utils 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
-]
-
-[[package]]
-name = "radix-engine-macros"
-version = "1.1.2"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
-dependencies = [
- "paste 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2",
- "quote",
- "radix-engine-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
- "syn 1.0.93",
+ "utils",
 ]
 
 [[package]]
@@ -2267,16 +2155,8 @@ dependencies = [
  "paste 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2",
  "quote",
- "radix-engine-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "radix-engine-common",
  "syn 1.0.93",
-]
-
-[[package]]
-name = "radix-engine-profiling"
-version = "1.1.2"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
-dependencies = [
- "fixedstr",
 ]
 
 [[package]]
@@ -2295,26 +2175,12 @@ dependencies = [
  "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.10.5",
  "paste 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "radix-engine 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
- "radix-engine-interface 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
- "radix-engine-store-interface 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
- "sbor 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
- "transaction 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
- "utils 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
-]
-
-[[package]]
-name = "radix-engine-store-interface"
-version = "1.1.2"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
-dependencies = [
- "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.10.5",
- "radix-engine-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
- "radix-engine-derive 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
- "radix-engine-interface 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
- "sbor 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
- "utils 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
+ "radix-engine",
+ "radix-engine-interface",
+ "radix-engine-store-interface",
+ "sbor",
+ "transaction",
+ "utils",
 ]
 
 [[package]]
@@ -2324,11 +2190,11 @@ source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3a
 dependencies = [
  "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.10.5",
- "radix-engine-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
- "radix-engine-derive 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
- "radix-engine-interface 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
- "sbor 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
- "utils 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "radix-engine-common",
+ "radix-engine-derive",
+ "radix-engine-interface",
+ "sbor",
+ "utils",
 ]
 
 [[package]]
@@ -2338,59 +2204,59 @@ source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3a
 dependencies = [
  "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.10.5",
- "radix-engine-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
- "radix-engine-derive 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
- "radix-engine-store-interface 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
- "sbor 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
- "utils 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "radix-engine-common",
+ "radix-engine-derive",
+ "radix-engine-store-interface",
+ "sbor",
+ "utils",
 ]
 
 [[package]]
 name = "radix-engine-toolkit"
 version = "2.0.1"
-source = "git+https://github.com/radixdlt/radix-engine-toolkit?rev=566632afb4f1e292453950797bbf4329b37a04b0#566632afb4f1e292453950797bbf4329b37a04b0"
+source = "git+https://github.com/radixdlt/radix-engine-toolkit?rev=v2.0.1#566632afb4f1e292453950797bbf4329b37a04b0"
 dependencies = [
  "bech32",
  "cargo_toml 0.15.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "extend",
  "lazy_static",
  "paste 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "radix-engine 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
- "radix-engine-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
- "radix-engine-interface 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "radix-engine",
+ "radix-engine-common",
+ "radix-engine-interface",
  "radix-engine-queries",
- "radix-engine-store-interface 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "radix-engine-store-interface",
  "radix-engine-stores",
  "regex 1.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sbor 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "sbor",
  "sbor-json",
  "scrypto",
  "serde_json 1.0.113",
  "serde_with 3.6.1",
- "transaction 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "transaction",
 ]
 
 [[package]]
 name = "radix-engine-toolkit-json"
 version = "2.0.1"
-source = "git+https://github.com/radixdlt/radix-engine-toolkit?rev=566632afb4f1e292453950797bbf4329b37a04b0#566632afb4f1e292453950797bbf4329b37a04b0"
+source = "git+https://github.com/radixdlt/radix-engine-toolkit?rev=v2.0.1#566632afb4f1e292453950797bbf4329b37a04b0"
 dependencies = [
  "bech32",
  "indexmap 1.9.3",
  "jni",
  "paste 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "radix-engine 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
- "radix-engine-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
- "radix-engine-interface 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "radix-engine",
+ "radix-engine-common",
+ "radix-engine-interface",
  "radix-engine-queries",
  "radix-engine-toolkit",
- "sbor 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "sbor",
  "schemars",
  "scrypto",
  "serde",
  "serde_json 1.0.113",
  "serde_with 3.6.1",
- "transaction 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "transaction",
  "typeshare",
  "walkdir",
 ]
@@ -2577,22 +2443,11 @@ dependencies = [
 [[package]]
 name = "resources-tracker-macro"
 version = "1.1.2"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
-dependencies = [
- "proc-macro2",
- "quote",
- "radix-engine-profiling 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
- "syn 1.0.93",
-]
-
-[[package]]
-name = "resources-tracker-macro"
-version = "1.1.2"
 source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
 dependencies = [
  "proc-macro2",
  "quote",
- "radix-engine-profiling 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "radix-engine-profiling",
  "syn 1.0.93",
 ]
 
@@ -2673,7 +2528,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "0.6.55"
+version = "0.7.1"
 dependencies = [
  "actix-rt",
  "aes-gcm",
@@ -2698,23 +2553,23 @@ dependencies = [
  "paste 1.0.14 (git+https://github.com/dtolnay/paste?rev=1e0cc1025af5388397c67fa4389ad7ad24814df8)",
  "pretty_assertions",
  "pretty_env_logger",
- "radix-engine 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
- "radix-engine-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
- "radix-engine-derive 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
- "radix-engine-interface 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
+ "radix-engine",
+ "radix-engine-common",
+ "radix-engine-derive",
+ "radix-engine-interface",
  "radix-engine-toolkit",
  "radix-engine-toolkit-json",
  "rand 0.8.5",
  "regex 1.9.3 (git+https://github.com/rust-lang/regex/?rev=72f889ef3cca59ebac6a026f3646e8d92f056d88)",
  "reqwest",
- "sbor 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
+ "sbor",
  "serde",
  "serde_json 1.0.108",
  "serde_repr",
  "serde_with 3.4.0",
  "strum 0.26.1",
  "thiserror 1.0.50",
- "transaction 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
+ "transaction",
  "uniffi",
  "url",
  "uuid 1.6.1",
@@ -2724,38 +2579,15 @@ dependencies = [
 [[package]]
 name = "sbor"
 version = "1.1.2"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
-dependencies = [
- "const-sha1",
- "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static",
- "paste 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "sbor-derive 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
- "serde",
- "utils 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
-]
-
-[[package]]
-name = "sbor"
-version = "1.1.2"
 source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
 dependencies = [
  "const-sha1",
  "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static",
  "paste 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "sbor-derive 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "sbor-derive",
  "serde",
- "utils 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
-]
-
-[[package]]
-name = "sbor-derive"
-version = "1.1.2"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
-dependencies = [
- "proc-macro2",
- "sbor-derive-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
+ "utils",
 ]
 
 [[package]]
@@ -2764,19 +2596,7 @@ version = "1.1.2"
 source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
 dependencies = [
  "proc-macro2",
- "sbor-derive-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
-]
-
-[[package]]
-name = "sbor-derive-common"
-version = "1.1.2"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
-dependencies = [
- "const-sha1",
- "itertools 0.10.5",
- "proc-macro2",
- "quote",
- "syn 1.0.93",
+ "sbor-derive-common",
 ]
 
 [[package]]
@@ -2794,13 +2614,13 @@ dependencies = [
 [[package]]
 name = "sbor-json"
 version = "2.0.1"
-source = "git+https://github.com/radixdlt/radix-engine-toolkit?rev=566632afb4f1e292453950797bbf4329b37a04b0#566632afb4f1e292453950797bbf4329b37a04b0"
+source = "git+https://github.com/radixdlt/radix-engine-toolkit?rev=v2.0.1#566632afb4f1e292453950797bbf4329b37a04b0"
 dependencies = [
  "bech32",
- "radix-engine-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
- "radix-engine-interface 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "radix-engine-common",
+ "radix-engine-interface",
  "regex 1.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sbor 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "sbor",
  "serde",
  "serde_json 1.0.113",
  "serde_with 3.6.1",
@@ -2886,15 +2706,15 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "paste 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "radix-engine-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
- "radix-engine-derive 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
- "radix-engine-interface 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
- "sbor 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "radix-engine-common",
+ "radix-engine-derive",
+ "radix-engine-interface",
+ "sbor",
  "scrypto-derive",
- "scrypto-schema 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "scrypto-schema",
  "serde",
  "strum 0.24.1",
- "utils 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "utils",
 ]
 
 [[package]]
@@ -2904,10 +2724,10 @@ source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3a
 dependencies = [
  "proc-macro2",
  "quote",
- "radix-engine-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "radix-engine-common",
  "regex 1.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sbor 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
- "scrypto-schema 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "sbor",
+ "scrypto-schema",
  "serde",
  "serde_json 1.0.113",
  "syn 1.0.93",
@@ -2916,22 +2736,11 @@ dependencies = [
 [[package]]
 name = "scrypto-schema"
 version = "1.1.2"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
-dependencies = [
- "bitflags 1.3.2",
- "radix-engine-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
- "sbor 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
- "serde",
-]
-
-[[package]]
-name = "scrypto-schema"
-version = "1.1.2"
 source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
 dependencies = [
  "bitflags 1.3.2",
- "radix-engine-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
- "sbor 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "radix-engine-common",
+ "sbor",
  "serde",
 ]
 
@@ -3615,31 +3424,16 @@ dependencies = [
 [[package]]
 name = "transaction"
 version = "1.1.2"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
-dependencies = [
- "bech32",
- "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static",
- "radix-engine-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
- "radix-engine-interface 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
- "sbor 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
- "strum 0.24.1",
- "utils 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613)",
-]
-
-[[package]]
-name = "transaction"
-version = "1.1.2"
 source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
 dependencies = [
  "bech32",
  "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static",
- "radix-engine-common 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
- "radix-engine-interface 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
- "sbor 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "radix-engine-common",
+ "radix-engine-interface",
+ "sbor",
  "strum 0.24.1",
- "utils 1.1.2 (git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2)",
+ "utils",
 ]
 
 [[package]]
@@ -3881,15 +3675,6 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
-
-[[package]]
-name = "utils"
-version = "1.1.2"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=07327fcc3ac035fd7aff136d1a75a825e4b8f613#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
-dependencies = [
- "indexmap 2.0.0-pre",
- "serde",
-]
 
 [[package]]
 name = "utils"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,28 +74,24 @@ strum = { git = "https://github.com/Peternator7/strum/", rev = "f746c3699acf1501
     "derive",
 ] }
 
-# 587d5988cd4ca3c5193ddf37027ff4e4ecd637dc is the Scrypto commit that RET 1cfe879c7370cfa497857ada7a8973f8a3388abc uses
-radix-engine-common = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "587d5988cd4ca3c5193ddf37027ff4e4ecd637dc", features = [
+# radixdlt-scrypto = "1.1.2"
+radix-engine-common = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "07327fcc3ac035fd7aff136d1a75a825e4b8f613", features = [
     "serde",
 ] }
-
-radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "587d5988cd4ca3c5193ddf37027ff4e4ecd637dc" }
-
-sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "587d5988cd4ca3c5193ddf37027ff4e4ecd637dc" }
-
-radix-engine-derive = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "587d5988cd4ca3c5193ddf37027ff4e4ecd637dc" }
-
-radix-engine-interface = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "587d5988cd4ca3c5193ddf37027ff4e4ecd637dc", features = [
+radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "07327fcc3ac035fd7aff136d1a75a825e4b8f613" }
+sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "07327fcc3ac035fd7aff136d1a75a825e4b8f613" }
+radix-engine-derive = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "07327fcc3ac035fd7aff136d1a75a825e4b8f613" }
+radix-engine-interface = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "07327fcc3ac035fd7aff136d1a75a825e4b8f613", features = [
     "std",
 ] }
 
-transaction = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "587d5988cd4ca3c5193ddf37027ff4e4ecd637dc", features = [
+transaction = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "07327fcc3ac035fd7aff136d1a75a825e4b8f613", features = [
     "std",
 ] }
 
-radix-engine-toolkit-json = { git = "https://github.com/radixdlt/radix-engine-toolkit", rev = "1cfe879c7370cfa497857ada7a8973f8a3388abc" }
-
-radix-engine-toolkit = { git = "https://github.com/radixdlt/radix-engine-toolkit", rev = "1cfe879c7370cfa497857ada7a8973f8a3388abc" }
+# radix-engine-toolkit = "2.0.1"
+radix-engine-toolkit-json = { git = "https://github.com/radixdlt/radix-engine-toolkit", rev = "566632afb4f1e292453950797bbf4329b37a04b0" }
+radix-engine-toolkit = { git = "https://github.com/radixdlt/radix-engine-toolkit", rev = "566632afb4f1e292453950797bbf4329b37a04b0" }
 
 # enum-iterator = "1.4.1"
 enum-iterator = { git = "https://github.com/stephaneyfx/enum-iterator/", rev = "9d472a1237cfd03b1c7657fdcba74c8070bfb4ea" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "0.6.56"
+version = "0.7.1"
 edition = "2021"
 build = "build.rs"
 
@@ -74,24 +74,22 @@ strum = { git = "https://github.com/Peternator7/strum/", rev = "f746c3699acf1501
     "derive",
 ] }
 
-# radixdlt-scrypto = "1.1.2"
-radix-engine-common = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "07327fcc3ac035fd7aff136d1a75a825e4b8f613", features = [
+radix-engine-common = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "v1.1.2", features = [
     "serde",
 ] }
-radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "07327fcc3ac035fd7aff136d1a75a825e4b8f613" }
-sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "07327fcc3ac035fd7aff136d1a75a825e4b8f613" }
-radix-engine-derive = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "07327fcc3ac035fd7aff136d1a75a825e4b8f613" }
-radix-engine-interface = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "07327fcc3ac035fd7aff136d1a75a825e4b8f613", features = [
+radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "v1.1.2" }
+sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "v1.1.2" }
+radix-engine-derive = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "v1.1.2" }
+radix-engine-interface = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "v1.1.2", features = [
     "std",
 ] }
 
-transaction = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "07327fcc3ac035fd7aff136d1a75a825e4b8f613", features = [
+transaction = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "v1.1.2", features = [
     "std",
 ] }
 
-# radix-engine-toolkit = "2.0.1"
-radix-engine-toolkit-json = { git = "https://github.com/radixdlt/radix-engine-toolkit", rev = "566632afb4f1e292453950797bbf4329b37a04b0" }
-radix-engine-toolkit = { git = "https://github.com/radixdlt/radix-engine-toolkit", rev = "566632afb4f1e292453950797bbf4329b37a04b0" }
+radix-engine-toolkit-json = { git = "https://github.com/radixdlt/radix-engine-toolkit", rev = "v2.0.1" }
+radix-engine-toolkit = { git = "https://github.com/radixdlt/radix-engine-toolkit", rev = "v2.0.1" }
 
 # enum-iterator = "1.4.1"
 enum-iterator = { git = "https://github.com/stephaneyfx/enum-iterator/", rev = "9d472a1237cfd03b1c7657fdcba74c8070bfb4ea" }

--- a/src/core/types/keys/public_key.rs
+++ b/src/core/types/keys/public_key.rs
@@ -407,7 +407,7 @@ mod tests {
         "#;
 
         let result =
-            serde_json::from_str::<PublicKey>(&json_with_wrong_curve).unwrap();
+            serde_json::from_str::<PublicKey>(json_with_wrong_curve).unwrap();
         assert_eq!(expected_secp256k1, result);
     }
 

--- a/src/wrapped_radix_engine_toolkit/low_level/transaction_manifest/instructions/instructions.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/transaction_manifest/instructions/instructions.rs
@@ -6,7 +6,7 @@ use radix_engine_toolkit::functions::address::decode as RET_decode_address;
 #[derive(Clone, Debug, PartialEq, Eq, derive_more::Display, uniffi::Record)]
 #[display("{}", self.instructions_string())]
 pub struct Instructions {
-    secret_magic: InstructionsSecretMagic, // MUST be first prop, else you break build.
+    pub secret_magic: InstructionsSecretMagic, // MUST be first prop, else you break build.
     pub network_id: NetworkID,
 }
 

--- a/src/wrapped_radix_engine_toolkit/low_level/transaction_manifest/instructions/instructions_secret_magic.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/transaction_manifest/instructions/instructions_secret_magic.rs
@@ -7,7 +7,7 @@ use crate::prelude::*;
 /// `private let secretMagic: InstructionsSecretMagic`
 /// And hide its initializers.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct InstructionsSecretMagic(Vec<ScryptoInstruction>);
+pub struct InstructionsSecretMagic(pub Vec<ScryptoInstruction>);
 
 impl InstructionsSecretMagic {
     pub(crate) fn instructions(&self) -> &Vec<ScryptoInstruction> {

--- a/src/wrapped_radix_engine_toolkit/low_level/transaction_manifest/transaction_manifest.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/transaction_manifest/transaction_manifest.rs
@@ -126,7 +126,9 @@ impl TransactionManifest {
     }
 
     pub fn involved_resource_addresses(&self) -> Vec<ResourceAddress> {
-        let (addresses, _) = RET_ins_extract_addresses(self.instructions());
+        let (addresses, _) = RET_ins_extract_addresses(
+            self.secret_magic.instructions.secret_magic.0.as_slice(),
+        );
         addresses
             .into_iter()
             .filter_map(|a| {


### PR DESCRIPTION
Bump Scrypto to 1.1.2 which contains the two fixes to Rust Analyzer:
* https://github.com/radixdlt/radixdlt-scrypto/pull/1781
* https://github.com/radixdlt/radixdlt-scrypto/pull/1779

Also bump RET to 2.0.1 which uses Scrypto 1.1.2

* Bump Sargon to 0.7.1 (and have manually tagged and pushed 0.7.0 tag so that next release will be 0.7.1)