### PR TITLE
Fix equality and hashcode in identifiable collections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2529,7 +2529,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "actix-rt",
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "0.7.9"
+version = "0.7.10"
 edition = "2021"
 build = "build.rs"
 

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/Accounts.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/Accounts.kt
@@ -2,9 +2,10 @@ package com.radixdlt.sargon.extensions
 
 import com.radixdlt.sargon.Account
 import com.radixdlt.sargon.AccountAddress
+import com.radixdlt.sargon.annotation.KoverIgnore
 
 class Accounts private constructor(
-    array: IdentifiedArray<AccountAddress, Account>
+    private val array: IdentifiedArray<AccountAddress, Account>
 ) : IdentifiedArray<AccountAddress, Account> by array {
 
     constructor(accounts: List<Account>) : this(
@@ -15,5 +16,26 @@ class Accounts private constructor(
     )
 
     constructor(vararg account: Account) : this(accounts = account.asList())
+
+    @KoverIgnore // False positive in javaClass check
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as Accounts
+
+        return array == other.array
+    }
+
+    override fun hashCode(): Int {
+        return array.hashCode()
+    }
+
+    @KoverIgnore
+    override fun toString(): String {
+        return "Accounts(array=$array)"
+    }
+
 }
 
+fun List<Account>.asIdentifiable() = Accounts(accounts = this)

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/AssetsExceptionList.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/AssetsExceptionList.kt
@@ -2,9 +2,10 @@ package com.radixdlt.sargon.extensions
 
 import com.radixdlt.sargon.AssetException
 import com.radixdlt.sargon.ResourceAddress
