### PR TITLE
Use cargo.toml for determining version name

### DIFF
--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -50,10 +50,8 @@ jobs:
       - name: Install cargo-ndk
         run: cargo install cargo-ndk
 
-      - name: Setup Env Variables
-        run: |
-          git fetch --prune --tags
-          echo "SARGON_VERSION=`git tag --sort=committerdate | tail -1`-`git rev-parse --short @`" >> $GITHUB_ENV
+      - name: Prune Tags
+        run: git fetch --prune --tags
 
       - name: Build and publish Android
         uses: RDXWorks-actions/gradle-build-action@main

--- a/.github/workflows/release-desktop-bins.yml
+++ b/.github/workflows/release-desktop-bins.yml
@@ -37,10 +37,8 @@ jobs:
           distribution: "adopt"
           java-version: "17"
 
-      - name: Setup Env Variables
-        run: |
-          git fetch --prune --tags
-          echo "SARGON_VERSION=`git tag --sort=committerdate | tail -1`-`git rev-parse --short @`" >> $GITHUB_ENV
+      - name: Prune Tags
+        run: git fetch --prune --tags
 
       - name: Build and publish Desktop binaries
         uses: RDXWorks-actions/gradle-build-action@main

--- a/jvm/buildSrc/build.gradle.kts
+++ b/jvm/buildSrc/build.gradle.kts
@@ -11,6 +11,10 @@ repositories {
     mavenCentral()
 }
 
+dependencies {
+    implementation("org.tomlj:tomlj:1.1.1")
+}
+
 plugins {
     `kotlin-dsl`
 }

--- a/jvm/buildSrc/src/main/java/com/radixdlt/cargo/toml/SargonVersion.kt
+++ b/jvm/buildSrc/src/main/java/com/radixdlt/cargo/toml/SargonVersion.kt
@@ -1,0 +1,24 @@
+package com.radixdlt.cargo.toml
+
+import org.gradle.api.Project
+import org.tomlj.Toml
+import java.io.ByteArrayOutputStream
+import java.io.File
+
+private fun Project.parseTomlVersion(): String {
+    val tomlFile = File(projectDir.parentFile.parentFile, "Cargo.toml").toPath()
+
+    val toml = Toml.parse(tomlFile)
+    return toml.getString("package.version").orEmpty()
+}
+
+private fun Project.parseGitHash(): String {
+    val out = ByteArrayOutputStream()
+    exec {
+        commandLine("git", "rev-parse", "--short", "@")
+        standardOutput = out
+    }.assertNormalExitValue()
+    return String(out.toByteArray(), Charsets.UTF_8).trim()
+}
+
+fun Project.sargonVersion(): String = "${parseTomlVersion()}-${parseGitHash()}"

