### PR TITLE
Add 'regenerate' argument to build and test gradle tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2586,7 +2586,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.0.8"
+version = "1.0.9"
 dependencies = [
  "actix-rt",
  "aes-gcm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2586,7 +2586,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "actix-rt",
  "aes-gcm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2586,7 +2586,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "actix-rt",
  "aes-gcm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2586,7 +2586,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.0.4"
+version = "1.0.6"
 dependencies = [
  "actix-rt",
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "1.0.6"
+version = "1.0.7"
 edition = "2021"
 build = "build.rs"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "1.0.7"
+version = "1.0.8"
 edition = "2021"
 build = "build.rs"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "1.0.8"
+version = "1.0.9"
 edition = "2021"
 build = "build.rs"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "1.0.4"
+version = "1.0.6"
 edition = "2021"
 build = "build.rs"
 

--- a/apple/Tests/TestCases/Prelude/DateTests.swift
+++ b/apple/Tests/TestCases/Prelude/DateTests.swift
@@ -1,0 +1,74 @@
+import CustomDump
+import Foundation
+import Sargon
+import SargonUniFFI
+import XCTest
+
+final class DateTests: TestCase {
+    
+    func test_date() {
+        
+        /// This matches `[bindings.swift.custom_types.Timestamp]`
+        /// inside `uniffi.toml` with the only difference that we use `$0` here but
+        /// the toml uses `{}`;
+        let into_custom: (String) -> Date = {
+            let stringToDeserialize = $0
+            let formatter = ISO8601DateFormatter()
+            let formatOptionMS = ISO8601DateFormatter.Options.withFractionalSeconds
+            formatter.formatOptions.insert(formatOptionMS)
+            
+            func format() -> Date? {
+                formatter.date(from: stringToDeserialize)
+            }
+            
+            if let date = format() {
+                return date
+            }
+            
+            // try without fractional seconds
+            formatter.formatOptions.remove(formatOptionMS)
+            return format()!
+        }
+        
+        /// This matches `[bindings.swift.custom_types.Timestamp]`
+        /// inside `uniffi.toml`
+        let from_custom: (Date) -> String = {
+            let dateToSerialize = $0
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions.insert(.withFractionalSeconds)
+            return formatter.string(from: dateToSerialize)
+        }
+        
+        func testIntoThenFrom(_ vector: (String, String?)) {
+            let sut = vector.0
+            let expected = vector.1 ?? sut
+
+            let string = from_custom(into_custom(sut))
+            
+            XCTAssertEqual(string, expected)
+        }
+        
+        func testFromThenInto(_ vector: (String, String?)) {
+            let lhs = vector.0
+            let rhs = vector.1 ?? lhs
+            
+            let lhsString = from_custom(into_custom(lhs))
+            let rhsString = from_custom(into_custom(rhs))
+        
+            XCTAssertEqual(rhsString, rhs)
+            
+            XCTAssertEqual(
+                into_custom(lhsString),
+                into_custom(rhsString)
+            )
+        }
+        
+        let vectors = [
+            ("2023-12-24T17:13:56.123456Z", "2023-12-24T17:13:56.123Z"), // precision lost (which is OK)
+            ("2023-12-24T17:13:56.123Z", nil), // unchanged
+            ("2023-12-24T17:13:56Z", "2023-12-24T17:13:56.000Z") // (000 added, which is OK)
+        ]
+        vectors.forEach(testIntoThenFrom)
+        vectors.forEach(testFromThenInto)
+    }
+}

--- a/apple/Tests/TestCases/Profile/DeviceInfoTests.swift
+++ b/apple/Tests/TestCases/Profile/DeviceInfoTests.swift
@@ -76,21 +76,6 @@ final class DeviceInfoTests: Test<DeviceInfo> {
         }
         """, expected: nil)
 	}
+	
     
-}
-
-extension JSONEncoder {
-    static var iso8601: JSONEncoder {
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
-        return encoder
-    }
-}
-
-extension JSONDecoder {
-    static var iso8601: JSONDecoder {
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
-        return decoder
-    }
 }

--- a/apple/Tests/Utils/Extensions/JSON+ISO8601.swift
+++ b/apple/Tests/Utils/Extensions/JSON+ISO8601.swift
@@ -1,0 +1,24 @@
+//
+//  File.swift
+//  
+//
+//  Created by Alexander Cyon on 2024-05-31.
+//
+
+import Foundation
+
+extension JSONEncoder {
+    static var iso8601: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+}
+
+extension JSONDecoder {
+    static var iso8601: JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+}

--- a/jvm/sargon-android/build.gradle.kts
+++ b/jvm/sargon-android/build.gradle.kts
@@ -157,6 +157,12 @@ android.libraryVariants.all {
         "generate${buildTypeUpper}UniFFIBindings",
         Exec::class
     ) {
+        val rebuild = properties["rebuild"] ?: true
+        
+        onlyIf {
+            rebuild == true || !File("${buildDir}/generated/src/${buildType}/java").exists()
+        }
+
         group = BasePlugin.BUILD_GROUP
 
         workingDir = rootDir.parentFile

--- a/jvm/sargon-android/build.gradle.kts
+++ b/jvm/sargon-android/build.gradle.kts
@@ -157,10 +157,10 @@ android.libraryVariants.all {
         "generate${buildTypeUpper}UniFFIBindings",
         Exec::class
     ) {
-        val rebuild = properties["regenerate"] ?: true
+        val regenerate = properties["regenerate"] ?: true //TODO improve by using gradle outputs
 
         onlyIf {
-            rebuild == true || !File("${buildDir}/generated/src/${buildType}/java").exists()
+            regenerate == true || !File("${buildDir}/generated/src/${buildType}/java").exists()
         }
 
         group = BasePlugin.BUILD_GROUP

--- a/jvm/sargon-android/build.gradle.kts
+++ b/jvm/sargon-android/build.gradle.kts
@@ -157,8 +157,8 @@ android.libraryVariants.all {
         "generate${buildTypeUpper}UniFFIBindings",
         Exec::class
     ) {
-        val rebuild = properties["rebuild"] ?: true
-        
+        val rebuild = properties["regenerate"] ?: true
+
         onlyIf {
             rebuild == true || !File("${buildDir}/generated/src/${buildType}/java").exists()
         }

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/DappToWalletInteractionUnvalidated.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/DappToWalletInteractionUnvalidated.kt
@@ -1,0 +1,13 @@
+package com.radixdlt.sargon.extensions
+
+import com.radixdlt.sargon.DappToWalletInteractionUnvalidated
+import com.radixdlt.sargon.dappToWalletInteractionUnvalidatedToJsonBytes
+import com.radixdlt.sargon.newDappToWalletInteractionUnvalidatedFromJsonBytes
+
+@Throws(SargonException::class)
+fun DappToWalletInteractionUnvalidated.Companion.fromJson(json: String) =
+    newDappToWalletInteractionUnvalidatedFromJsonBytes(json.toByteArray().toBagOfBytes())
+
+fun DappToWalletInteractionUnvalidated.toJson() =
+    dappToWalletInteractionUnvalidatedToJsonBytes(this).string
+

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/WalletToDappInteractionResponse.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/WalletToDappInteractionResponse.kt
@@ -1,0 +1,12 @@
+package com.radixdlt.sargon.extensions
+
+import com.radixdlt.sargon.WalletToDappInteractionResponse
+import com.radixdlt.sargon.newWalletToDappInteractionResponseFromJsonBytes
+import com.radixdlt.sargon.walletToDappInteractionResponseToJsonBytes
+
+@Throws(SargonException::class)
+fun WalletToDappInteractionResponse.Companion.fromJson(json: String) =
+    newWalletToDappInteractionResponseFromJsonBytes(json.toByteArray().toBagOfBytes())
+
+fun WalletToDappInteractionResponse.toJson() =
+    walletToDappInteractionResponseToJsonBytes(this).string

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/BagOfBytesTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/BagOfBytesTest.kt
@@ -3,7 +3,6 @@ package com.radixdlt.sargon
 import com.radixdlt.sargon.extensions.hash
 import com.radixdlt.sargon.extensions.hex
 import com.radixdlt.sargon.extensions.hexToBagOfBytes
-import com.radixdlt.sargon.extensions.init
 import com.radixdlt.sargon.extensions.randomBagOfBytes
 import com.radixdlt.sargon.extensions.toBagOfBytes
 import com.radixdlt.sargon.samples.acedBagOfBytesSample

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/DappToWalletInteractionUnvalidatedTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/DappToWalletInteractionUnvalidatedTest.kt
@@ -1,0 +1,16 @@
+package com.radixdlt.sargon
+
+import com.radixdlt.sargon.extensions.fromJson
+import com.radixdlt.sargon.extensions.toJson
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class DappToWalletInteractionUnvalidatedTest {
+
+    @Test
+    fun testRoundtrip() {
+        val sample = newDappToWalletInteractionUnvalidatedSample()
+        assertEquals(sample, DappToWalletInteractionUnvalidated.Companion.fromJson(sample.toJson()))
+    }
+
+}

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/P2PLinkTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/P2PLinkTest.kt
@@ -2,7 +2,6 @@ package com.radixdlt.sargon
 
 import com.radixdlt.sargon.extensions.clientID
 import com.radixdlt.sargon.extensions.fromJson
-import com.radixdlt.sargon.extensions.hex
 import com.radixdlt.sargon.extensions.init
 import com.radixdlt.sargon.extensions.toJson
 import com.radixdlt.sargon.samples.Sample

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/RadixConnectPurposeTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/RadixConnectPurposeTest.kt
@@ -1,7 +1,6 @@
 package com.radixdlt.sargon
 
 import com.radixdlt.sargon.extensions.init
-import com.radixdlt.sargon.extensions.string
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/WalletToDappInteractionResponseTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/WalletToDappInteractionResponseTest.kt
@@ -1,0 +1,16 @@
+package com.radixdlt.sargon
+
+import com.radixdlt.sargon.extensions.fromJson
+import com.radixdlt.sargon.extensions.toJson
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class WalletToDappInteractionResponseTest {
+
+    @Test
+    fun testRoundtrip() {
+        val sample = newWalletToDappInteractionResponseSample()
+        assertEquals(sample, WalletToDappInteractionResponse.Companion.fromJson(sample.toJson()))
+    }
+
+}

--- a/src/radix_connect/wallet_interaction/dapp_wallet_interaction/dapp_to_wallet/dapp_to_wallet_interaction_uniffi_fn.rs
+++ b/src/radix_connect/wallet_interaction/dapp_wallet_interaction/dapp_to_wallet/dapp_to_wallet_interaction_uniffi_fn.rs
@@ -1,0 +1,26 @@
+use crate::prelude::*;
+
+#[uniffi::export]
+pub(crate) fn new_dapp_to_wallet_interaction_unvalidated_sample(
+) -> DappToWalletInteractionUnvalidated {
+    DappToWalletInteractionUnvalidated::sample()
+}
+
+#[uniffi::export]
+pub(crate) fn new_dapp_to_wallet_interaction_unvalidated_sample_other(
+) -> DappToWalletInteractionUnvalidated {
+    DappToWalletInteractionUnvalidated::sample_other()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inequality_of_samples() {
+        assert_ne!(
+            new_dapp_to_wallet_interaction_unvalidated_sample(),
+            new_dapp_to_wallet_interaction_unvalidated_sample_other()
+        );
+    }
+}

--- a/src/radix_connect/wallet_interaction/dapp_wallet_interaction/dapp_to_wallet/mod.rs
+++ b/src/radix_connect/wallet_interaction/dapp_wallet_interaction/dapp_to_wallet/mod.rs
@@ -1,11 +1,15 @@
 mod dapp_metadata;
+mod dapp_to_wallet_interaction_uniffi_fn;
 mod interaction;
 mod interaction_items;
 mod interaction_uniffi_fn;
 mod interaction_unvalidated;
+mod wallet_to_dapp_interaction_uniffi_fn;
 
 pub use dapp_metadata::*;
+pub use dapp_to_wallet_interaction_uniffi_fn::*;
 pub use interaction::*;
 pub use interaction_items::*;
 pub use interaction_uniffi_fn::*;
 pub use interaction_unvalidated::*;
+pub use wallet_to_dapp_interaction_uniffi_fn::*;

--- a/src/radix_connect/wallet_interaction/dapp_wallet_interaction/dapp_to_wallet/wallet_to_dapp_interaction_uniffi_fn.rs
+++ b/src/radix_connect/wallet_interaction/dapp_wallet_interaction/dapp_to_wallet/wallet_to_dapp_interaction_uniffi_fn.rs
@@ -1,0 +1,26 @@
+use crate::prelude::*;
+
+#[uniffi::export]
+pub(crate) fn new_wallet_to_dapp_interaction_response_sample(
+) -> WalletToDappInteractionResponse {
+    WalletToDappInteractionResponse::sample()
+}
+
+#[uniffi::export]
+pub(crate) fn new_wallet_to_dapp_interaction_response_sample_other(
+) -> WalletToDappInteractionResponse {
+    WalletToDappInteractionResponse::sample_other()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inequality_of_samples() {
+        assert_ne!(
+            new_wallet_to_dapp_interaction_response_sample(),
+            new_wallet_to_dapp_interaction_response_sample_other()
+        );
+    }
+}

--- a/uniffi.toml
+++ b/uniffi.toml
@@ -44,8 +44,34 @@ from_custom = "{}.toString()"
 [bindings.swift.custom_types.Timestamp]
 type_name = "Date"
 imports = ["Foundation"]
-into_custom = "{let df = DateFormatter();df.dateFormat = \"yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ\";return df.date(from: {})!}()"
-from_custom = "{let df = DateFormatter();df.dateFormat = \"yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ\";return df.string(from: {})}()"
+into_custom = """
+{
+    let stringToDeserialize = {} // this is UniFFIs counterpart to `$0`
+    let formatter = ISO8601DateFormatter()
+    let formatOptionMS = ISO8601DateFormatter.Options.withFractionalSeconds
+    formatter.formatOptions.insert(formatOptionMS)
+    
+    func format() -> Date? {
+        formatter.date(from: stringToDeserialize)
+    }
+    
+    if let date = format() {
+        return date
+    }
+    
+    // try without fractional seconds
+    formatter.formatOptions.remove(formatOptionMS)
+    return format()!
+}()
+"""
+from_custom = """
+{ 
+    let dateToSerialize = {} // this is UniFFIs counterpart to `$0`
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions.insert(.withFractionalSeconds)
+    return formatter.string(from: dateToSerialize)
+}()
+"""
 
 [bindings.kotlin.custom_types.Timestamp]
 type_name = "OffsetDateTime"


### PR DESCRIPTION
This is an attempt to improve consecutive builds time by adding `regenerate` boolean argument to build gradle tasks. If you don't pass any arg to the gradle task, it will follow the same steps as before (generating uniffi bindings which takes long and re-run even if there are no changes in rust), but if passing `regenerate=false` to gradle task, it skips this step entirely and rely upon previously generated bindings:

`./jvm/gradlew -p jvm/sargon-android testDebugUnitTest -Pregenerate=false`