+import com.radixdlt.sargon.annotation.KoverIgnore
 
 class AssetsExceptionList private constructor(
-    array: IdentifiedArray<ResourceAddress, AssetException>
+    private val array: IdentifiedArray<ResourceAddress, AssetException>
 ) : IdentifiedArray<ResourceAddress, AssetException> by array {
 
     constructor(assetExceptions: List<AssetException>) : this(
@@ -17,4 +18,26 @@ class AssetsExceptionList private constructor(
     constructor(
         vararg assetException: AssetException
     ) : this(assetExceptions = assetException.asList())
+
+    @KoverIgnore // False positive in javaClass check
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as AssetsExceptionList
+
+        return array == other.array
+    }
+
+    override fun hashCode(): Int {
+        return array.hashCode()
+    }
+
+    @KoverIgnore
+    override fun toString(): String {
+        return "AssetsExceptionList(array=$array)"
+    }
+
 }
+
+fun List<AssetException>.asIdentifiable() = AssetsExceptionList(assetExceptions = this)

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/AuthorizedDapps.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/AuthorizedDapps.kt
@@ -2,9 +2,10 @@ package com.radixdlt.sargon.extensions
 
 import com.radixdlt.sargon.AccountAddress
 import com.radixdlt.sargon.AuthorizedDapp
+import com.radixdlt.sargon.annotation.KoverIgnore
 
 class AuthorizedDapps private constructor(
-    array: IdentifiedArray<AccountAddress, AuthorizedDapp>
+    private val array: IdentifiedArray<AccountAddress, AuthorizedDapp>
 ) : IdentifiedArray<AccountAddress, AuthorizedDapp> by array {
 
     constructor(authorizedDapps: List<AuthorizedDapp>) : this(
@@ -17,4 +18,26 @@ class AuthorizedDapps private constructor(
     constructor(
         vararg authorizedDapp: AuthorizedDapp
     ) : this(authorizedDapps = authorizedDapp.asList())
+
+    @KoverIgnore // False positive in javaClass check
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as AuthorizedDapps
+
+        return array == other.array
+    }
+
+    override fun hashCode(): Int {
+        return array.hashCode()
+    }
+
+    @KoverIgnore
+    override fun toString(): String {
+        return "AuthorizedDapps(array=$array)"
+    }
+
 }
+
+fun List<AuthorizedDapp>.asIdentifiable() = AuthorizedDapps(authorizedDapps = this)

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/DepositorsAllowList.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/DepositorsAllowList.kt
@@ -1,9 +1,10 @@
 package com.radixdlt.sargon.extensions
 
 import com.radixdlt.sargon.ResourceOrNonFungible
+import com.radixdlt.sargon.annotation.KoverIgnore
 
 class DepositorsAllowList private constructor(
-    array: IdentifiedArray<ResourceOrNonFungible, ResourceOrNonFungible>
+    private val array: IdentifiedArray<ResourceOrNonFungible, ResourceOrNonFungible>
 ) : IdentifiedArray<ResourceOrNonFungible, ResourceOrNonFungible> by array {
 
     constructor(resourcesOrNonFungibles: List<ResourceOrNonFungible>) : this(
@@ -16,4 +17,27 @@ class DepositorsAllowList private constructor(
     constructor(vararg resourceOrNonFungible: ResourceOrNonFungible) : this(
         resourcesOrNonFungibles = resourceOrNonFungible.asList()
     )
+
+    @KoverIgnore // False positive in javaClass check
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as DepositorsAllowList
+
+        return array == other.array
+    }
+
+    override fun hashCode(): Int {
+        return array.hashCode()
+    }
+
+    @KoverIgnore
+    override fun toString(): String {
+        return "DepositorsAllowList(array=$array)"
+    }
+
 }
+
+fun List<ResourceOrNonFungible>.asIdentifiable() =
+    DepositorsAllowList(resourcesOrNonFungibles = this)

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/EntityFlags.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/EntityFlags.kt
@@ -1,9 +1,10 @@
 package com.radixdlt.sargon.extensions
 
 import com.radixdlt.sargon.EntityFlag
+import com.radixdlt.sargon.annotation.KoverIgnore
 
 class EntityFlags private constructor(
-    array: IdentifiedArray<EntityFlag, EntityFlag>
+    private val array: IdentifiedArray<EntityFlag, EntityFlag>
 ) : IdentifiedArray<EntityFlag, EntityFlag> by array {
 
     constructor(entityFlags: List<EntityFlag>) : this(
@@ -15,5 +16,25 @@ class EntityFlags private constructor(
 
     constructor(vararg entityFlag: EntityFlag) : this(entityFlags = entityFlag.asList())
 
-    companion object
+    @KoverIgnore // False positive in javaClass check
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as EntityFlags
+
+        return array == other.array
+    }
+
+    override fun hashCode(): Int {
+        return array.hashCode()
+    }
+
+    @KoverIgnore
+    override fun toString(): String {
+        return "EntityFlags(array=$array)"
+    }
+
 }
+
+fun List<EntityFlag>.asIdentifiable() = EntityFlags(entityFlags = this)

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/FactorSources.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/FactorSources.kt
@@ -2,9 +2,10 @@ package com.radixdlt.sargon.extensions
 
 import com.radixdlt.sargon.FactorSource
 import com.radixdlt.sargon.FactorSourceId
+import com.radixdlt.sargon.annotation.KoverIgnore
 
 class FactorSources private constructor(
-    array: IdentifiedArray<FactorSourceId, FactorSource>
+    private val array: IdentifiedArray<FactorSourceId, FactorSource>
 ) : IdentifiedArray<FactorSourceId, FactorSource> by array {
 
     constructor(factorSources: List<FactorSource>) : this(
@@ -17,5 +18,26 @@ class FactorSources private constructor(
     constructor(vararg factorSource: FactorSource) : this(
         factorSources = factorSource.asList()
     )
+
+    @KoverIgnore // False positive in javaClass check
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as FactorSources
+
+        return array == other.array
+    }
+
+    override fun hashCode(): Int {
+        return array.hashCode()
+    }
+
+    @KoverIgnore
+    override fun toString(): String {
+        return "FactorSources(array=$array)"
+    }
+
 }
 
+fun List<FactorSource>.asIdentifiable() = FactorSources(factorSources = this)

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/Gateways.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/Gateways.kt
@@ -2,9 +2,10 @@ package com.radixdlt.sargon.extensions
 
 import com.radixdlt.sargon.Gateway
 import com.radixdlt.sargon.Url
+import com.radixdlt.sargon.annotation.KoverIgnore
 
 class Gateways private constructor(
-    array: IdentifiedArray<Url, Gateway>
+    private val array: IdentifiedArray<Url, Gateway>
 ) : IdentifiedArray<Url, Gateway> by array {
 
     constructor(gateways: List<Gateway>) : this(
@@ -15,4 +16,27 @@ class Gateways private constructor(
     )
 
     constructor(vararg gateway: Gateway) : this(gateways = gateway.asList())
+
+    @KoverIgnore // False positive in javaClass check
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as Gateways
+
+        return array == other.array
+    }
+
+    override fun hashCode(): Int {
+        return array.hashCode()
+    }
+
+    @KoverIgnore
+    override fun toString(): String {
+        return "Gateways(array=$array)"
+    }
+
 }
+
+fun List<Gateway>.asIdentifiable() = Gateways(gateways = this)
+

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/IdentifiedArray.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/IdentifiedArray.kt
@@ -1,6 +1,8 @@
 package com.radixdlt.sargon.extensions
 
-internal interface IdentifiedArray<Identifier, Element> {
+import com.radixdlt.sargon.annotation.KoverIgnore
+
+interface IdentifiedArray<Identifier, Element> {
     val size: Int
 
     fun asList(): List<Element>
@@ -17,7 +19,15 @@ internal interface IdentifiedArray<Identifier, Element> {
 
     operator fun get(index: Int): Element
 
+    operator fun contains(element: Element): Boolean
+
     fun removeBy(identifier: Identifier): IdentifiedArray<Identifier, Element>
+
+    override fun equals(other: Any?): Boolean
+
+    override fun hashCode(): Int
+
+    override fun toString(): String
 }
 
 
@@ -41,6 +51,8 @@ internal class IdentifiedArrayImpl<Identifier, Element>(
         .toList()
 
     override fun get(index: Int): Element = inner.values.elementAt(index)
+
+    override fun contains(element: Element): Boolean = inner.contains(identifier(element))
 
     override fun append(element: Element) = apply {
         val identifier = identifier(element)
@@ -82,4 +94,23 @@ internal class IdentifiedArrayImpl<Identifier, Element>(
     override fun removeBy(identifier: Identifier) = apply {
         inner.remove(identifier)
     }
+
+    @KoverIgnore
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+
+        return inner == (other as? IdentifiedArrayImpl<*, *>)?.inner
+    }
+
+    @KoverIgnore
+    override fun hashCode(): Int {
+        return inner.hashCode()
+    }
+
+    @KoverIgnore
+    override fun toString(): String {
+        return "IdentifiedArrayImpl(inner=$inner)"
+    }
+
+
 }

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/P2PLinks.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/P2PLinks.kt
@@ -2,9 +2,10 @@ package com.radixdlt.sargon.extensions
 
 import com.radixdlt.sargon.Hash
 import com.radixdlt.sargon.P2pLink
+import com.radixdlt.sargon.annotation.KoverIgnore
 
 class P2pLinks private constructor(
-    array: IdentifiedArray<Hash, P2pLink>
+    private val array: IdentifiedArray<Hash, P2pLink>
 ) : IdentifiedArray<Hash, P2pLink> by array {
 
     constructor(p2pLinks: List<P2pLink>) : this(
@@ -15,4 +16,26 @@ class P2pLinks private constructor(
     )
 
     constructor(vararg p2pLink: P2pLink) : this(p2pLinks = p2pLink.asList())
+
+    @KoverIgnore // False positive in javaClass check
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as P2pLinks
+
+        return array == other.array
+    }
+
+    override fun hashCode(): Int {
+        return array.hashCode()
+    }
+
+    @KoverIgnore
+    override fun toString(): String {
+        return "P2pLinks(array=$array)"
+    }
+
 }
+
+fun List<P2pLink>.asIdentifiable() = P2pLinks(p2pLinks = this)

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/Personas.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/Personas.kt
@@ -2,9 +2,10 @@ package com.radixdlt.sargon.extensions
 
 import com.radixdlt.sargon.IdentityAddress
 import com.radixdlt.sargon.Persona
+import com.radixdlt.sargon.annotation.KoverIgnore
 
 class Personas private constructor(
-    array: IdentifiedArray<IdentityAddress, Persona>
+    private val array: IdentifiedArray<IdentityAddress, Persona>
 ) : IdentifiedArray<IdentityAddress, Persona> by array {
 
     constructor(personas: List<Persona>) : this(
@@ -15,4 +16,26 @@ class Personas private constructor(
     )
 
     constructor(vararg persona: Persona) : this(personas = persona.asList())
+
+    @KoverIgnore // False positive in javaClass check
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as Personas
+
+        return array == other.array
+    }
+
+    override fun hashCode(): Int {
+        return array.hashCode()
+    }
+
+    @KoverIgnore
+    override fun toString(): String {
+        return "Personas(array=$array)"
+    }
+
 }
+
+fun List<Persona>.asIdentifiable() = Personas(personas = this)

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/ProfileNetworks.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/ProfileNetworks.kt
@@ -2,9 +2,10 @@ package com.radixdlt.sargon.extensions
 
 import com.radixdlt.sargon.NetworkId
 import com.radixdlt.sargon.ProfileNetwork
+import com.radixdlt.sargon.annotation.KoverIgnore
 
 class ProfileNetworks private constructor(
-    array: IdentifiedArray<NetworkId, ProfileNetwork>
+    private val array: IdentifiedArray<NetworkId, ProfileNetwork>
 ) : IdentifiedArray<NetworkId, ProfileNetwork> by array {
 
     constructor(networks: List<ProfileNetwork>) : this(
@@ -15,4 +16,26 @@ class ProfileNetworks private constructor(
     )
 
     constructor(vararg network: ProfileNetwork) : this(networks = network.asList())
+
+    @KoverIgnore // False positive in javaClass check
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as ProfileNetworks
+
+        return array == other.array
+    }
+
+    override fun hashCode(): Int {
+        return array.hashCode()
+    }
+
+    @KoverIgnore
+    override fun toString(): String {
+        return "ProfileNetworks(array=$array)"
+    }
+
 }
+
+fun List<ProfileNetwork>.asIdentifiable() = ProfileNetworks(networks = this)

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/ReferencesToAuthorizedPersonas.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/ReferencesToAuthorizedPersonas.kt
@@ -2,9 +2,10 @@ package com.radixdlt.sargon.extensions
 
 import com.radixdlt.sargon.AuthorizedPersonaSimple
 import com.radixdlt.sargon.IdentityAddress
+import com.radixdlt.sargon.annotation.KoverIgnore
 
 class ReferencesToAuthorizedPersonas private constructor(
-    array: IdentifiedArray<IdentityAddress, AuthorizedPersonaSimple>
+    private val array: IdentifiedArray<IdentityAddress, AuthorizedPersonaSimple>
 ) : IdentifiedArray<IdentityAddress, AuthorizedPersonaSimple> by array {
 
     constructor(authorizedPersonasSimple: List<AuthorizedPersonaSimple>) : this(
@@ -17,4 +18,26 @@ class ReferencesToAuthorizedPersonas private constructor(
     constructor(vararg authorizedPersonaSimple: AuthorizedPersonaSimple) : this(
         authorizedPersonasSimple = authorizedPersonaSimple.asList()
     )
+
+    @KoverIgnore // False positive in javaClass check
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as ReferencesToAuthorizedPersonas
+
+        return array == other.array
+    }
+
+    override fun hashCode(): Int {
+        return array.hashCode()
+    }
+
+    @KoverIgnore
+    override fun toString(): String {
+        return "ReferencesToAuthorizedPersonas(array=$array)"
+    }
+
 }
+
+fun List<AuthorizedPersonaSimple>.asIdentifiable() = ReferencesToAuthorizedPersonas(authorizedPersonasSimple = this)

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/SupportedCurves.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/SupportedCurves.kt
@@ -1,9 +1,10 @@
 package com.radixdlt.sargon.extensions
 
 import com.radixdlt.sargon.Slip10Curve
+import com.radixdlt.sargon.annotation.KoverIgnore
 
 class SupportedCurves private constructor(
-    array: IdentifiedArray<Slip10Curve, Slip10Curve>
+    private val array: IdentifiedArray<Slip10Curve, Slip10Curve>
 ) : IdentifiedArray<Slip10Curve, Slip10Curve> by array {
 
     constructor(curves: List<Slip10Curve>) : this(
@@ -14,4 +15,26 @@ class SupportedCurves private constructor(
     )
 
     constructor(vararg curve: Slip10Curve) : this(curves = curve.asList())
+
+    @KoverIgnore // False positive in javaClass check
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as SupportedCurves
+
+        return array == other.array
+    }
+
+    override fun hashCode(): Int {
+        return array.hashCode()
+    }
+
+    @KoverIgnore
+    override fun toString(): String {
+        return "SupportedCurves(array=$array)"
+    }
+
 }
+
+fun List<Slip10Curve>.asIdentifiable() = SupportedCurves(curves = this)

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/AccountsTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/AccountsTest.kt
@@ -1,7 +1,12 @@
 package com.radixdlt.sargon
 
 import com.radixdlt.sargon.extensions.Accounts
+import com.radixdlt.sargon.extensions.asIdentifiable
 import com.radixdlt.sargon.samples.sampleMainnet
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
 
 internal class AccountsTest: IdentifiedArrayTest<Accounts, AccountAddress, Account>() {
 
@@ -12,5 +17,47 @@ internal class AccountsTest: IdentifiedArrayTest<Accounts, AccountAddress, Accou
     override fun identifier(element: Account): AccountAddress = element.address
 
     override fun init(element: Account): Accounts = Accounts(element)
+
+    @Test
+    fun testAsIdentifiable() {
+        assertEquals(
+            Accounts(
+                element(),
+                elementWithDifferentId()
+            ),
+            listOf(
+                element(),
+                elementWithDifferentId()
+            ).asIdentifiable()
+        )
+    }
+
+    @Test
+    fun testEquality() {
+        val element = element()
+
+        assertEquals(
+            listOf(element).asIdentifiable(),
+            listOf(element).asIdentifiable()
+        )
+
+        val collection = listOf(element).asIdentifiable()
+        assertEquals(collection, collection)
+        assertNotEquals(collection, "")
+    }
+
+    @Test
+    fun testUniqueness() {
+        val element = element()
+        val elementOther = elementWithDifferentId()
+        assertEquals(
+            2,
+            setOf(
+                listOf(element).asIdentifiable(),
+                listOf(elementOther).asIdentifiable(),
+                listOf(element).asIdentifiable()
+            ).size
+        )
+    }
 
 }

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/AssetsExceptionListTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/AssetsExceptionListTest.kt
@@ -1,7 +1,12 @@
 package com.radixdlt.sargon
 
 import com.radixdlt.sargon.extensions.AssetsExceptionList
+import com.radixdlt.sargon.extensions.asIdentifiable
 import com.radixdlt.sargon.samples.sample
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
 
 internal class AssetsExceptionListTest :
     IdentifiedArrayTest<AssetsExceptionList, ResourceAddress, AssetException>() {
@@ -13,4 +18,45 @@ internal class AssetsExceptionListTest :
 
     override fun init(element: AssetException): AssetsExceptionList = AssetsExceptionList(element)
 
+    @Test
+    fun testAsIdentifiable() {
+        assertEquals(
+            AssetsExceptionList(
+                element(),
+                elementWithDifferentId()
+            ),
+            listOf(
+                element(),
+                elementWithDifferentId()
+            ).asIdentifiable()
+        )
+    }
+
+    @Test
+    fun testEquality() {
+        val element = element()
+
+        assertEquals(
+            listOf(element).asIdentifiable(),
+            listOf(element).asIdentifiable()
+        )
+
+        val collection = listOf(element).asIdentifiable()
+        assertEquals(collection, collection)
+        assertNotEquals(collection, "")
+    }
+
+    @Test
+    fun testUniqueness() {
+        val element = element()
+        val elementOther = elementWithDifferentId()
+        assertEquals(
+            2,
+            setOf(
+                listOf(element).asIdentifiable(),
+                listOf(elementOther).asIdentifiable(),
+                listOf(element).asIdentifiable()
+            ).size
+        )
+    }
 }

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/AuthorizedDappsTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/AuthorizedDappsTest.kt
@@ -1,7 +1,12 @@
 package com.radixdlt.sargon
 
 import com.radixdlt.sargon.extensions.AuthorizedDapps
+import com.radixdlt.sargon.extensions.asIdentifiable
 import com.radixdlt.sargon.samples.sampleMainnet
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
 
 internal class AuthorizedDappsTest: IdentifiedArrayTest<AuthorizedDapps, AccountAddress, AuthorizedDapp>() {
     override fun element(): AuthorizedDapp = AuthorizedDapp.sampleMainnet()
@@ -12,4 +17,45 @@ internal class AuthorizedDappsTest: IdentifiedArrayTest<AuthorizedDapps, Account
 
     override fun init(element: AuthorizedDapp): AuthorizedDapps = AuthorizedDapps(element)
 
+    @Test
+    fun testAsIdentifiable() {
+        assertEquals(
+            AuthorizedDapps(
+                element(),
+                elementWithDifferentId()
+            ),
+            listOf(
+                element(),
+                elementWithDifferentId()
+            ).asIdentifiable()
+        )
+    }
+
+    @Test
+    fun testEquality() {
+        val element = element()
+
+        assertEquals(
+            listOf(element).asIdentifiable(),
+            listOf(element).asIdentifiable()
+        )
+
+        val collection = listOf(element).asIdentifiable()
+        assertEquals(collection, collection)
+        assertNotEquals(collection, "")
+    }
+
+    @Test
+    fun testUniqueness() {
+        val element = element()
+        val elementOther = elementWithDifferentId()
+        assertEquals(
+            2,
+            setOf(
+                listOf(element).asIdentifiable(),
+                listOf(elementOther).asIdentifiable(),
+                listOf(element).asIdentifiable()
+            ).size
+        )
+    }
 }

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/DepositorsAllowListTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/DepositorsAllowListTest.kt
@@ -1,7 +1,11 @@
 package com.radixdlt.sargon
 
 import com.radixdlt.sargon.extensions.DepositorsAllowList
+import com.radixdlt.sargon.extensions.asIdentifiable
 import com.radixdlt.sargon.samples.sample
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
 
 internal class DepositorsAllowListTest :
     IdentifiedArrayTest<DepositorsAllowList, ResourceOrNonFungible, ResourceOrNonFungible>() {
@@ -14,4 +18,45 @@ internal class DepositorsAllowListTest :
     override fun init(element: ResourceOrNonFungible): DepositorsAllowList =
         DepositorsAllowList(element)
 
+    @Test
+    fun testAsIdentifiable() {
+        assertEquals(
+            DepositorsAllowList(
+                element(),
+                elementWithDifferentId()
+            ),
+            listOf(
+                element(),
+                elementWithDifferentId()
+            ).asIdentifiable()
+        )
+    }
+
+    @Test
+    fun testEquality() {
+        val element = element()
+
+        assertEquals(
+            listOf(element).asIdentifiable(),
+            listOf(element).asIdentifiable()
+        )
+
+        val collection = listOf(element).asIdentifiable()
+        assertEquals(collection, collection)
+        assertNotEquals(collection, "")
+    }
+
+    @Test
+    fun testUniqueness() {
+        val element = element()
+        val elementOther = elementWithDifferentId()
+        assertEquals(
+            2,
+            setOf(
+                listOf(element).asIdentifiable(),
+                listOf(elementOther).asIdentifiable(),
+                listOf(element).asIdentifiable()
+            ).size
+        )
+    }
 }

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/EntityFlagsTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/EntityFlagsTest.kt
@@ -1,7 +1,11 @@
 package com.radixdlt.sargon
 
 import com.radixdlt.sargon.extensions.EntityFlags
+import com.radixdlt.sargon.extensions.asIdentifiable
 import com.radixdlt.sargon.samples.sample
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
 
 internal class EntityFlagsTest: IdentifiedArrayTest<EntityFlags, EntityFlag, EntityFlag>() {
     override fun element(): EntityFlag =  EntityFlag.sample()
@@ -12,4 +16,45 @@ internal class EntityFlagsTest: IdentifiedArrayTest<EntityFlags, EntityFlag, Ent
 
     override fun init(element: EntityFlag): EntityFlags = EntityFlags(element)
 
+    @Test
+    fun testAsIdentifiable() {
+        assertEquals(
+            EntityFlags(
+                element(),
+                elementWithDifferentId()
+            ),
+            listOf(
+                element(),
+                elementWithDifferentId()
+            ).asIdentifiable()
+        )
+    }
+
+    @Test
+    fun testEquality() {
+        val element = element()
+
+        assertEquals(
+            listOf(element).asIdentifiable(),
+            listOf(element).asIdentifiable()
+        )
+
+        val collection = listOf(element).asIdentifiable()
+        assertEquals(collection, collection)
+        assertNotEquals(collection, "")
+    }
+
+    @Test
+    fun testUniqueness() {
+        val element = element()
+        val elementOther = elementWithDifferentId()
+        assertEquals(
+            2,
+            setOf(
+                listOf(element).asIdentifiable(),
+                listOf(elementOther).asIdentifiable(),
+                listOf(element).asIdentifiable()
+            ).size
+        )
+    }
 }

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/FactorSourcesTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/FactorSourcesTest.kt
@@ -3,11 +3,13 @@ package com.radixdlt.sargon
 import com.radixdlt.sargon.extensions.FactorSources
 import com.radixdlt.sargon.extensions.SupportedCurves
 import com.radixdlt.sargon.extensions.asGeneral
+import com.radixdlt.sargon.extensions.asIdentifiable
 import com.radixdlt.sargon.extensions.id
 import com.radixdlt.sargon.extensions.init
 import com.radixdlt.sargon.extensions.randomBagOfBytes
 import com.radixdlt.sargon.samples.sample
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Test
 
 internal class FactorSourcesTest : IdentifiedArrayTest<FactorSources, FactorSourceId, FactorSource>() {
@@ -19,6 +21,48 @@ internal class FactorSourcesTest : IdentifiedArrayTest<FactorSources, FactorSour
     override fun identifier(element: FactorSource): FactorSourceId = element.id
 
     override fun init(element: FactorSource): FactorSources = FactorSources(element)
+
+    @Test
+    fun testAsIdentifiable() {
+        assertEquals(
+            FactorSources(
+                element(),
+                elementWithDifferentId()
+            ),
+            listOf(
+                element(),
+                elementWithDifferentId()
+            ).asIdentifiable()
+        )
+    }
+
+    @Test
+    fun testEquality() {
+        val element = element()
+
+        assertEquals(
+            listOf(element).asIdentifiable(),
+            listOf(element).asIdentifiable()
+        )
+
+        val collection = listOf(element).asIdentifiable()
+        assertEquals(collection, collection)
+        assertNotEquals(collection, "")
+    }
+
+    @Test
+    fun testUniqueness() {
+        val element = element()
+        val elementOther = elementWithDifferentId()
+        assertEquals(
+            2,
+            setOf(
+                listOf(element).asIdentifiable(),
+                listOf(elementOther).asIdentifiable(),
+                listOf(element).asIdentifiable()
+            ).size
+        )
+    }
 
     @Test
     fun testDeviceFactorSourceAsGeneral() {

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/GatewaysTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/GatewaysTest.kt
@@ -1,10 +1,12 @@
 package com.radixdlt.sargon
 
 import com.radixdlt.sargon.extensions.Gateways
+import com.radixdlt.sargon.extensions.asIdentifiable
 import com.radixdlt.sargon.samples.sampleMainnet
 import com.radixdlt.sargon.samples.sampleStokenet
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Test
 
 internal class GatewaysTest: IdentifiedArrayTest<Gateways, Url, Gateway>() {
@@ -15,6 +17,48 @@ internal class GatewaysTest: IdentifiedArrayTest<Gateways, Url, Gateway>() {
     override fun identifier(element: Gateway): Url = element.url
 
     override fun init(element: Gateway): Gateways = Gateways(element)
+
+    @Test
+    fun testAsIdentifiable() {
+        assertEquals(
+            Gateways(
+                element(),
+                elementWithDifferentId()
+            ),
+            listOf(
+                element(),
+                elementWithDifferentId()
+            ).asIdentifiable()
+        )
+    }
+
+    @Test
+    fun testEquality() {
+        val element = element()
+
+        assertEquals(
+            listOf(element).asIdentifiable(),
+            listOf(element).asIdentifiable()
+        )
+
+        val collection = listOf(element).asIdentifiable()
+        assertEquals(collection, collection)
+        assertNotEquals(collection, "")
+    }
+
+    @Test
+    fun testUniqueness() {
+        val element = element()
+        val elementOther = elementWithDifferentId()
+        assertEquals(
+            2,
+            setOf(
+                listOf(element).asIdentifiable(),
+                listOf(elementOther).asIdentifiable(),
+                listOf(element).asIdentifiable()
+            ).size
+        )
+    }
 
     @Test
     fun similarUrlsTest() {

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/IdentifiedArrayTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/IdentifiedArrayTest.kt
@@ -2,6 +2,7 @@ package com.radixdlt.sargon
 
 import com.radixdlt.sargon.extensions.IdentifiedArray
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
@@ -27,14 +28,19 @@ internal abstract class IdentifiedArrayTest<A, Identifier, Element> where A : Id
 
         collection = collection.append(elementWithDifferentId)
         assertEquals(2, collection.size)
+        collection = collection.append(elementWithDifferentId) // Append again does nothing
+        assertEquals(2, collection.size)
         assertEquals(elementWithDifferentId, collection[1])
+        assertTrue(elementWithDifferentId in collection)
 
         collection = collection.remove(elementWithDifferentId)
         assertEquals(1, collection.size)
+        assertFalse(elementWithDifferentId in collection)
 
         collection = collection.updateOrInsert(elementWithDifferentId, 1)
         assertEquals(elementWithDifferentId, collection[1])
         assertTrue(collection.size == 2)
+        assertTrue(elementWithDifferentId in collection)
 
         collection = collection.updateOrInsert(elementWithDifferentId, 0)
         assertEquals(elementWithDifferentId, collection[1]) // The item remains in previous position

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/P2PLinksTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/P2PLinksTest.kt
@@ -1,10 +1,14 @@
 package com.radixdlt.sargon
 
 import com.radixdlt.sargon.extensions.P2pLinks
+import com.radixdlt.sargon.extensions.asIdentifiable
 import com.radixdlt.sargon.extensions.id
 import com.radixdlt.sargon.samples.sample
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
 
-internal class P2PLinksTest: IdentifiedArrayTest<P2pLinks, Hash, P2pLink>() {
+internal class P2PLinksTest : IdentifiedArrayTest<P2pLinks, Hash, P2pLink>() {
     override fun element(): P2pLink = P2pLink.sample()
 
     override fun elementWithDifferentId(): P2pLink = P2pLink.sample.other()
@@ -12,4 +16,48 @@ internal class P2PLinksTest: IdentifiedArrayTest<P2pLinks, Hash, P2pLink>() {
     override fun identifier(element: P2pLink): Hash = element.id
 
     override fun init(element: P2pLink): P2pLinks = P2pLinks(element)
+
+    @Test
+    fun testAsIdentifiable() {
+        val element = element()
+        val elementOther = elementWithDifferentId()
+        assertEquals(
+            P2pLinks(
+                element,
+                elementOther
+            ),
+            listOf(
+                element,
+                elementOther
+            ).asIdentifiable()
+        )
+    }
+
+    @Test
+    fun testEquality() {
+        val element = element()
+
+        assertEquals(
+            listOf(element).asIdentifiable(),
+            listOf(element).asIdentifiable()
+        )
+
+        val collection = listOf(element).asIdentifiable()
+        assertEquals(collection, collection)
+        assertNotEquals(collection, "")
+    }
+
+    @Test
+    fun testUniqueness() {
+        val element = element()
+        val elementOther = elementWithDifferentId()
+        assertEquals(
+            2,
+            setOf(
+                listOf(element).asIdentifiable(),
+                listOf(elementOther).asIdentifiable(),
+                listOf(element).asIdentifiable()
+            ).size
+        )
+    }
 }

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/PersonasTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/PersonasTest.kt
@@ -1,7 +1,11 @@
 package com.radixdlt.sargon
 
 import com.radixdlt.sargon.extensions.Personas
+import com.radixdlt.sargon.extensions.asIdentifiable
 import com.radixdlt.sargon.samples.sampleMainnet
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
 
 internal class PersonasTest: IdentifiedArrayTest<Personas, IdentityAddress, Persona>() {
     override fun element(): Persona = Persona.sampleMainnet()
@@ -12,4 +16,45 @@ internal class PersonasTest: IdentifiedArrayTest<Personas, IdentityAddress, Pers
 
     override fun init(element: Persona): Personas = Personas(element)
 
+    @Test
+    fun testAsIdentifiable() {
+        assertEquals(
+            Personas(
+                element(),
+                elementWithDifferentId()
+            ),
+            listOf(
+                element(),
+                elementWithDifferentId()
+            ).asIdentifiable()
+        )
+    }
+
+    @Test
+    fun testEquality() {
+        val element = element()
+
+        assertEquals(
+            listOf(element).asIdentifiable(),
+            listOf(element).asIdentifiable()
+        )
+
+        val collection = listOf(element).asIdentifiable()
+        assertEquals(collection, collection)
+        assertNotEquals(collection, "")
+    }
+
+    @Test
+    fun testUniqueness() {
+        val element = element()
+        val elementOther = elementWithDifferentId()
+        assertEquals(
+            2,
+            setOf(
+                listOf(element).asIdentifiable(),
+                listOf(elementOther).asIdentifiable(),
+                listOf(element).asIdentifiable()
+            ).size
+        )
+    }
 }

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/ProfileNetworksTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/ProfileNetworksTest.kt
@@ -1,8 +1,12 @@
 package com.radixdlt.sargon
 
 import com.radixdlt.sargon.extensions.ProfileNetworks
+import com.radixdlt.sargon.extensions.asIdentifiable
 import com.radixdlt.sargon.samples.sampleMainnet
 import com.radixdlt.sargon.samples.sampleStokenet
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
 
 internal class ProfileNetworksTest: IdentifiedArrayTest<ProfileNetworks, NetworkId, ProfileNetwork>()  {
     override fun element(): ProfileNetwork = ProfileNetwork.sampleMainnet()
@@ -12,4 +16,46 @@ internal class ProfileNetworksTest: IdentifiedArrayTest<ProfileNetworks, Network
     override fun identifier(element: ProfileNetwork): NetworkId = element.id
 
     override fun init(element: ProfileNetwork): ProfileNetworks = ProfileNetworks(element)
+
+    @Test
+    fun testAsIdentifiable() {
+        assertEquals(
+            ProfileNetworks(
+                element(),
+                elementWithDifferentId()
+            ),
+            listOf(
+                element(),
+                elementWithDifferentId()
+            ).asIdentifiable()
+        )
+    }
+
+    @Test
+    fun testEquality() {
+        val element = element()
+
+        assertEquals(
+            listOf(element).asIdentifiable(),
+            listOf(element).asIdentifiable()
+        )
+
+        val collection = listOf(element).asIdentifiable()
+        assertEquals(collection, collection)
+        assertNotEquals(collection, "")
+    }
+
+    @Test
+    fun testUniqueness() {
+        val element = element()
+        val elementOther = elementWithDifferentId()
+        assertEquals(
+            2,
+            setOf(
+                listOf(element).asIdentifiable(),
+                listOf(elementOther).asIdentifiable(),
+                listOf(element).asIdentifiable()
+            ).size
+        )
+    }
 }

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/ReferencesToAuthorizedPersonasTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/ReferencesToAuthorizedPersonasTest.kt
@@ -1,7 +1,11 @@
 package com.radixdlt.sargon
 
 import com.radixdlt.sargon.extensions.ReferencesToAuthorizedPersonas
+import com.radixdlt.sargon.extensions.asIdentifiable
 import com.radixdlt.sargon.samples.sampleMainnet
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
 
 internal class ReferencesToAuthorizedPersonasTest :
     IdentifiedArrayTest<ReferencesToAuthorizedPersonas, IdentityAddress, AuthorizedPersonaSimple>() {
@@ -15,4 +19,45 @@ internal class ReferencesToAuthorizedPersonasTest :
     override fun init(element: AuthorizedPersonaSimple): ReferencesToAuthorizedPersonas =
         ReferencesToAuthorizedPersonas(element)
 
+    @Test
+    fun testAsIdentifiable() {
+        assertEquals(
+            ReferencesToAuthorizedPersonas(
+                element(),
+                elementWithDifferentId()
+            ),
+            listOf(
+                element(),
+                elementWithDifferentId()
+            ).asIdentifiable()
+        )
+    }
+
+    @Test
+    fun testEquality() {
+        val element = element()
+
+        assertEquals(
+            listOf(element).asIdentifiable(),
+            listOf(element).asIdentifiable()
+        )
+
+        val collection = listOf(element).asIdentifiable()
+        assertEquals(collection, collection)
+        assertNotEquals(collection, "")
+    }
+
+    @Test
+    fun testUniqueness() {
+        val element = element()
+        val elementOther = elementWithDifferentId()
+        assertEquals(
+            2,
+            setOf(
+                listOf(element).asIdentifiable(),
+                listOf(elementOther).asIdentifiable(),
+                listOf(element).asIdentifiable()
+            ).size
+        )
+    }
 }

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/SupportedCurvesTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/SupportedCurvesTest.kt
@@ -1,7 +1,11 @@
 package com.radixdlt.sargon
 
 import com.radixdlt.sargon.extensions.SupportedCurves
+import com.radixdlt.sargon.extensions.asIdentifiable
 import com.radixdlt.sargon.samples.sample
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
 
 internal class SupportedCurvesTest: IdentifiedArrayTest<SupportedCurves, Slip10Curve, Slip10Curve>() {
 
@@ -12,4 +16,46 @@ internal class SupportedCurvesTest: IdentifiedArrayTest<SupportedCurves, Slip10C
     override fun identifier(element: Slip10Curve): Slip10Curve = element
 
     override fun init(element: Slip10Curve): SupportedCurves = SupportedCurves(element)
+
+    @Test
+    fun testAsIdentifiable() {
+        assertEquals(
+            SupportedCurves(
+                element(),
+                elementWithDifferentId()
+            ),
+            listOf(
+                element(),
+                elementWithDifferentId()
+            ).asIdentifiable()
+        )
+    }
+
+    @Test
+    fun testEquality() {
+        val element = element()
+
+        assertEquals(
+            listOf(element).asIdentifiable(),
+            listOf(element).asIdentifiable()
+        )
+
+        val collection = listOf(element).asIdentifiable()
+        assertEquals(collection, collection)
+        assertNotEquals(collection, "")
+    }
+
+    @Test
+    fun testUniqueness() {
+        val element = element()
+        val elementOther = elementWithDifferentId()
+        assertEquals(
+            2,
+            setOf(
+                listOf(element).asIdentifiable(),
+                listOf(elementOther).asIdentifiable(),
+                listOf(element).asIdentifiable()
+            ).size
+        )
+    }
 }


### PR DESCRIPTION
* `equals`, `hashCode` and `toString` need to be exposed in interface so the actual class can use those methods when delegating to `array` instead of the default implementations on `Any`
* Individual tests for each collection
* Added `operator fun contains` so we can use `in` operator in project
* Inner `array` should become property so equality could work with delegation. Not sure if it was possible without making `array` property of the class.
* There is a false positive in code coverage regarding `javaClass` check, so I had to ignore the whole method, even though it is tested.