--- a/jvm/sargon-android/build.gradle.kts
+++ b/jvm/sargon-android/build.gradle.kts
@@ -1,6 +1,6 @@
+import com.radixdlt.cargo.toml.sargonVersion
 import org.gradle.configurationcache.extensions.capitalized
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import java.io.ByteArrayOutputStream
 
 plugins {
     alias(libs.plugins.android.library)
@@ -108,36 +108,10 @@ dependencies {
 
 publishing {
     publications {
-        fun command(command: String): String {
-            val out = ByteArrayOutputStream()
-            exec {
-                commandLine(command.split(" "))
-                standardOutput = out
-            }.assertNormalExitValue()
-            return String(out.toByteArray(), Charsets.UTF_8).trim()
-        }
-
         register<MavenPublication>("release") {
             groupId = "com.radixdlt.sargon"
             artifactId = "sargon-android"
-
-            val toml = File(projectDir.parentFile.parentFile, "Cargo.toml").readText()
-            val matchResult: MatchResult? = "version\\s*=\\s*\"(.+)\"".toRegex().find(toml)
-            version = matchResult?.let {
-                val (version) = matchResult.destructured
-
-                version
-            } ?: run {
-                command("git tag --sort=committerdate").split("\n").last()
-            }.let { version ->
-                val commitHash = command("git rev-parse --short @")
-
-                if (commitHash.isNotBlank()) {
-                    "$version-$commitHash"
-                } else {
-                    version
-                }
-            }
+            version = project.sargonVersion()
 
             afterEvaluate {
                 from(components["release"])

--- a/jvm/sargon-android/build.gradle.kts
+++ b/jvm/sargon-android/build.gradle.kts
@@ -209,45 +209,17 @@ android.libraryVariants.all {
 
 tasks.register("cargoClean") {
     group = BasePlugin.BUILD_GROUP
-
-    fun command(command: String): String {
-        val out = ByteArrayOutputStream()
-        exec {
-            commandLine(command.split(" "))
-            standardOutput = out
-        }.assertNormalExitValue()
-        return String(out.toByteArray(), Charsets.UTF_8).trim()
-    }
-
     doLast {
-        val toml = File(projectDir.parentFile.parentFile, "Cargo.toml").readText()
-        val matchResult: MatchResult? = "version\\s*=\\s*\"(.+)\"".toRegex().find(toml)
-        val mavenVersion = if (matchResult != null) {
-            val (version) = matchResult.destructured
-
-            version
-        } else {
-            command("git tag --sort=committerdate").split("\n").last()
-        }.let { version ->
-            val commitHash = command("git rev-parse --short @")
-
-            if (commitHash.isNotBlank()) {
-                "$version-$commitHash"
-            } else {
-                version
-            }
+        exec {
+            workingDir = rootDir.parentFile
+            println("Cleaning for aarch64-linux-android")
+            commandLine("cargo", "clean", "--target", "aarch64-linux-android")
         }
-        println("=============> $mavenVersion")
-//        exec {
-//            workingDir = rootDir.parentFile
-//            println("Cleaning for aarch64-linux-android")
-//            commandLine("cargo", "clean", "--target", "aarch64-linux-android")
-//        }
-//        exec {
-//            workingDir = rootDir.parentFile
-//            println("Cleaning for armv7-linux-androideabi")
-//            commandLine("cargo", "clean", "--target", "armv7-linux-androideabi")
-//        }
+        exec {
+            workingDir = rootDir.parentFile
+            println("Cleaning for armv7-linux-androideabi")
+            commandLine("cargo", "clean", "--target", "armv7-linux-androideabi")
+        }
     }
 }
 

--- a/jvm/sargon-desktop-release/build.gradle.kts
+++ b/jvm/sargon-desktop-release/build.gradle.kts
@@ -1,5 +1,5 @@
 import com.radixdlt.cargo.desktop.BuildType
-import java.io.ByteArrayOutputStream
+import com.radixdlt.cargo.toml.sargonVersion
 
 plugins {
     id("java-library")
@@ -24,37 +24,10 @@ dependencies {
 
 publishing {
     publications {
-
-        fun command(command: String): String {
-            val out = ByteArrayOutputStream()
-            exec {
-                commandLine(command.split(" "))
-                standardOutput = out
-            }.assertNormalExitValue()
-            return String(out.toByteArray(), Charsets.UTF_8).trim()
-        }
-
         register<MavenPublication>("release") {
             groupId = "com.radixdlt.sargon"
             artifactId = "sargon-desktop-bins"
-
-            val toml = File(projectDir.parentFile.parentFile, "Cargo.toml").readText()
-            val matchResult: MatchResult? = "version\\s*=\\s*\"(.+)\"".toRegex().find(toml)
-            version = matchResult?.let {
-                val (version) = matchResult.destructured
-
-                version
-            } ?: run {
-                command("git tag --sort=committerdate").split("\n").last()
-            }.let { version ->
-                val commitHash = command("git rev-parse --short @")
-
-                if (commitHash.isNotBlank()) {
-                    "$version-$commitHash"
-                } else {
-                    version
-                }
-            }
+            version = project.sargonVersion()
 
             from(components["java"])
         }


### PR DESCRIPTION
* Android and desktop-bins now use the `cargo.toml` version to decide on the version name in maven
* Falls back to latest git tag
* All can be calculated from inside gradle. No need to export env variables.