### PR TITLE
Decimal192 string parsing and representing in text fields

### DIFF
--- a/jvm/gradle/libs.versions.toml
+++ b/jvm/gradle/libs.versions.toml
@@ -27,6 +27,7 @@ androidx-compose-ui-preview = { module = "androidx.compose.ui:ui-tooling-preview
 androidx-compose-material3 = { module = "androidx.compose.material3:material3" }
 material = { module = "com.google.android.material:material", version.ref = "material" }
 junit = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
+junit-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 
 [plugins]

--- a/jvm/sargon-android/build.gradle.kts
+++ b/jvm/sargon-android/build.gradle.kts
@@ -100,6 +100,7 @@ dependencies {
     implementation("com.squareup.okhttp3:okhttp-coroutines")
 
     testImplementation(libs.junit)
+    testImplementation(libs.junit.params)
     testImplementation(libs.mockk)
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testDebugRuntimeOnly(project(":sargon-desktop-debug"))

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/Decimal192.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/Decimal192.kt
@@ -92,18 +92,29 @@ val Decimal192.Companion.MAX_DIVISIBILITY: UByte
 fun Decimal192.Companion.parseFromTextField(
     textFieldString: String,
     decimalFormat: DecimalFormatSymbols = DecimalFormatSymbols.getInstance()
-): Decimal192 {
-    val config = LocaleConfig(
-        decimalSeparator = decimalFormat.decimalSeparator.toString(),
-        groupingSeparator = null // We do not allow grouping separator characters in input
-    )
-
-    val charactersToReplace = "[^0-9\\\\${config.decimalSeparator}]".toRegex()
+): TextInputDecimal {
+    val charactersToReplace = "[^0-9\\\\${decimalFormat.decimalSeparator}]".toRegex()
     val sanitizedString = textFieldString.replace(charactersToReplace, "")
 
-    return Decimal192.init(
-        formattedString = sanitizedString,
-        config = config
+    return TextInputDecimal(
+        input = sanitizedString,
+        decimalSeparator = decimalFormat.decimalSeparator
+    )
+}
+
+/**
+ * A pair of an input represented with a decimal
+ */
+class TextInputDecimal(
+    val input: String,
+    decimalSeparator: Char
+) {
+    val decimal: Decimal192 = Decimal192.init(
+        formattedString = input,
+        config = LocaleConfig(
+            decimalSeparator = decimalSeparator.toString(),
+            groupingSeparator = null // We do not allow grouping separator characters in input
+        )
     )
 }
 

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/Decimal192.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/Decimal192.kt
@@ -98,7 +98,7 @@ fun Decimal192.Companion.parseFromTextField(
         groupingSeparator = null // We do not allow grouping separator characters in input
     )
 
-    val charactersToReplace = "[^0-9${config.decimalSeparator}]".toRegex()
+    val charactersToReplace = "[^0-9\\\\${config.decimalSeparator}]".toRegex()
     val sanitizedString = textFieldString.replace(charactersToReplace, "")
 
     return Decimal192.init(

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/Decimal192Test.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/Decimal192Test.kt
@@ -220,7 +220,8 @@ class Decimal192Test : SampleTestable<Decimal192> {
             input: String,
             decimal: Char,
             grouping: Char,
-            output: String
+            formattedTextField: String,
+            sanitizedInput: String
         ) {
             val decimalFormatSymbols = mockk<DecimalFormatSymbols>(relaxed = true).apply {
                 every { decimalSeparator } returns decimal
@@ -232,9 +233,11 @@ class Decimal192Test : SampleTestable<Decimal192> {
                 decimalFormat = decimalFormatSymbols
             )
 
-            assertEquals(output, result.formattedTextField(
+            assertEquals(formattedTextField, result.decimal.formattedTextField(
                 format = decimalFormatSymbols
             ))
+
+            assertEquals(sanitizedInput, result.input)
         }
 
     }
@@ -242,28 +245,28 @@ class Decimal192Test : SampleTestable<Decimal192> {
     companion object {
         @JvmStatic
         fun input() = listOf(
-            // of(input, "<decimal>", "<grouping>, "output")
-            of("1234.9", ',', ' ', "12349"), // Wrong decimal separator is ignored
-            of("1 234,9", ',', ' ', "1234,9"), // Grouping separator is ignored
-            of("1234,9", ',', ' ', "1234,9"), // Correct format returns the same result
-            of("1234,999999999", ',', ' ', "1234,999999999"), // Correct format with many digits
-            of(",9", ',', ' ', "0,9"), // Without 0 at the beginning, adds zero in output
+            // of(input, "<decimal>", "<grouping>, "formattedTextField", "sanitizedInput")
+            of("1234.9", ',', ' ', "12349", "12349"), // Wrong decimal separator is ignored
+            of("1 234,9", ',', ' ', "1234,9", "1234,9"), // Grouping separator is ignored
+            of("1234,9", ',', ' ', "1234,9", "1234,9"), // Correct format returns the same result
+            of("1234,999999999", ',', ' ', "1234,999999999", "1234,999999999"), // Correct format with many digits
+            of(",9", ',', ' ', "0,9", ",9"), // Without 0 at the beginning, adds zero in output
 
             // Same with dot as separator
-            of("1234,9", '.', ',', "12349"),
-            of("1 234.9", '.', ',', "1234.9"),
-            of("1234.9", '.', ',', "1234.9"),
-            of("1234.999999999", '.', ',', "1234.999999999"),
-            of(".9", '.', ',', "0.9"),
+            of("1234,9", '.', ',', "12349", "12349"),
+            of("1 234.9", '.', ',', "1234.9", "1234.9"),
+            of("1234.9", '.', ',', "1234.9", "1234.9"),
+            of("1234.999999999", '.', ',', "1234.999999999", "1234.999999999"),
+            of(".9", '.', ',', "0.9", ".9"),
 
-            of("0-9", '-', ' ', "0-9"), // Decimal separator that needs to be escaped in regex
-            of("0^9", '^', ' ', "0^9"), // Decimal separator that needs to be escaped in regex
+            of("0-9", '-', ' ', "0-9", "0-9"), // Decimal separator that needs to be escaped in regex
+            of("0^9", '^', ' ', "0^9", "0^9"), // Decimal separator that needs to be escaped in regex
 
-            of(" ", ',', ' ', "0"), // Blank resolves to 0
-            of(" ", ' ', ',', "0"), // Blank with space as decimal separator resolves to 0
+            of(" ", ',', ' ', "0", ""), // Blank resolves to 0 prints empty
+            of(" ", ' ', ',', "0", " "), // Blank with space as decimal separator resolves to 0 prints space
 
-            of("1,000,000.10", '.', ',', "1000000.1"),
-            of("1.000.000,10", ',', '.', "1000000,1")
+            of("1,000,000.10", '.', ',', "1000000.1", "1000000.10"), // Large number resolves to decimal without trailing zero, prints the same number with 0
+            of("1.000.000,10", ',', '.', "1000000,1", "1000000,10")
         )
     }
 }

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/Decimal192Test.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/Decimal192Test.kt
@@ -11,11 +11,12 @@ import com.radixdlt.sargon.extensions.exponent
 import com.radixdlt.sargon.extensions.floor
 import com.radixdlt.sargon.extensions.formatted
 import com.radixdlt.sargon.extensions.formattedPlain
-import com.radixdlt.sargon.extensions.init
+import com.radixdlt.sargon.extensions.formattedTextField
 import com.radixdlt.sargon.extensions.isNegative
 import com.radixdlt.sargon.extensions.isPositive
 import com.radixdlt.sargon.extensions.negative
 import com.radixdlt.sargon.extensions.orZero
+import com.radixdlt.sargon.extensions.parseFromTextField
 import com.radixdlt.sargon.extensions.plus
 import com.radixdlt.sargon.extensions.rounded
 import com.radixdlt.sargon.extensions.string
@@ -32,13 +33,14 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
-import java.text.DecimalFormat
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments.of
+import org.junit.jupiter.params.provider.MethodSource
 import java.text.DecimalFormatSymbols
 import java.util.Locale
-import kotlin.math.PI
 
 class Decimal192Test : SampleTestable<Decimal192> {
 
@@ -151,32 +153,6 @@ class Decimal192Test : SampleTestable<Decimal192> {
     }
 
     @Test
-    fun testStringParsing() {
-        val usFormat = DecimalFormat().apply {
-            decimalFormatSymbols = DecimalFormatSymbols(Locale.US)
-        }
-        val greekFormat = DecimalFormat().apply {
-            decimalFormatSymbols = DecimalFormatSymbols(Locale.forLanguageTag("el"))
-        }
-
-        assertEquals(
-            Decimal192.init(usFormat.format(PI), DecimalFormatSymbols(Locale.US)),
-            Decimal192.init(
-                greekFormat.format(PI),
-                DecimalFormatSymbols(Locale.forLanguageTag("el"))
-            )
-        )
-
-        assertThrows<CommonException.DecimalException> {
-            greekFormat.format(PI).toDecimal192()
-        }
-
-        assertDoesNotThrow {
-            Decimal192.init(DecimalFormat().format(PI))
-        }
-    }
-
-    @Test
     fun testFromDouble() {
         assertEquals("0.1", 0.1.toDecimal192().string)
         assertEquals("4.012345678901235", 4.012345678901234567895555555.toDecimal192().string)
@@ -234,4 +210,54 @@ class Decimal192Test : SampleTestable<Decimal192> {
         format = DecimalFormatSymbols.getInstance(Locale.US),
         useGroupingSeparator = false
     )
+
+    @Nested
+    inner class UserInputTest {
+
+        @ParameterizedTest
+        @MethodSource("com.radixdlt.sargon.Decimal192Test#input")
+        fun test(
+            input: String,
+            decimal: Char,
+            grouping: Char,
+            output: String
+        ) {
+            val decimalFormatSymbols = mockk<DecimalFormatSymbols>(relaxed = true).apply {
+                every { decimalSeparator } returns decimal
+                every { groupingSeparator } returns grouping
+            }
+
+            val result = Decimal192.parseFromTextField(
+                textFieldString = input,
+                decimalFormat = decimalFormatSymbols
+            )
+
+            assertEquals(output, result.formattedTextField(
+                format = decimalFormatSymbols
+            ))
+        }
+
+    }
+
+    companion object {
+        @JvmStatic
+        fun input() = listOf(
+            // of(input, "<decimal>", "<grouping>, "output")
+            of("1234.9", ',', ' ', "12349"), // Wrong decimal separator is ignored
+            of("1 234,9", ',', ' ', "1234,9"), // Grouping separator is ignored
+            of("1234,9", ',', ' ', "1234,9"), // Correct format returns the same result
+            of("1234,999999999", ',', ' ', "1234,999999999"), // Correct format with many digits
+            of(",9", ',', ' ', "0,9"), // Without 0 at the beginning, adds zero in output
+
+            // Same with dot as separator
+            of("1234,9", '.', ',', "12349"),
+            of("1 234.9", '.', ',', "1234.9"),
+            of("1234.9", '.', ',', "1234.9"),
+            of("1234.999999999", '.', ',', "1234.999999999"),
+            of(".9", '.', ',', "0.9"),
+
+            of(" ", ',', ' ', "0"), // Blank resolves to 0
+            of(" ", ' ', ',', "0"), // Blank with space as decimal separator resolves to 0
+        )
+    }
 }

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/Decimal192Test.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/Decimal192Test.kt
@@ -261,6 +261,9 @@ class Decimal192Test : SampleTestable<Decimal192> {
 
             of(" ", ',', ' ', "0"), // Blank resolves to 0
             of(" ", ' ', ',', "0"), // Blank with space as decimal separator resolves to 0
+
+            of("1,000,000.10", '.', ',', "1000000.1"),
+            of("1.000.000,10", ',', '.', "1000000,1")
         )
     }
 }

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/Decimal192Test.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/Decimal192Test.kt
@@ -256,6 +256,9 @@ class Decimal192Test : SampleTestable<Decimal192> {
             of("1234.999999999", '.', ',', "1234.999999999"),
             of(".9", '.', ',', "0.9"),
 
+            of("0-9", '-', ' ', "0-9"), // Decimal separator that needs to be escaped in regex
+            of("0^9", '^', ' ', "0^9"), // Decimal separator that needs to be escaped in regex
+
             of(" ", ',', ' ', "0"), // Blank resolves to 0
             of(" ", ' ', ',', "0"), // Blank with space as decimal separator resolves to 0
         )


### PR DESCRIPTION
* Android keyboards may allow more characters than decimals to be typed regardless the current locale
* We need to act upon the text input and edit the string accordingly.
* Only digits and decimal separator is allowed.
* Any text is stripped from non-allowed characters with a regex and passes the result to sargon along with the locale's decimal separator.
* The same applies when the converted decimal192 is converted back to string for text inputs. Again only digits and decimal separator are allowed.
* Space is represented as 0. (In case user pastes `" "`)