### PR TITLE
update CI / CD to use main branch instead of develop

### DIFF
--- a/.github/workflows/release-desktop-bins.yml
+++ b/.github/workflows/release-desktop-bins.yml
@@ -6,7 +6,7 @@ on:
     tags:
       - "**"
     branches:
-      - develop
+      - main
 
 permissions:
   id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - develop
+      - main
 
 permissions:
   id-token: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
   push:
     branches:
-      - develop
+      - main
 
 permissions:
   id-token: write

--- a/apple/Tests/TestCases/Prelude/DependencyInformationTests.swift
+++ b/apple/Tests/TestCases/Prelude/DependencyInformationTests.swift
@@ -6,6 +6,6 @@ import XCTest
 
 final class DependencyInformationTests: Test<DependencyInformation> {
 	func test_description() {
-		XCTAssertNoDifference(SUT.sample.description, "develop")
+		XCTAssertNoDifference(SUT.sample.description, "main")
 	}
 }

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/DependencyInformationTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/DependencyInformationTest.kt
@@ -12,6 +12,6 @@ class DependencyInformationTest: SampleTestable<DependencyInformation> {
 
     @Test
     fun testString() {
-        assertEquals("develop", DependencyInformation.sample().string)
+        assertEquals("main", DependencyInformation.sample().string)
     }
 }

--- a/scripts/ios/release.sh
+++ b/scripts/ios/release.sh
@@ -51,7 +51,7 @@ GIT_ADD_CMD="git add --force Package.swift apple/Sources/UniFFI/Sargon.swift"
 echo "🚢  Staging (potentially) changed files with: $GIT_ADD_CMD"
 eval $GIT_ADD_CMD
 
-GIT_COMMIT_CMD="git commit -m \"Release of '$NEXT_TAG' (updated Package.swift with new checksum and path to zip on Github, and maybe apple/Sources/UniFFI/Sargon.swift). This commit is not merged into main/develop branch (and need not be).\" --no-verify"
+GIT_COMMIT_CMD="git commit -m \"Release of '$NEXT_TAG' (updated Package.swift with new checksum and path to zip on Github, and maybe apple/Sources/UniFFI/Sargon.swift). This commit is not merged into main branch (and need not be).\" --no-verify"
 echo "🚢  Git commiting changes to Package.swift (and maybe Sargon.swift)"
 eval $GIT_COMMIT_CMD
 

--- a/src/wrapped_radix_engine_toolkit/high_level/sargon_specific_types/build_information/dependency_information.rs
+++ b/src/wrapped_radix_engine_toolkit/high_level/sargon_specific_types/build_information/dependency_information.rs
@@ -40,7 +40,7 @@ impl DependencyInformation {
 
 impl HasSampleValues for DependencyInformation {
     fn sample() -> Self {
-        Self::Branch("develop".to_owned())
+        Self::Branch("main".to_owned())
     }
 
     fn sample_other() -> Self {
@@ -68,7 +68,7 @@ mod tests {
 
     #[test]
     fn display() {
-        assert_eq!(format!("{}", SUT::sample()), "develop");
+        assert_eq!(format!("{}", SUT::sample()), "main");
     }
 
     #[test]

--- a/src/wrapped_radix_engine_toolkit/high_level/sargon_specific_types/build_information/dependency_information_uniffi_fn.rs
+++ b/src/wrapped_radix_engine_toolkit/high_level/sargon_specific_types/build_information/dependency_information_uniffi_fn.rs
@@ -41,6 +41,6 @@ mod tests {
 
     #[test]
     fn to_string() {
-        assert_eq!(dependency_information_to_string(&SUT::sample()), "develop");
+        assert_eq!(dependency_information_to_string(&SUT::sample()), "main");
     }
 }


### PR DESCRIPTION
I've also changed the default branch to be `main` (and changes the branch protection rules to use `main`)