### PR TITLE
Make TextInputDecimal decimal property nullable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2529,7 +2529,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "0.7.16"
+version = "0.7.17"
 dependencies = [
  "actix-rt",
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "0.7.16"
+version = "0.7.17"
 edition = "2021"
 build = "build.rs"
 

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/Decimal192.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/Decimal192.kt
@@ -109,13 +109,15 @@ class TextInputDecimal(
     val input: String,
     decimalSeparator: Char
 ) {
-    val decimal: Decimal192 = Decimal192.init(
-        formattedString = input,
-        config = LocaleConfig(
-            decimalSeparator = decimalSeparator.toString(),
-            groupingSeparator = null // We do not allow grouping separator characters in input
+    val decimal: Decimal192? = runCatching {
+        Decimal192.init(
+            formattedString = input,
+            config = LocaleConfig(
+                decimalSeparator = decimalSeparator.toString(),
+                groupingSeparator = null // We do not allow grouping separator characters in input
+            )
         )
-    )
+    }.getOrNull()
 }
 
 fun Decimal192.Companion.init(
@@ -188,7 +190,7 @@ fun Decimal192.rounded(decimalPlaces: UByte, roundingMode: RoundingMode): Decima
     return try {
         decimalRound(
             decimal = this,
-            decimalPlaces = decimalPlaces.toUByte(),
+            decimalPlaces = decimalPlaces,
             roundingMode = roundingMode
         )
     } catch (exception: Exception) {

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/Decimal192Test.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/Decimal192Test.kt
@@ -220,7 +220,7 @@ class Decimal192Test : SampleTestable<Decimal192> {
             input: String,
             decimal: Char,
             grouping: Char,
-            formattedTextField: String,
+            formattedTextField: String?,
             sanitizedInput: String
         ) {
             val decimalFormatSymbols = mockk<DecimalFormatSymbols>(relaxed = true).apply {
@@ -233,7 +233,7 @@ class Decimal192Test : SampleTestable<Decimal192> {
                 decimalFormat = decimalFormatSymbols
             )
 
-            assertEquals(formattedTextField, result.decimal.formattedTextField(
+            assertEquals(formattedTextField, result.decimal?.formattedTextField(
                 format = decimalFormatSymbols
             ))
 
@@ -266,7 +266,9 @@ class Decimal192Test : SampleTestable<Decimal192> {
             of(" ", ' ', ',', "0", " "), // Blank with space as decimal separator resolves to 0 prints space
 
             of("1,000,000.10", '.', ',', "1000000.1", "1000000.10"), // Large number resolves to decimal without trailing zero, prints the same number with 0
-            of("1.000.000,10", ',', '.', "1000000,1", "1000000,10")
+            of("1.000.000,10", ',', '.', "1000000,1", "1000000,10"),
+            of("2,", ',', '.', null, "2,"),
+            of("2.", '.', ',', null, "2.")
         )
     }
 }


### PR DESCRIPTION
## Description
- wrap `decimal` property of `TextInputDecimal` in runCatching {} to catch decimal parse error
- add test examples for this particular case