### PR TITLE
Update the Scrypto Dependency for Bottlenose

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.48",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -86,18 +86,18 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.16"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "android-tzdata"
@@ -115,48 +115,59 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstream"
-version = "0.6.11"
+name = "annotate-snippets"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
+checksum = "6d9b665789884a7e8fb06c84b295e923b03ca51edbb7d08f91a6a50322ecbfe6"
+dependencies = [
+ "anstyle",
+ "unicode-width",
+]
+
+[[package]]
+name = "anstream"
+version = "0.6.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
+ "is_terminal_polyfill",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
 dependencies = [
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
 dependencies = [
  "anstyle",
  "windows-sys 0.52.0",
@@ -164,9 +175,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.79"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
+checksum = "25bdb32cbbdce2b519a9cd7df3a678443100e265d5e25ca763b7572a5104f5f3"
 
 [[package]]
 name = "askama"
@@ -191,7 +202,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.48",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -215,7 +226,7 @@ version = "2.0.2"
 source = "git+https://github.com/davidpdrsn/assert-json-diff/?rev=bca0d2c590808274298d939e0533da79cd09076d#bca0d2c590808274298d939e0533da79cd09076d"
 dependencies = [
  "serde",
- "serde_json 1.0.113",
+ "serde_json 1.0.117",
 ]
 
 [[package]]
@@ -225,14 +236,14 @@ source = "git+https://github.com/dtolnay/async-trait?rev=1eb21ed8bd87029bf4dcbea
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.63",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "backtrace"
@@ -263,9 +274,9 @@ checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
@@ -275,9 +286,9 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "basic-toml"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2db21524cad41c5591204d22d75e1970a2d1f71060214ca931dc7d5afe2c14e5"
+checksum = "823388e228f614e9558c6804262db37960ec8821856535f5c3f59913140558f8"
 dependencies = [
  "serde",
 ]
@@ -322,9 +333,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "blake2"
@@ -367,9 +378,9 @@ dependencies = [
 
 [[package]]
 name = "bnum"
-version = "0.7.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "845141a4fade3f790628b7daaaa298a25b204fb28907eb54febe5142db6ce653"
+checksum = "3e31ea183f6ee62ac8b8a8cf7feddd766317adfb13ff469de57ce033efd6a790"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -377,15 +388,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.14.0"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytecount"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e5f035d16fc623ae5f74981db80a439803888314e3a555fd6f04acd51a3205"
+checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
 
 [[package]]
 name = "byteorder"
@@ -395,9 +406,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "camino"
@@ -406,18 +417,18 @@ source = "git+https://github.com/camino-rs/camino/?rev=afa51b1b4c684b7e6698a6717
 
 [[package]]
 name = "camino"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
+checksum = "e0ec6b951b160caa93cc0c7b209e5a3bff7aae9062213451ac99493cd844c239"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "694c8807f2ae16faecc43dc17d74b3eb042482789fd0eb64b39a2e04e087053f"
+checksum = "24b1f0365a6c6bb4020cd05806fd0d33c44d38046b8bd7f0e40814b9763cabfc"
 dependencies = [
  "serde",
 ]
@@ -428,11 +439,11 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
 dependencies = [
- "camino 1.1.6",
+ "camino 1.1.7",
  "cargo-platform",
  "semver",
  "serde",
- "serde_json 1.0.113",
+ "serde_json 1.0.117",
 ]
 
 [[package]]
@@ -441,12 +452,12 @@ version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
 dependencies = [
- "camino 1.1.6",
+ "camino 1.1.7",
  "cargo-platform",
  "semver",
  "serde",
- "serde_json 1.0.113",
- "thiserror 1.0.57",
+ "serde_json 1.0.117",
+ "thiserror 1.0.60",
 ]
 
 [[package]]
@@ -470,9 +481,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.91"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd97381a8cc6493395a5afc4c691c1084b3768db713b73aa215217aa245d153"
+checksum = "099a5357d84c4c61eb35fc8eafa9a79a902c2f76911e5747ced4e032edd8d9b4"
 
 [[package]]
 name = "cesu8"
@@ -488,9 +499,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.34"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -498,7 +509,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.0",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -513,33 +524,21 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80c21025abd42669a92efc996ef13cfb2c5c627858421ea58d5c3b331a6c134f"
-dependencies = [
- "clap_builder 4.5.0",
- "clap_derive 4.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "clap"
 version = "4.5.1"
 source = "git+https://github.com/clap-rs/clap/?rev=8a7a13a5618cfdc4ff328624a5266e7b4d88649a#8a7a13a5618cfdc4ff328624a5266e7b4d88649a"
 dependencies = [
  "clap_builder 4.5.1",
- "clap_derive 4.5.0 (git+https://github.com/clap-rs/clap/?rev=8a7a13a5618cfdc4ff328624a5266e7b4d88649a)",
+ "clap_derive 4.5.0",
 ]
 
 [[package]]
-name = "clap_builder"
-version = "4.5.0"
+name = "clap"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458bf1f341769dfcf849846f65dffdf9146daa56bcd2a47cb4e1de9915567c99"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
 dependencies = [
- "anstream",
- "anstyle",
- "clap_lex 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "strsim 0.11.0",
+ "clap_builder 4.5.2",
+ "clap_derive 4.5.4",
 ]
 
 [[package]]
@@ -552,15 +551,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap_derive"
-version = "4.5.0"
+name = "clap_builder"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
 dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "syn 2.0.48",
+ "anstream",
+ "anstyle",
+ "clap_lex 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim",
 ]
 
 [[package]]
@@ -571,7 +570,19 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.63",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -587,9 +598,9 @@ source = "git+https://github.com/clap-rs/clap/?rev=8a7a13a5618cfdc4ff328624a5266
 
 [[package]]
 name = "colorchoice"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
 name = "colored"
@@ -603,9 +614,9 @@ dependencies = [
 
 [[package]]
 name = "combine"
-version = "4.6.6"
+version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
@@ -619,8 +630,9 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-sha1"
-version = "0.2.0"
-source = "git+https://github.com/radixdlt/const-sha1#5e9ae2a99e9c76e85aa67f42e4b62e7f7ce8dad4"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8a42181e0652c2997ae4d217f25b63c5337a52fd2279736e97b832fa0a3cff"
 
 [[package]]
 name = "core-foundation"
@@ -649,9 +661,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176dc175b78f56c0f321911d9c8eb2b77a78a4860b9c19db83835fea1a46649b"
+checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -741,14 +753,14 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.63",
 ]
 
 [[package]]
 name = "darling"
-version = "0.20.5"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc5d6b04b3fd0ba9926f945895de7d806260a2d7431ba82e7edaecb043c4c6b8"
+checksum = "83b2eb4d90d12bdda5ed17de686c2acb4c57914f8f921b8da7e112b5a36f3fe1"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -756,27 +768,27 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.5"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e48a959bcd5c761246f5d090ebc2fbf7b9cd527a492b07a67510c108f1e7e3"
+checksum = "622687fe0bac72a04e5599029151f5796111b90f1baaa9b544d807a5e31cd120"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
- "syn 2.0.48",
+ "strsim",
+ "syn 2.0.63",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.20.5"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1545d67a2149e1d93b7e5c7752dce5a7426eb5d1357ddcfd89336b94444f77"
+checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -786,14 +798,14 @@ source = "git+https://github.com/Kobzol/rust-delegate/?rev=ac852be64f3e4b5f9b58b
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.63",
 ]
 
 [[package]]
 name = "der"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
+checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
  "const-oid",
  "zeroize 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -824,7 +836,7 @@ source = "git+https://github.com/JelteF/derive_more?rev=1196b2dd7a366c06db621093
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.63",
  "unicode-xid",
 ]
 
@@ -857,15 +869,15 @@ dependencies = [
 
 [[package]]
 name = "downcast-rs"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "545b22097d44f8a9581187cdf93de7a71e4722bf51200cfaba810865b49a495d"
+checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
 name = "ecdsa"
@@ -921,7 +933,7 @@ checksum = "7d9ce6874da5d4415896cd45ffbc4d1cfc0c4f9c079427bd870742c30f2f65a9"
 dependencies = [
  "curve25519-dalek 4.1.2",
  "ed25519 2.2.3",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.10.8",
@@ -930,9 +942,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
 
 [[package]]
 name = "elliptic-curve"
@@ -961,7 +973,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -979,7 +991,7 @@ source = "git+https://github.com/stephaneyfx/enum-iterator/?rev=9d472a1237cfd03b
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -1003,9 +1015,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -1028,14 +1040,14 @@ checksum = "311a6d2f1f9d60bff73d2c78a0af97ed27f79672f15c238192a5bbb64db56d00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.63",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "ff"
@@ -1049,9 +1061,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.7"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c007b1ae3abe1cb6f85a16305acd418b7ca6343b953633fee2b76d8f108b830f"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "fixedstr"
@@ -1164,9 +1176,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1197,9 +1209,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "goblin"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb07a4ffed2093b118a525b1d8f5204ae274faed5604537caf7135d0f18d9887"
+checksum = "1b363a30c165f666402fe6a3024d3bec7ebc898f96a4a23bd1c99f8dbf3f4f47"
 dependencies = [
  "log",
  "plain",
@@ -1225,15 +1237,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.13.2"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-
-[[package]]
-name = "hashbrown"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
  "allocator-api2",
@@ -1253,9 +1259,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.5"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c62115964e08cb8039170eb33c1d0e2388a256930279edca206fff675f82c3"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -1336,9 +1342,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186548d73ac615b32a73aafe38fb4f56c0d340e110e5a200bcadbaf2e199263a"
+checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1441,31 +1447,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.0-pre"
-source = "git+https://github.com/bluss/indexmap?rev=eedabaca9f84e520eab01325b305c08f3773e66c#eedabaca9f84e520eab01325b305c08f3773e66c"
-dependencies = [
- "hashbrown 0.13.2",
- "serde",
-]
-
-[[package]]
-name = "indexmap"
-version = "2.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
-dependencies = [
- "equivalent",
- "hashbrown 0.14.3",
- "serde",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.2.6"
-source = "git+https://github.com/indexmap-rs/indexmap?rev=3f0fffb85b99a2a37bbee363703f8509dd03e2d7#3f0fffb85b99a2a37bbee363703f8509dd03e2d7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "serde",
 ]
 
@@ -1516,6 +1503,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+
+[[package]]
 name = "iso8601-timestamp"
 version = "0.2.17"
 source = "git+https://github.com/Lantern-chat/iso8601-timestamp/?rev=e5a3f2a5911759bc6b0d8100b032a6b4dd6e12c1#e5a3f2a5911759bc6b0d8100b032a6b4dd6e12c1"
@@ -1544,9 +1537,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jni"
@@ -1559,7 +1552,7 @@ dependencies = [
  "combine",
  "jni-sys",
  "log",
- "thiserror 1.0.57",
+ "thiserror 1.0.60",
  "walkdir",
  "windows-sys 0.45.0",
 ]
@@ -1572,9 +1565,9 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "js-sys"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1627,9 +1620,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
 
 [[package]]
 name = "libm"
@@ -1645,9 +1638,9 @@ checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "lock_api"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1655,15 +1648,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "mime"
@@ -1724,21 +1717,9 @@ dependencies = [
  "skeptic",
  "smallvec",
  "tagptr",
- "thiserror 1.0.57",
+ "thiserror 1.0.60",
  "triomphe",
- "uuid 1.7.0",
-]
-
-[[package]]
-name = "native-sdk"
-version = "1.1.2"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
-dependencies = [
- "radix-engine-common",
- "radix-engine-derive",
- "radix-engine-interface",
- "sbor",
- "utils",
+ "uuid 1.8.0",
 ]
 
 [[package]]
@@ -1771,11 +1752,10 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -1797,9 +1777,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
@@ -1831,9 +1811,9 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opaque-debug"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
@@ -1841,7 +1821,7 @@ version = "0.10.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1858,7 +1838,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -1891,9 +1871,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -1901,27 +1881,27 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
 name = "paste"
 version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+source = "git+https://github.com/dtolnay/paste?rev=1e0cc1025af5388397c67fa4389ad7ad24814df8#1e0cc1025af5388397c67fa4389ad7ad24814df8"
 
 [[package]]
 name = "paste"
-version = "1.0.14"
-source = "git+https://github.com/dtolnay/paste?rev=1e0cc1025af5388397c67fa4389ad7ad24814df8#1e0cc1025af5388397c67fa4389ad7ad24814df8"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -1946,7 +1926,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -2033,9 +2013,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
 dependencies = [
  "unicode-ident",
 ]
@@ -2046,54 +2026,35 @@ version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "memchr",
  "unicase",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
-name = "radix-engine"
-version = "1.1.2"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
+name = "radix-blueprint-schema-init"
+version = "1.2.0-dev"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad#397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad"
 dependencies = [
  "bitflags 1.3.2",
- "colored",
- "const-sha1",
- "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static",
- "moka",
- "native-sdk",
- "num-traits",
- "paste 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "radix-engine-common",
- "radix-engine-interface",
- "radix-engine-macros",
- "radix-engine-store-interface",
- "resources-tracker-macro",
+ "radix-common",
  "sbor",
- "serde_json 1.0.113",
- "strum 0.24.1",
- "syn 1.0.93",
- "transaction",
- "utils",
- "wasm-instrument",
- "wasmi",
- "wasmparser 0.107.0",
+ "serde",
 ]
 
 [[package]]
-name = "radix-engine-common"
-version = "1.1.2"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
+name = "radix-common"
+version = "1.2.0-dev"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad#397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad"
 dependencies = [
  "bech32",
  "blake2",
@@ -2105,162 +2066,269 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
- "paste 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "radix-engine-derive",
+ "paste 1.0.15",
+ "radix-rust",
+ "radix-sbor-derive",
  "sbor",
  "secp256k1",
  "serde",
  "sha3",
  "strum 0.24.1",
- "utils",
+ "zeroize 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "radix-engine-derive"
-version = "1.1.2"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
+name = "radix-common-derive"
+version = "1.2.0-dev"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad#397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad"
 dependencies = [
+ "paste 1.0.15",
  "proc-macro2",
  "quote",
- "sbor-derive-common",
- "syn 1.0.93",
+ "radix-common",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "radix-engine"
+version = "1.2.0-dev"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad#397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad"
+dependencies = [
+ "bitflags 1.3.2",
+ "colored",
+ "const-sha1",
+ "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static",
+ "moka",
+ "num-traits",
+ "paste 1.0.15",
+ "radix-blueprint-schema-init",
+ "radix-common",
+ "radix-common-derive",
+ "radix-engine-interface",
+ "radix-engine-profiling-derive",
+ "radix-native-sdk",
+ "radix-rust",
+ "radix-substate-store-interface",
+ "radix-transactions",
+ "radix-wasm-instrument",
+ "radix-wasmi",
+ "sbor",
+ "serde_json 1.0.117",
+ "strum 0.24.1",
+ "syn 1.0.109",
+ "wasmparser 0.107.0",
 ]
 
 [[package]]
 name = "radix-engine-interface"
-version = "1.1.2"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
+version = "1.2.0-dev"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad#397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad"
 dependencies = [
  "bitflags 1.3.2",
  "const-sha1",
  "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static",
- "paste 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "radix-engine-common",
- "radix-engine-derive",
- "radix-engine-macros",
+ "paste 1.0.15",
+ "radix-blueprint-schema-init",
+ "radix-common",
+ "radix-common-derive",
+ "radix-rust",
  "regex 1.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "sbor",
- "scrypto-schema",
  "serde",
- "serde_json 1.0.113",
+ "serde_json 1.0.117",
  "strum 0.24.1",
- "utils",
-]
-
-[[package]]
-name = "radix-engine-macros"
-version = "1.1.2"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
-dependencies = [
- "paste 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2",
- "quote",
- "radix-engine-common",
- "syn 1.0.93",
 ]
 
 [[package]]
 name = "radix-engine-profiling"
-version = "1.1.2"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
+version = "1.2.0-dev"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad#397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad"
 dependencies = [
  "fixedstr",
 ]
 
 [[package]]
-name = "radix-engine-queries"
-version = "1.1.2"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
+name = "radix-engine-profiling-derive"
+version = "1.2.0-dev"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad#397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad"
 dependencies = [
- "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.10.5",
- "paste 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "radix-engine",
- "radix-engine-interface",
- "radix-engine-store-interface",
- "sbor",
- "transaction",
- "utils",
-]
-
-[[package]]
-name = "radix-engine-store-interface"
-version = "1.1.2"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
-dependencies = [
- "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.10.5",
- "radix-engine-common",
- "radix-engine-derive",
- "radix-engine-interface",
- "sbor",
- "utils",
-]
-
-[[package]]
-name = "radix-engine-stores"
-version = "1.1.2"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
-dependencies = [
- "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.10.5",
- "radix-engine-common",
- "radix-engine-derive",
- "radix-engine-store-interface",
- "sbor",
- "utils",
+ "proc-macro2",
+ "quote",
+ "radix-engine-profiling",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "radix-engine-toolkit"
-version = "2.0.1"
-source = "git+https://github.com/radixdlt/radix-engine-toolkit?rev=v2.0.1#566632afb4f1e292453950797bbf4329b37a04b0"
+version = "2.1.0-dev1"
+source = "git+https://github.com/radixdlt/radix-engine-toolkit?rev=d4325484305275d647491c521c2e3938f5296029#d4325484305275d647491c521c2e3938f5296029"
 dependencies = [
  "bech32",
  "cargo_toml 0.15.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "extend",
  "lazy_static",
- "paste 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "paste 1.0.15",
+ "radix-common",
  "radix-engine",
- "radix-engine-common",
  "radix-engine-interface",
- "radix-engine-queries",
- "radix-engine-store-interface",
- "radix-engine-stores",
+ "radix-substate-store-impls",
+ "radix-substate-store-interface",
+ "radix-substate-store-queries",
+ "radix-transactions",
  "regex 1.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "sbor",
  "sbor-json",
  "scrypto",
- "serde_json 1.0.113",
- "serde_with 3.6.1",
- "transaction",
+ "serde_json 1.0.117",
+ "serde_with 3.8.1",
 ]
 
 [[package]]
 name = "radix-engine-toolkit-json"
-version = "2.0.1"
-source = "git+https://github.com/radixdlt/radix-engine-toolkit?rev=v2.0.1#566632afb4f1e292453950797bbf4329b37a04b0"
+version = "2.1.0-dev1"
+source = "git+https://github.com/radixdlt/radix-engine-toolkit?rev=d4325484305275d647491c521c2e3938f5296029#d4325484305275d647491c521c2e3938f5296029"
 dependencies = [
  "bech32",
  "indexmap 1.9.3",
  "jni",
- "paste 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "paste 1.0.15",
+ "radix-common",
  "radix-engine",
- "radix-engine-common",
  "radix-engine-interface",
- "radix-engine-queries",
  "radix-engine-toolkit",
+ "radix-substate-store-queries",
+ "radix-transactions",
  "sbor",
  "schemars",
  "scrypto",
  "serde",
- "serde_json 1.0.113",
- "serde_with 3.6.1",
- "transaction",
+ "serde_json 1.0.117",
+ "serde_with 3.8.1",
  "typeshare",
  "walkdir",
 ]
+
+[[package]]
+name = "radix-native-sdk"
+version = "1.2.0-dev"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad#397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad"
+dependencies = [
+ "radix-common",
+ "radix-engine-interface",
+ "radix-rust",
+ "sbor",
+]
+
+[[package]]
+name = "radix-rust"
+version = "1.2.0-dev"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad#397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad"
+dependencies = [
+ "indexmap 2.2.6",
+ "serde",
+]
+
+[[package]]
+name = "radix-sbor-derive"
+version = "1.2.0-dev"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad#397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sbor-derive-common",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "radix-substate-store-impls"
+version = "1.2.0-dev"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad#397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad"
+dependencies = [
+ "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.10.5",
+ "radix-common",
+ "radix-rust",
+ "radix-substate-store-interface",
+ "sbor",
+]
+
+[[package]]
+name = "radix-substate-store-interface"
+version = "1.2.0-dev"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad#397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad"
+dependencies = [
+ "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.10.5",
+ "radix-common",
+ "radix-rust",
+ "sbor",
+]
+
+[[package]]
+name = "radix-substate-store-queries"
+version = "1.2.0-dev"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad#397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad"
+dependencies = [
+ "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.10.5",
+ "paste 1.0.15",
+ "radix-common",
+ "radix-engine",
+ "radix-engine-interface",
+ "radix-rust",
+ "radix-substate-store-interface",
+ "radix-transactions",
+ "sbor",
+]
+
+[[package]]
+name = "radix-transactions"
+version = "1.2.0-dev"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad#397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad"
+dependencies = [
+ "annotate-snippets",
+ "bech32",
+ "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static",
+ "radix-common",
+ "radix-engine-interface",
+ "radix-rust",
+ "sbor",
+ "strum 0.24.1",
+]
+
+[[package]]
+name = "radix-wasm-instrument"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b5e1305200330d3dd5c9b16ca43eba268993036ba19a2b2cadadee1b9166ab4"
+dependencies = [
+ "anyhow",
+ "paste 1.0.15",
+ "wasm-encoder",
+ "wasmparser 0.107.0",
+ "wasmprinter",
+]
+
+[[package]]
+name = "radix-wasmi"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59bf4a0498ed223122e726f9360e9889c2bb6eb6898069f4b6f9960b067a742d"
+dependencies = [
+ "radix-wasmi-arena",
+ "spin",
+ "wasmi_core",
+ "wasmparser-nostd",
+]
+
+[[package]]
+name = "radix-wasmi-arena"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a03d7e7816ade40c6ecedff7515198906d644527771bd8fb5a335094353a15a"
 
 [[package]]
 name = "rand"
@@ -2319,7 +2387,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.12",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -2327,7 +2395,7 @@ name = "rand_core"
 version = "0.6.4"
 source = "git+https://github.com/rust-random/rand/?rev=937320cbfeebd4352a23086d9c6e68f067f74644#937320cbfeebd4352a23086d9c6e68f067f74644"
 dependencies = [
- "getrandom 0.2.12",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -2341,11 +2409,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.5.0",
 ]
 
 [[package]]
@@ -2408,7 +2476,7 @@ name = "reqwest"
 version = "0.12.3"
 source = "git+https://github.com/seanmonstar/reqwest?rev=0720159f6369f54e045a1fd315e0f24b7a0b4a39#0720159f6369f54e045a1fd315e0f24b7a0b4a39"
 dependencies = [
- "base64 0.22.0",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -2428,7 +2496,7 @@ dependencies = [
  "pin-project-lite",
  "rustls-pemfile",
  "serde",
- "serde_json 1.0.113",
+ "serde_json 1.0.117",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
@@ -2439,17 +2507,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "winreg",
-]
-
-[[package]]
-name = "resources-tracker-macro"
-version = "1.1.2"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
-dependencies = [
- "proc-macro2",
- "quote",
- "radix-engine-profiling",
- "syn 1.0.93",
 ]
 
 [[package]]
@@ -2464,9 +2521,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc_version"
@@ -2479,11 +2536,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.31"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2496,27 +2553,27 @@ version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
 dependencies = [
- "base64 0.22.0",
+ "base64 0.22.1",
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.4.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
+checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
 
 [[package]]
 name = "rustversion"
-version = "1.0.14"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "ryu"
-version = "1.0.16"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "same-file"
@@ -2545,21 +2602,22 @@ dependencies = [
  "enum-iterator",
  "hex 0.4.3 (git+https://github.com/KokaKiwi/rust-hex/?rev=b2b4370b5bf021b98ee7adc92233e8de3f2de792)",
  "hkdf",
- "indexmap 2.2.6",
  "iota-crypto",
  "iso8601-timestamp",
  "itertools 0.12.0",
  "k256 0.13.3 (git+https://github.com/RustCrypto/elliptic-curves?rev=e158ce5cf0e9acee2fd76aff2a628334f5c771e5)",
  "log",
- "paste 1.0.14 (git+https://github.com/dtolnay/paste?rev=1e0cc1025af5388397c67fa4389ad7ad24814df8)",
+ "paste 1.0.14",
  "pretty_assertions",
  "pretty_env_logger",
+ "radix-common",
+ "radix-common-derive",
  "radix-engine",
- "radix-engine-common",
- "radix-engine-derive",
  "radix-engine-interface",
  "radix-engine-toolkit",
  "radix-engine-toolkit-json",
+ "radix-rust",
+ "radix-transactions",
  "rand 0.8.5",
  "regex 1.9.3 (git+https://github.com/rust-lang/regex/?rev=72f889ef3cca59ebac6a026f3646e8d92f056d88)",
  "reqwest",
@@ -2570,7 +2628,6 @@ dependencies = [
  "serde_with 3.4.0",
  "strum 0.26.1",
  "thiserror 1.0.50",
- "transaction",
  "uniffi",
  "url",
  "uuid 1.6.1",
@@ -2579,52 +2636,53 @@ dependencies = [
 
 [[package]]
 name = "sbor"
-version = "1.1.2"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
+version = "1.2.0-dev"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad#397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad"
 dependencies = [
  "const-sha1",
  "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static",
- "paste 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "paste 1.0.15",
+ "radix-rust",
  "sbor-derive",
  "serde",
- "utils",
 ]
 
 [[package]]
 name = "sbor-derive"
-version = "1.1.2"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
+version = "1.2.0-dev"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad#397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad"
 dependencies = [
  "proc-macro2",
  "sbor-derive-common",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "sbor-derive-common"
-version = "1.1.2"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
+version = "1.2.0-dev"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad#397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad"
 dependencies = [
  "const-sha1",
  "itertools 0.10.5",
  "proc-macro2",
  "quote",
- "syn 1.0.93",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "sbor-json"
-version = "2.0.1"
-source = "git+https://github.com/radixdlt/radix-engine-toolkit?rev=v2.0.1#566632afb4f1e292453950797bbf4329b37a04b0"
+version = "2.1.0-dev1"
+source = "git+https://github.com/radixdlt/radix-engine-toolkit?rev=d4325484305275d647491c521c2e3938f5296029#d4325484305275d647491c521c2e3938f5296029"
 dependencies = [
  "bech32",
- "radix-engine-common",
+ "radix-common",
  "radix-engine-interface",
  "regex 1.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "sbor",
  "serde",
- "serde_json 1.0.113",
- "serde_with 3.6.1",
+ "serde_json 1.0.117",
+ "serde_with 3.8.1",
 ]
 
 [[package]]
@@ -2647,27 +2705,27 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.16"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a28f4c49489add4ce10783f7911893516f15afe45d015608d41faca6bc4d29"
+checksum = "fc6e7ed6919cb46507fb01ff1654309219f62b4d603822501b0b80d42f6f21ef"
 dependencies = [
  "dyn-clone",
  "indexmap 1.9.3",
  "schemars_derive",
  "serde",
- "serde_json 1.0.113",
+ "serde_json 1.0.117",
 ]
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.16"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c767fd6fa65d9ccf9cf026122c1b555f2ef9a4f0cea69da4d7dbc3e258d30967"
+checksum = "185f2b7aa7e02d418e453790dde16890256bbd2bcd04b7dc5348811052b53f49"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 1.0.109",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -2693,56 +2751,44 @@ checksum = "7f81c2fde025af7e69b1d1420531c8a8811ca898919db177141a85313b1cb932"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.63",
 ]
 
 [[package]]
 name = "scrypto"
-version = "1.1.2"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
+version = "1.2.0-dev"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad#397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad"
 dependencies = [
  "bech32",
  "const-sha1",
  "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-bigint",
  "num-traits",
- "paste 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "radix-engine-common",
- "radix-engine-derive",
+ "paste 1.0.15",
+ "radix-blueprint-schema-init",
+ "radix-common",
  "radix-engine-interface",
+ "radix-rust",
  "sbor",
  "scrypto-derive",
- "scrypto-schema",
  "serde",
  "strum 0.24.1",
- "utils",
 ]
 
 [[package]]
 name = "scrypto-derive"
-version = "1.1.2"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
+version = "1.2.0-dev"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad#397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad"
 dependencies = [
  "proc-macro2",
  "quote",
- "radix-engine-common",
+ "radix-blueprint-schema-init",
+ "radix-common",
  "regex 1.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "sbor",
- "scrypto-schema",
  "serde",
- "serde_json 1.0.113",
- "syn 1.0.93",
-]
-
-[[package]]
-name = "scrypto-schema"
-version = "1.1.2"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
-dependencies = [
- "bitflags 1.3.2",
- "radix-engine-common",
- "sbor",
- "serde",
+ "serde_json 1.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2761,29 +2807,29 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.24.3"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b1629c9c557ef9b293568b338dddfc8208c98a18c59d722a9d53f859d9c9b62"
+checksum = "d24b59d129cdadea20aea4fb2352fa053712e5d713eee47d700cd4b2bc002f10"
 dependencies = [
  "secp256k1-sys",
 ]
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.6.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83080e2c2fc1006e625be82e5d1eb6a43b7fd9578b617fcc55814daf286bba4b"
+checksum = "e5d1746aae42c19d583c3c1a8c646bfad910498e2051c551a7f2e3c0c9fbb7eb"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "security-framework"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "770452e37cad93e0a50d5abc3990d2bc351c36d0328f86cefec2f2fb206eaef6"
+checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.5.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2792,9 +2838,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f3cc463c0ef97e11c3461a9d3787412d30e8e7eb907c79180c4a57bf7c04ef"
+checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2802,42 +2848,42 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.196"
+version = "1.0.202"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+checksum = "226b61a0d411b2ba5ff6d7f73a476ac4f8bb900373459cd00fab8512828ba395"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.196"
+version = "1.0.202"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.63",
 ]
 
 [[package]]
 name = "serde_derive_internals"
-version = "0.26.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -2845,7 +2891,7 @@ name = "serde_json"
 version = "1.0.108"
 source = "git+https://github.com/serde-rs/json/?rev=4bc1eaa03a6160593575bc9bc60c94dba4cab1e3#4bc1eaa03a6160593575bc9bc60c94dba4cab1e3"
 dependencies = [
- "indexmap 2.2.3",
+ "indexmap 2.2.6",
  "itoa",
  "ryu",
  "serde",
@@ -2853,11 +2899,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.113"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
- "indexmap 2.2.3",
+ "indexmap 2.2.6",
  "itoa",
  "ryu",
  "serde",
@@ -2870,7 +2916,7 @@ source = "git+https://github.com/dtolnay/serde-repr/?rev=94cce18a51bc169869f2cdc
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -2903,28 +2949,28 @@ dependencies = [
  "chrono",
  "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.9.3",
- "indexmap 2.2.3",
+ "indexmap 2.2.6",
  "serde",
- "serde_json 1.0.113",
+ "serde_json 1.0.117",
  "serde_with_macros 3.4.0",
  "time",
 ]
 
 [[package]]
 name = "serde_with"
-version = "3.6.1"
+version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d167997bd841ec232f5b2b8e0e26606df2e7caa4c31b95ea9ca52b200bd270"
+checksum = "0ad483d2ab0149d5a5ebcd9972a3852711e0153d863bf5a5d0391d28883c4a20"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "chrono",
  "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.9.3",
- "indexmap 2.2.3",
+ "indexmap 2.2.6",
  "serde",
  "serde_derive",
- "serde_json 1.0.113",
- "serde_with_macros 3.6.1",
+ "serde_json 1.0.117",
+ "serde_with_macros 3.8.1",
  "time",
 ]
 
@@ -2936,19 +2982,19 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.63",
 ]
 
 [[package]]
 name = "serde_with_macros"
-version = "3.6.1"
+version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "865f9743393e638991566a8b7a479043c2c8da94a33e0a31f18214c9cae0a64d"
+checksum = "65569b702f41443e8bc8bbb1c5779bd0450bbe723b56198980e80ec45780bce2"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -2987,9 +3033,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
@@ -3033,9 +3079,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "smawk"
@@ -3045,9 +3091,9 @@ checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "socket2"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -3077,15 +3123,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "strsim"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
@@ -3126,7 +3166,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.48",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -3134,16 +3174,6 @@ name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
-
-[[package]]
-name = "syn"
-version = "1.0.93"
-source = "git+https://github.com/dtolnay/syn.git?tag=1.0.93#2e505a847174ff8939431c4f5ffb565906590ac2"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
-]
 
 [[package]]
 name = "syn"
@@ -3158,9 +3188,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "bf5be731623ca1a1fb7d8be6f261a3be6d3e2337b8a1f97be944d020c8fcb704"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3181,9 +3211,9 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tempfile"
-version = "3.10.0"
+version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -3202,9 +3232,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
+checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 dependencies = [
  "smawk",
 ]
@@ -3219,11 +3249,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.57"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
+checksum = "579e9083ca58dd9dcf91a9923bb9054071b9ebbd800b342194c9feb0ee89fc18"
 dependencies = [
- "thiserror-impl 1.0.57",
+ "thiserror-impl 1.0.60",
 ]
 
 [[package]]
@@ -3233,18 +3263,18 @@ source = "git+https://github.com/dtolnay/thiserror/?rev=a7d220d7915fb888413aa797
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.63",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.57"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+checksum = "e2470041c06ec3ac1ab38d0356a6119054dedaea53e12fbefc0de730a1c08524"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -3258,9 +3288,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -3279,9 +3309,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3365,7 +3395,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.2.3",
+ "indexmap 2.2.6",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -3421,21 +3451,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "transaction"
-version = "1.1.2"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
-dependencies = [
- "bech32",
- "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static",
- "radix-engine-common",
- "radix-engine-interface",
- "sbor",
- "strum 0.24.1",
- "utils",
-]
-
-[[package]]
 name = "triomphe"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3455,24 +3470,24 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "typeshare"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f44d1a2f454cb35fbe05b218c410792697e76bd868f48d3a418f2cd1a7d527d6"
+checksum = "04f17399b76c2e743d58eac0635d7686e9c00f48cd4776f00695d9882a7d3187"
 dependencies = [
  "chrono",
  "serde",
- "serde_json 1.0.113",
+ "serde_json 1.0.117",
  "typeshare-annotation",
 ]
 
 [[package]]
 name = "typeshare-annotation"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc670d0e358428857cc3b4bf504c691e572fccaec9542ff09212d3f13d74b7a9"
+checksum = "a615d6c2764852a2e88a4f16e9ce1ea49bb776b5872956309e170d63a042a34f"
 dependencies = [
  "quote",
- "syn 1.0.109",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -3506,6 +3521,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-width"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3517,8 +3538,8 @@ version = "0.27.1"
 source = "git+https://github.com/mozilla/uniffi-rs/?rev=6f33088e8100a2ea9586c8c3ecf98ab51d5aba62#6f33088e8100a2ea9586c8c3ecf98ab51d5aba62"
 dependencies = [
  "anyhow",
- "camino 1.1.6",
- "clap 4.5.0",
+ "camino 1.1.7",
+ "clap 4.5.4",
  "uniffi_bindgen",
  "uniffi_build",
  "uniffi_core",
@@ -3532,15 +3553,15 @@ source = "git+https://github.com/mozilla/uniffi-rs/?rev=6f33088e8100a2ea9586c8c3
 dependencies = [
  "anyhow",
  "askama",
- "camino 1.1.6",
+ "camino 1.1.7",
  "cargo_metadata 0.15.4",
- "clap 4.5.0",
+ "clap 4.5.4",
  "fs-err",
  "glob",
  "goblin",
  "heck 0.5.0",
  "once_cell",
- "paste 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "paste 1.0.15",
  "serde",
  "textwrap",
  "toml 0.5.11",
@@ -3555,7 +3576,7 @@ version = "0.27.1"
 source = "git+https://github.com/mozilla/uniffi-rs/?rev=6f33088e8100a2ea9586c8c3ecf98ab51d5aba62#6f33088e8100a2ea9586c8c3ecf98ab51d5aba62"
 dependencies = [
  "anyhow",
- "camino 1.1.6",
+ "camino 1.1.7",
  "uniffi_bindgen",
 ]
 
@@ -3565,7 +3586,7 @@ version = "0.27.1"
 source = "git+https://github.com/mozilla/uniffi-rs/?rev=6f33088e8100a2ea9586c8c3ecf98ab51d5aba62#6f33088e8100a2ea9586c8c3ecf98ab51d5aba62"
 dependencies = [
  "quote",
- "syn 2.0.48",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -3575,10 +3596,10 @@ source = "git+https://github.com/mozilla/uniffi-rs/?rev=6f33088e8100a2ea9586c8c3
 dependencies = [
  "anyhow",
  "bytes",
- "camino 1.1.6",
+ "camino 1.1.7",
  "log",
  "once_cell",
- "paste 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "paste 1.0.15",
  "static_assertions",
 ]
 
@@ -3588,13 +3609,13 @@ version = "0.27.1"
 source = "git+https://github.com/mozilla/uniffi-rs/?rev=6f33088e8100a2ea9586c8c3ecf98ab51d5aba62#6f33088e8100a2ea9586c8c3ecf98ab51d5aba62"
 dependencies = [
  "bincode",
- "camino 1.1.6",
+ "camino 1.1.7",
  "fs-err",
  "once_cell",
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.48",
+ "syn 2.0.63",
  "toml 0.5.11",
  "uniffi_meta",
 ]
@@ -3616,7 +3637,7 @@ version = "0.27.1"
 source = "git+https://github.com/mozilla/uniffi-rs/?rev=6f33088e8100a2ea9586c8c3ecf98ab51d5aba62#6f33088e8100a2ea9586c8c3ecf98ab51d5aba62"
 dependencies = [
  "anyhow",
- "camino 1.1.6",
+ "camino 1.1.7",
  "cargo_metadata 0.15.4",
  "fs-err",
  "once_cell",
@@ -3663,30 +3684,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
-name = "utils"
-version = "1.1.2"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=v1.1.2#07327fcc3ac035fd7aff136d1a75a825e4b8f613"
-dependencies = [
- "indexmap 2.0.0-pre",
- "serde",
-]
-
-[[package]]
 name = "uuid"
 version = "1.6.1"
 source = "git+https://github.com/uuid-rs/uuid/?rev=c8891073248ddc7faa8c53ac9ceb629a341c7b9b#c8891073248ddc7faa8c53ac9ceb629a341c7b9b"
 dependencies = [
- "getrandom 0.2.12",
+ "getrandom 0.2.15",
  "serde",
 ]
 
 [[package]]
 name = "uuid"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
+checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 dependencies = [
- "getrandom 0.2.12",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -3703,9 +3715,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
@@ -3734,9 +3746,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -3744,24 +3756,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.63",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877b9c3f61ceea0e56331985743b13f3d25c406a7098d45180fb5f09bc19ed97"
+checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3771,9 +3783,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3781,22 +3793,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.63",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "wasm-encoder"
@@ -3808,42 +3820,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-instrument"
-version = "0.4.0"
-source = "git+https://github.com/radixdlt/wasm-instrument?branch=radix-master#fe2390722be31ace255bca1887b48f43ec1e2622"
-dependencies = [
- "anyhow",
- "paste 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-encoder",
- "wasmparser 0.107.0",
- "wasmprinter",
-]
-
-[[package]]
-name = "wasmi"
-version = "0.23.0"
-source = "git+https://github.com/radixdlt/wasmi.git?branch=v0.23.0_store_clone#84085f82bd4a18e6ecee530e1cb16675c7334df7"
-dependencies = [
- "spin",
- "wasmi_arena",
- "wasmi_core",
- "wasmparser-nostd",
-]
-
-[[package]]
-name = "wasmi_arena"
-version = "0.3.0"
-source = "git+https://github.com/radixdlt/wasmi.git?branch=v0.23.0_store_clone#84085f82bd4a18e6ecee530e1cb16675c7334df7"
-
-[[package]]
 name = "wasmi_core"
 version = "0.8.0"
-source = "git+https://github.com/radixdlt/wasmi.git?branch=v0.23.0_store_clone#84085f82bd4a18e6ecee530e1cb16675c7334df7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d21fc8d8dafc2df566ebcba7d48a2df7b37386d6afa64237cdf9415c8d7d98ec"
 dependencies = [
  "downcast-rs",
  "libm",
  "num-traits",
- "paste 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "paste 1.0.15",
 ]
 
 [[package]]
@@ -3862,8 +3847,8 @@ version = "0.121.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dbe55c8f9d0dbd25d9447a5a889ff90c0cc3feaa7395310d3d826b2c703eaab"
 dependencies = [
- "bitflags 2.4.2",
- "indexmap 2.2.3",
+ "bitflags 2.5.0",
+ "indexmap 2.2.6",
  "semver",
 ]
 
@@ -3888,9 +3873,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3905,35 +3890,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
- "winapi",
+ "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -3941,7 +3904,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -3968,7 +3931,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -4003,17 +3966,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.0"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm 0.52.5",
+ "windows_aarch64_msvc 0.52.5",
+ "windows_i686_gnu 0.52.5",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.5",
+ "windows_x86_64_gnu 0.52.5",
+ "windows_x86_64_gnullvm 0.52.5",
+ "windows_x86_64_msvc 0.52.5",
 ]
 
 [[package]]
@@ -4030,9 +3994,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -4048,9 +4012,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4066,9 +4030,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4084,9 +4054,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4102,9 +4072,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4120,9 +4090,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4138,9 +4108,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "winnow"
@@ -4169,22 +4139,22 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.32"
+version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.32"
+version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -4212,7 +4182,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -4222,5 +4192,5 @@ source = "git+https://github.com/RustCrypto/utils?rev=df6d2f48a5e8afe8eef04ba32e
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.63",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2163,7 +2163,7 @@ dependencies = [
 [[package]]
 name = "radix-engine-toolkit"
 version = "2.1.0-dev1"
-source = "git+https://github.com/radixdlt/radix-engine-toolkit?rev=d4325484305275d647491c521c2e3938f5296029#d4325484305275d647491c521c2e3938f5296029"
+source = "git+https://github.com/radixdlt/radix-engine-toolkit?rev=429dd3de58c0860ddbb8a83e9b57e65a1c0765d1#429dd3de58c0860ddbb8a83e9b57e65a1c0765d1"
 dependencies = [
  "bech32",
  "cargo_toml 0.15.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2188,7 +2188,7 @@ dependencies = [
 [[package]]
 name = "radix-engine-toolkit-json"
 version = "2.1.0-dev1"
-source = "git+https://github.com/radixdlt/radix-engine-toolkit?rev=d4325484305275d647491c521c2e3938f5296029#d4325484305275d647491c521c2e3938f5296029"
+source = "git+https://github.com/radixdlt/radix-engine-toolkit?rev=429dd3de58c0860ddbb8a83e9b57e65a1c0765d1#429dd3de58c0860ddbb8a83e9b57e65a1c0765d1"
 dependencies = [
  "bech32",
  "indexmap 1.9.3",
@@ -2673,7 +2673,7 @@ dependencies = [
 [[package]]
 name = "sbor-json"
 version = "2.1.0-dev1"
-source = "git+https://github.com/radixdlt/radix-engine-toolkit?rev=d4325484305275d647491c521c2e3938f5296029#d4325484305275d647491c521c2e3938f5296029"
+source = "git+https://github.com/radixdlt/radix-engine-toolkit?rev=429dd3de58c0860ddbb8a83e9b57e65a1c0765d1#429dd3de58c0860ddbb8a83e9b57e65a1c0765d1"
 dependencies = [
  "bech32",
  "radix-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,22 +74,21 @@ strum = { git = "https://github.com/Peternator7/strum/", rev = "f746c3699acf1501
     "derive",
 ] }
 
-radix-engine-common = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "v1.1.2", features = [
+sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad" }
+radix-rust = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad", features = [
     "serde",
 ] }
-radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "v1.1.2" }
-sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "v1.1.2" }
-radix-engine-derive = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "v1.1.2" }
-radix-engine-interface = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "v1.1.2", features = [
-    "std",
+radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad" }
+radix-common = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad", features = [
+    "serde", "secp256k1_sign_and_validate"
 ] }
+radix-common-derive = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad" }
+radix-engine-interface = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad" }
 
-transaction = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "v1.1.2", features = [
-    "std",
-] }
+radix-transactions = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad" }
 
-radix-engine-toolkit-json = { git = "https://github.com/radixdlt/radix-engine-toolkit", rev = "v2.0.1" }
-radix-engine-toolkit = { git = "https://github.com/radixdlt/radix-engine-toolkit", rev = "v2.0.1" }
+radix-engine-toolkit-json = { git = "https://github.com/radixdlt/radix-engine-toolkit", rev = "d4325484305275d647491c521c2e3938f5296029" }
+radix-engine-toolkit = { git = "https://github.com/radixdlt/radix-engine-toolkit", rev = "d4325484305275d647491c521c2e3938f5296029" }
 
 # enum-iterator = "1.4.1"
 enum-iterator = { git = "https://github.com/stephaneyfx/enum-iterator/", rev = "9d472a1237cfd03b1c7657fdcba74c8070bfb4ea" }
@@ -112,10 +111,6 @@ enum-as-inner = { git = "https://github.com/bluejekyll/enum-as-inner/", rev = "c
 # uniffi = "0.27.1"
 uniffi = { git = "https://github.com/mozilla/uniffi-rs/", rev = "6f33088e8100a2ea9586c8c3ecf98ab51d5aba62", features = [
     "cli",
-] }
-
-indexmap = { git = "https://github.com/indexmap-rs/indexmap", rev = "3f0fffb85b99a2a37bbee363703f8509dd03e2d7", features = [
-    "serde",
 ] }
 
 # SLIP10 implementation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,8 +87,8 @@ radix-engine-interface = { git = "https://github.com/radixdlt/radixdlt-scrypto",
 
 radix-transactions = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad" }
 
-radix-engine-toolkit-json = { git = "https://github.com/radixdlt/radix-engine-toolkit", rev = "d4325484305275d647491c521c2e3938f5296029" }
-radix-engine-toolkit = { git = "https://github.com/radixdlt/radix-engine-toolkit", rev = "d4325484305275d647491c521c2e3938f5296029" }
+radix-engine-toolkit-json = { git = "https://github.com/radixdlt/radix-engine-toolkit", rev = "429dd3de58c0860ddbb8a83e9b57e65a1c0765d1" }
+radix-engine-toolkit = { git = "https://github.com/radixdlt/radix-engine-toolkit", rev = "429dd3de58c0860ddbb8a83e9b57e65a1c0765d1" }
 
 # enum-iterator = "1.4.1"
 enum-iterator = { git = "https://github.com/stephaneyfx/enum-iterator/", rev = "9d472a1237cfd03b1c7657fdcba74c8070bfb4ea" }

--- a/src/core/types/identified_vec_of/identified_vec_of.rs
+++ b/src/core/types/identified_vec_of/identified_vec_of.rs
@@ -1,4 +1,4 @@
-use indexmap::{IndexMap, IndexSet};
+use radix_rust::prelude::{IndexMap, IndexSet};
 
 use crate::prelude::*;
 

--- a/src/core/types/identified_vec_of/identified_vec_of_iterator.rs
+++ b/src/core/types/identified_vec_of/identified_vec_of_iterator.rs
@@ -1,4 +1,4 @@
-use indexmap::IndexMap;
+use radix_rust::prelude::IndexMap;
 
 use crate::prelude::*;
 

--- a/src/core/types/identified_vec_of/identified_vec_of_query.rs
+++ b/src/core/types/identified_vec_of/identified_vec_of_query.rs
@@ -1,4 +1,4 @@
-use indexmap::IndexSet;
+use radix_rust::prelude::IndexSet;
 
 use crate::prelude::*;
 

--- a/src/core/types/identified_vec_of/identified_vec_of_uniffi_converter.rs
+++ b/src/core/types/identified_vec_of/identified_vec_of_uniffi_converter.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use indexmap::IndexMap;
+use radix_rust::prelude::IndexMap;
 use std::any::TypeId as StdTypeId;
 use uniffi::TypeId as UFTypeId;
 use uniffi::{

--- a/src/core/types/keys/is_public_key.rs
+++ b/src/core/types/keys/is_public_key.rs
@@ -2,6 +2,6 @@ pub trait IsPublicKey<S>: Sized {
     fn is_valid_signature_for_hash(
         &self,
         signature: &S,
-        hash: &impl radix_engine_common::crypto::IsHash,
+        hash: &impl radix_common::crypto::IsHash,
     ) -> bool;
 }

--- a/src/core/types/non_empty_max_n_bytes.rs
+++ b/src/core/types/non_empty_max_n_bytes.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 use delegate::delegate;
 use paste::*;
-use radix_engine_common::crypto::{Hash, IsHash};
+use radix_common::crypto::{Hash, IsHash};
 
 /// This macro exists since UniFFI does not support generics currently, when/if
 /// UniFFI does, we SHOULD remove this macro and use generics.

--- a/src/core/types/signatures/signature_with_public_key.rs
+++ b/src/core/types/signatures/signature_with_public_key.rs
@@ -14,7 +14,7 @@ use crate::prelude::*;
     uniffi::Enum,
 )]
 pub enum SignatureWithPublicKey {
-    // N.B. `transaction::model::SignatureWithPublicKeyV1::Secp256k1` does
+    // N.B. `radix_transactions::model::SignatureWithPublicKeyV1::Secp256k1` does
     // NOT include the public key, it relies on ECDSA Signature supporting
     // recovery, but it is not reliable since passing the wrong hash to
     // a signature will return the WRONG public key. In other words one might
@@ -75,7 +75,7 @@ impl TryFrom<(ScryptoSignatureWithPublicKey, Hash)> for SignatureWithPublicKey {
     ) -> Result<Self, Self::Error> {
         match value.0 {
             ScryptoSignatureWithPublicKey::Secp256k1 { signature } => {
-                let hash: radix_engine_common::crypto::Hash = value.1.into();
+                let hash: radix_common::crypto::Hash = value.1.into();
                 let scrypto_public_key = Scrypto_recover_secp256k1(
                     &hash, &signature,
                 )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,9 @@ pub mod prelude {
     pub use crate::wallet::*;
     pub use crate::wrapped_radix_engine_toolkit::*;
 
-    pub(crate) use std::collections::{BTreeSet, HashMap, HashSet};
+    pub(crate) use radix_rust::prelude::{
+        BTreeSet, HashMap, HashSet, IndexMap, IndexSet,
+    };
 
     pub(crate) use ::hex::decode as hex_decode;
     pub(crate) use ::hex::encode as hex_encode;
@@ -36,7 +38,7 @@ pub mod prelude {
     pub(crate) use serde_with::*;
     pub(crate) use zeroize::{Zeroize, ZeroizeOnDrop};
 
-    pub use radix_engine_common::math::traits::CheckedMul as ScryptoCheckedMul;
+    pub use radix_common::math::traits::CheckedMul as ScryptoCheckedMul;
     pub(crate) use std::cmp::Ordering;
     pub(crate) use std::collections::BTreeMap;
     pub(crate) use std::fmt::{Debug, Display, Formatter};
@@ -60,31 +62,10 @@ pub mod prelude {
             TransactionReceiptV1 as ScryptoTransactionReceipt,
             VersionedTransactionReceipt as ScryptoVersionedTransactionReceipt,
         },
-        types::{
-            node_modules::{
-                metadata::ToMetadataEntry as ScryptoToMetadataEntry,
-                ModuleConfig as ScryptoModuleConfig,
-            },
-            recover_secp256k1 as Scrypto_recover_secp256k1,
-            AccessRule as ScryptoAccessRule, Epoch as ScryptoEpoch,
-            FungibleResourceRoles as ScryptoFungibleResourceRoles,
-            ManifestAddress as ScryptoManifestAddress,
-            ManifestBucket as ScryptoManifestBucket,
-            ManifestCustomValue as ScryptoManifestCustomValue,
-            ManifestCustomValueKind as ScryptoManifestCustomValueKind,
-            ManifestEncode as ScryptoManifestEncode,
-            MetadataInit as ScryptoMetadataInit,
-            NonFungibleData as ScryptoNonFungibleData,
-            NonFungibleGlobalId as ScryptoNonFungibleGlobalId,
-            NonFungibleIdType as ScryptoNonFungibleIdType,
-            NonFungibleResourceRoles as ScryptoNonFungibleResourceRoles,
-            OwnerRole as ScryptoOwnerRole,
-            RoleAssignmentInit as ScryptoRoleAssignmentInit,
-        },
     };
-    pub(crate) use sbor::HasLatestVersion;
+    pub(crate) use sbor::Versioned;
 
-    pub(crate) use radix_engine_common::{
+    pub(crate) use radix_common::{
         address::AddressBech32Encoder as ScryptoAddressBech32Encoder,
         crypto::{
             blake2b_256_hash, verify_ed25519 as scrypto_verify_ed25519,
@@ -115,12 +96,25 @@ pub mod prelude {
             Decimal as ScryptoDecimal192, RoundingMode as ScryptoRoundingMode,
         },
         network::NetworkDefinition as ScryptoNetworkDefinition,
+        prelude::{
+            recover_secp256k1 as Scrypto_recover_secp256k1,
+            ManifestAddress as ScryptoManifestAddress,
+            ManifestBucket as ScryptoManifestBucket,
+            ManifestCustomValue as ScryptoManifestCustomValue,
+            ManifestCustomValueKind as ScryptoManifestCustomValueKind,
+            ManifestEncode as ScryptoManifestEncode,
+            ManifestValue as ScryptoManifestValue,
+            NonFungibleData as ScryptoNonFungibleData,
+            NonFungibleGlobalId as ScryptoNonFungibleGlobalId,
+            NonFungibleIdType as ScryptoNonFungibleIdType, XRD,
+        },
         types::{
             ComponentAddress as ScryptoComponentAddress,
             EntityType as ScryptoEntityType,
             GlobalAddress as ScryptoGlobalAddress, NodeId as ScryptoNodeId,
             ResourceAddress as ScryptoResourceAddress,
         },
+        ManifestSbor as ScryptoManifestSbor, ScryptoSbor,
     };
     pub(crate) use radix_engine_interface::blueprints::{
         account::{
@@ -129,10 +123,22 @@ pub mod prelude {
         },
         resource::ResourceOrNonFungible as ScryptoResourceOrNonFungible,
     };
+    pub(crate) use radix_engine_interface::prelude::{
+        AccessRule as ScryptoAccessRule, Epoch as ScryptoEpoch,
+        FungibleResourceRoles as ScryptoFungibleResourceRoles,
+        MetadataInit as ScryptoMetadataInit,
+        MetadataValue as ScryptoMetadataValue,
+        ModuleConfig as ScryptoModuleConfig,
+        NonFungibleResourceRoles as ScryptoNonFungibleResourceRoles,
+        OwnerRole as ScryptoOwnerRole,
+        RoleAssignmentInit as ScryptoRoleAssignmentInit,
+        ToMetadataEntry as ScryptoToMetadataEntry,
+        UncheckedUrl as ScryptoUncheckedUrl,
+    };
 
     pub(crate) use enum_iterator::all;
 
-    pub(crate) use transaction::{
+    pub(crate) use radix_transactions::{
         builder::{
             ExistingManifestBucket as ScryptoExistingManifestBucket,
             ManifestNameRegistrar as ScryptoManifestNameRegistrar,
@@ -142,6 +148,8 @@ pub mod prelude {
         },
         manifest::{
             compile as scrypto_compile, decompile as scrypto_decompile,
+            generator::{GeneratorError, GeneratorErrorKind},
+            token::{Position, Span},
             CompileError as ScryptoCompileError,
             MockBlobProvider as ScryptoMockBlobProvider,
         },
@@ -172,14 +180,8 @@ pub mod prelude {
         },
         prelude::{
             ManifestBuilder as ScryptoManifestBuilder,
-            ManifestValue as ScryptoManifestValue,
-            MetadataValue as ScryptoMetadataValue,
             TransactionManifestV1 as ScryptoTransactionManifest,
         },
-    };
-
-    pub(crate) use radix_engine_derive::{
-        ManifestSbor as ScryptoManifestSbor, ScryptoSbor,
     };
 
     pub(crate) use radix_engine_toolkit_json::models::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,6 +149,7 @@ pub mod prelude {
         manifest::{
             compile as scrypto_compile, decompile as scrypto_decompile,
             generator::{GeneratorError, GeneratorErrorKind},
+            lexer::{LexerError, LexerErrorKind},
             token::{Position, Span},
             CompileError as ScryptoCompileError,
             MockBlobProvider as ScryptoMockBlobProvider,

--- a/src/profile/logic/persona/persona_data_ids.rs
+++ b/src/profile/logic/persona/persona_data_ids.rs
@@ -1,4 +1,4 @@
-use indexmap::IndexSet;
+use radix_rust::prelude::IndexSet;
 
 use crate::prelude::*;
 

--- a/src/profile/logic/persona/shared_persona_data_ids.rs
+++ b/src/profile/logic/persona/shared_persona_data_ids.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use indexmap::IndexSet;
+use radix_rust::prelude::IndexSet;
 
 impl SharedPersonaData {
     pub fn ids_of_entries(&self) -> IndexSet<PersonaDataEntryID> {

--- a/src/profile/v100/address/account_address.rs
+++ b/src/profile/v100/address/account_address.rs
@@ -331,11 +331,10 @@ mod tests {
     #[test]
     fn into_scrypto_global_address() {
         assert_eq!(
-            radix_engine::types::GlobalAddress::from(SUT::sample())
+            ScryptoGlobalAddress::from(SUT::sample())
                 .into_node_id()
                 .as_bytes()[0],
-            radix_engine_common::types::EntityType::GlobalVirtualEd25519Account
-                as u8
+            ScryptoEntityType::GlobalVirtualEd25519Account as u8
         );
     }
 

--- a/src/profile/v100/address/resource_address.rs
+++ b/src/profile/v100/address/resource_address.rs
@@ -27,8 +27,7 @@ impl ResourceAddress {
     }
 
     pub fn xrd_on_network(id: NetworkID) -> Self {
-        Self::new(radix_engine::types::XRD, id)
-            .expect("Should never fail to get XRD on network.")
+        Self::new(XRD, id).expect("Should never fail to get XRD on network.")
     }
 
     pub fn is_xrd_on_network(&self, id: NetworkID) -> bool {

--- a/src/profile/v100/factors/factor_source_id_from_hash.rs
+++ b/src/profile/v100/factors/factor_source_id_from_hash.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use radix_engine_common::crypto::{blake2b_256_hash, Hash};
+use radix_common::crypto::{blake2b_256_hash, Hash};
 
 /// FactorSourceID from the blake2b hash of the special HD public key derived at `CAP26::GetID`,
 /// for a certain `FactorSourceKind`

--- a/src/profile/v100/networks/network/network_id.rs
+++ b/src/profile/v100/networks/network/network_id.rs
@@ -126,7 +126,7 @@ impl std::fmt::Display for NetworkID {
 
 impl NetworkID {
     /// Looks up a `ScryptoNetworkDefinition` in lookup table,
-    /// this is used internally for radix_engine_common::address::AddressBech32Decoder,
+    /// this is used internally for radix_common::address::AddressBech32Decoder,
     /// and to read out the canonical name (logical name) for a network.
     pub(crate) fn network_definition(&self) -> ScryptoNetworkDefinition {
         use NetworkID::*;

--- a/src/wrapped_radix_engine_toolkit/high_level/manifest_building/manifests_create_tokens.rs
+++ b/src/wrapped_radix_engine_toolkit/high_level/manifest_building/manifests_create_tokens.rs
@@ -114,11 +114,9 @@ impl TransactionManifest {
                 ScryptoNonFungibleResourceRoles::single_locked_rule(
                     ScryptoAccessRule::AllowAll,
                 ),
-                Into::<
-                    radix_engine::types::node_modules::ModuleConfig<
-                        radix_engine::types::MetadataInit,
-                    >,
-                >::into(metadata.clone()),
+                Into::<ScryptoModuleConfig<ScryptoMetadataInit>>::into(
+                    metadata.clone(),
+                ),
                 Some(
                     initial_supply
                         .clone()

--- a/src/wrapped_radix_engine_toolkit/high_level/sargon_specific_types/assets_transfers/per_recipient/per_recipient_asset_transfers.rs
+++ b/src/wrapped_radix_engine_toolkit/high_level/sargon_specific_types/assets_transfers/per_recipient/per_recipient_asset_transfers.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use indexmap::IndexMap;
+use radix_rust::prelude::IndexMap;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, uniffi::Record)]
 pub struct PerRecipientAssetTransfers {

--- a/src/wrapped_radix_engine_toolkit/high_level/token_definition_metadata.rs
+++ b/src/wrapped_radix_engine_toolkit/high_level/token_definition_metadata.rs
@@ -1,7 +1,5 @@
 use crate::prelude::*;
 
-use radix_engine::types::UncheckedUrl as ScryptoUncheckedUrl;
-
 #[derive(
     Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash, uniffi::Record,
 )]

--- a/src/wrapped_radix_engine_toolkit/low_level/execution_summary/execution_summary.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/execution_summary/execution_summary.rs
@@ -1,4 +1,4 @@
-use radix_engine::types::IndexMap;
+use radix_rust::prelude::IndexMap;
 
 use crate::prelude::*;
 

--- a/src/wrapped_radix_engine_toolkit/low_level/execution_summary/newly_created_resource.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/execution_summary/newly_created_resource.rs
@@ -1,4 +1,4 @@
-use radix_engine::types::IndexMap;
+use radix_rust::prelude::IndexMap;
 
 use crate::prelude::*;
 

--- a/src/wrapped_radix_engine_toolkit/low_level/execution_summary/reserved_instruction.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/execution_summary/reserved_instruction.rs
@@ -8,6 +8,7 @@ pub enum ReservedInstruction {
     AccountSecurify,
     IdentitySecurify,
     AccessControllerMethod,
+    AccountUpdateSettings,
 }
 
 impl From<RetReservedInstruction> for ReservedInstruction {
@@ -18,6 +19,9 @@ impl From<RetReservedInstruction> for ReservedInstruction {
             RetReservedInstruction::IdentitySecurify => Self::IdentitySecurify,
             RetReservedInstruction::AccessControllerMethod => {
                 Self::AccessControllerMethod
+            }
+            RetReservedInstruction::AccountUpdateSettings => {
+                Self::AccountUpdateSettings
             }
         }
     }

--- a/src/wrapped_radix_engine_toolkit/low_level/execution_summary/resource_indicator/predicted.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/execution_summary/resource_indicator/predicted.rs
@@ -1,4 +1,4 @@
-use radix_engine::types::{IndexMap, IndexSet};
+use radix_rust::prelude::{IndexMap, IndexSet};
 
 use crate::prelude::*;
 

--- a/src/wrapped_radix_engine_toolkit/low_level/intent_signatures.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/intent_signatures.rs
@@ -59,9 +59,7 @@ impl HasSampleValues for IntentSignatures {
         let mut signatures = Vec::<IntentSignature>::new();
         for n in 1..4 {
             let private_key: Secp256k1PrivateKey =
-                radix_engine::types::Secp256k1PrivateKey::from_u64(n)
-                    .unwrap()
-                    .into();
+                ScryptoSecp256k1PrivateKey::from_u64(n).unwrap().into();
 
             signatures.push(private_key.sign_intent_hash(&intent.intent_hash()))
         }
@@ -74,9 +72,7 @@ impl HasSampleValues for IntentSignatures {
         let mut signatures = Vec::<IntentSignature>::new();
         for n in 1..4 {
             let private_key: Secp256k1PrivateKey =
-                radix_engine::types::Secp256k1PrivateKey::from_u64(n)
-                    .unwrap()
-                    .into();
+                ScryptoSecp256k1PrivateKey::from_u64(n).unwrap().into();
 
             signatures.push(private_key.sign_intent_hash(&intent.intent_hash()))
         }

--- a/src/wrapped_radix_engine_toolkit/low_level/message/message.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/message/message.rs
@@ -64,7 +64,7 @@ impl HasSampleValues for Message {
 mod tests {
     use super::*;
 
-    use transaction::model::EncryptedMessageV1;
+    use radix_transactions::model::EncryptedMessageV1;
 
     #[allow(clippy::upper_case_acronyms)]
     type SUT = Message;
@@ -120,7 +120,7 @@ mod tests {
     #[test]
     fn encrypted_msg_are_not_yet_supported() {
         let dummy = EncryptedMessageV1 {
-            encrypted: transaction::prelude::AesGcmPayload(vec![]),
+            encrypted: radix_transactions::prelude::AesGcmPayload(vec![]),
             decryptors_by_curve: [].into(),
         };
         assert_eq!(

--- a/src/wrapped_radix_engine_toolkit/low_level/notarized_transaction.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/notarized_transaction.rs
@@ -114,9 +114,7 @@ impl HasSampleValues for NotarizedTransaction {
     // bech32 encoded (simulator): `"txid_sim1vrjkzlt8pekg5s46tum5na8lzpulvc3p72p92nkdm2dd8p0vkx2svr7ejr"`
     fn sample_other() -> Self {
         let private_key: Secp256k1PrivateKey =
-            radix_engine::types::Secp256k1PrivateKey::from_u64(1)
-                .unwrap()
-                .into();
+            ScryptoSecp256k1PrivateKey::from_u64(1).unwrap().into();
 
         let intent = TransactionIntent::sample_other();
         assert_eq!(intent.intent_hash().to_string(), "txid_sim1vrjkzlt8pekg5s46tum5na8lzpulvc3p72p92nkdm2dd8p0vkx2svr7ejr");

--- a/src/wrapped_radix_engine_toolkit/low_level/notary_signature.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/notary_signature.rs
@@ -110,9 +110,9 @@ mod tests {
 
     #[test]
     fn from_scrypto_notary() {
-        let sig: radix_engine_common::crypto::Ed25519Signature = "2150c2f6b6c496d197ae03afb23f6adf23b275c675394f23786250abd006d5a2c7543566403cb414f70d0e229b0a9b55b4c74f42fc38cdf1aba2307f97686f0b".parse().unwrap();
+        let sig: radix_common::crypto::Ed25519Signature = "2150c2f6b6c496d197ae03afb23f6adf23b275c675394f23786250abd006d5a2c7543566403cb414f70d0e229b0a9b55b4c74f42fc38cdf1aba2307f97686f0b".parse().unwrap();
         let scrypto_notary = ScryptoNotarySignature(
-            transaction::model::SignatureV1::Ed25519(sig),
+            radix_transactions::model::SignatureV1::Ed25519(sig),
         );
         assert_eq!(SUT::from(scrypto_notary), SUT::sample());
     }

--- a/src/wrapped_radix_engine_toolkit/low_level/sbor_depth_validation.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/sbor_depth_validation.rs
@@ -1,10 +1,10 @@
 use crate::prelude::*;
 
-use radix_engine::types::{
-    manifest_encode as Scrypto_manifest_encode, MANIFEST_SBOR_V1_MAX_DEPTH,
+use radix_common::prelude::{
+    manifest_encode as Scrypto_manifest_encode,
+    ScryptoValue as ScryptoScryptoValue, MANIFEST_SBOR_V1_MAX_DEPTH,
     SCRYPTO_SBOR_V1_MAX_DEPTH,
 };
-use radix_engine_interface::prelude::ScryptoValue as ScryptoScryptoValue;
 use sbor::{
     CustomValue as ScryptoCustomValue,
     CustomValueKind as ScryptoCustomValueKind, Value as ScryptoValue,

--- a/src/wrapped_radix_engine_toolkit/low_level/signed_intent.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/signed_intent.rs
@@ -115,9 +115,7 @@ impl HasSampleValues for SignedIntent {
         let mut signatures = Vec::<IntentSignature>::new();
         for n in 1..4 {
             let private_key: Secp256k1PrivateKey =
-                radix_engine::types::Secp256k1PrivateKey::from_u64(n)
-                    .unwrap()
-                    .into();
+                ScryptoSecp256k1PrivateKey::from_u64(n).unwrap().into();
 
             let intent_signature =
                 private_key.sign_intent_hash(&intent.intent_hash());
@@ -149,9 +147,7 @@ impl SignedIntent {
                 let mut signatures = Vec::<IntentSignature>::new();
                 for n in 1..4 {
                     let private_key: Secp256k1PrivateKey =
-                        radix_engine::types::Secp256k1PrivateKey::from_u64(n)
-                            .unwrap()
-                            .into();
+                        ScryptoSecp256k1PrivateKey::from_u64(n).unwrap().into();
 
                     let intent_signature =
                         private_key.sign_intent_hash(&intent.intent_hash());
@@ -205,9 +201,7 @@ mod tests {
         let mut signatures = Vec::<IntentSignature>::new();
         for n in 1..4 {
             let private_key: Secp256k1PrivateKey =
-                radix_engine::types::Secp256k1PrivateKey::from_u64(n)
-                    .unwrap()
-                    .into();
+                ScryptoSecp256k1PrivateKey::from_u64(n).unwrap().into();
 
             let intent_signature =
                 private_key.sign_intent_hash(&intent.intent_hash());
@@ -232,9 +226,7 @@ mod tests {
         let mut signatures = Vec::<IntentSignature>::new();
         for n in 1..4 {
             let private_key: Secp256k1PrivateKey =
-                radix_engine::types::Secp256k1PrivateKey::from_u64(n)
-                    .unwrap()
-                    .into();
+                ScryptoSecp256k1PrivateKey::from_u64(n).unwrap().into();
 
             let intent_signature =
                 private_key.sign_intent_hash(&intent.intent_hash());
@@ -256,9 +248,7 @@ mod tests {
         let mut signatures = Vec::<IntentSignature>::new();
         for n in 1..4 {
             let private_key: Secp256k1PrivateKey =
-                radix_engine::types::Secp256k1PrivateKey::from_u64(n)
-                    .unwrap()
-                    .into();
+                ScryptoSecp256k1PrivateKey::from_u64(n).unwrap().into();
             let hash = intent.intent_hash();
             let intent_signature = private_key.sign_intent_hash(&hash);
             signatures.push(intent_signature)

--- a/src/wrapped_radix_engine_toolkit/low_level/transaction_hashes/validate_and_decode_hash.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/transaction_hashes/validate_and_decode_hash.rs
@@ -34,7 +34,7 @@ mod tests {
         // valid bech32 encoded string, unknown network (id: 0xfa, hrp: "fake")
         let s = "txid_fake_1frcm6zzyfd08z0deu9x24sh64eccxeux4j2dv3dsqeuh9qsz4y6sfken4s";
         assert_eq!(
-            validate_and_decode_hash::<transaction::model::IntentHash>(s),
+            validate_and_decode_hash::<radix_transactions::model::IntentHash>(s),
             Err(CommonError::FailedToBech32DecodeTransactionHashAfterHavingTestedAllNetworkID { bad_value: s.to_owned() })
         );
     }
@@ -43,9 +43,11 @@ mod tests {
     fn decode_sim_success() {
         let s = "txid_sim1vrjkzlt8pekg5s46tum5na8lzpulvc3p72p92nkdm2dd8p0vkx2svr7ejr";
         assert_eq!(
-            validate_and_decode_hash::<transaction::model::IntentHash>(s)
-                .unwrap()
-                .1,
+            validate_and_decode_hash::<radix_transactions::model::IntentHash>(
+                s
+            )
+            .unwrap()
+            .1,
             NetworkID::Simulator
         );
     }

--- a/src/wrapped_radix_engine_toolkit/low_level/transaction_header.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/transaction_header.rs
@@ -103,9 +103,7 @@ impl HasSampleValues for TransactionHeader {
     // https://github.com/radixdlt/radixdlt-scrypto/blob/ff21f24952318387803ae720105eec079afe33f3/transaction/src/model/hash/encoder.rs#L115
     fn sample_other() -> Self {
         let private_key: Secp256k1PrivateKey =
-            radix_engine::types::Secp256k1PrivateKey::from_u64(1)
-                .unwrap()
-                .into();
+            ScryptoSecp256k1PrivateKey::from_u64(1).unwrap().into();
         let public_key: Secp256k1PublicKey = private_key.public_key();
         let network_id = NetworkID::Simulator;
         Self::new(network_id, 0, 10, 10, public_key, true, 0)

--- a/src/wrapped_radix_engine_toolkit/low_level/transaction_manifest/blobs/blobs.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/transaction_manifest/blobs/blobs.rs
@@ -60,10 +60,7 @@ impl From<Blobs> for ScryptoBlobsMap {
             .into_iter()
             .map(|b| {
                 let bytes = b.secret_magic.to_vec();
-                (
-                    radix_engine::types::Hash::from(hash_of(bytes.clone())),
-                    bytes,
-                )
+                (ScryptoHash::from(hash_of(bytes.clone())), bytes)
             })
             .collect()
     }

--- a/src/wrapped_radix_engine_toolkit/low_level/transaction_manifest/blobs/blobs_secret_magic.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/transaction_manifest/blobs/blobs_secret_magic.rs
@@ -40,7 +40,7 @@ impl From<ScryptoBlobs> for BlobsSecretMagic {
     }
 }
 
-pub(crate) type ScryptoBlobsMap = BTreeMap<radix_engine::types::Hash, Vec<u8>>;
+pub(crate) type ScryptoBlobsMap = IndexMap<ScryptoHash, Vec<u8>>;
 
 impl From<ScryptoBlobsMap> for BlobsSecretMagic {
     fn from(value: ScryptoBlobsMap) -> Self {

--- a/src/wrapped_radix_engine_toolkit/low_level/transaction_manifest/execution_summary/transaction_manifest_execution_summary.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/transaction_manifest/execution_summary/transaction_manifest_execution_summary.rs
@@ -222,7 +222,7 @@ mod tests {
                 [acc_g2], // addresses_of_accounts_requiring_auth
                 [],               // addresses_of_identities_requiring_auth
                 [],               // newly_created_non_fungibles
-                [],               // reserved_instructions
+                [ReservedInstruction::AccountUpdateSettings],
                 [],               // presented_proofs
                 [],               // encountered_component_addresses
                 [

--- a/src/wrapped_radix_engine_toolkit/low_level/transaction_manifest/instructions/instructions.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/transaction_manifest/instructions/instructions.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 
-use radix_engine::types::MANIFEST_SBOR_V1_MAX_DEPTH;
+use radix_common::prelude::MANIFEST_SBOR_V1_MAX_DEPTH;
 use radix_engine_toolkit::functions::address::decode as RET_decode_address;
 
 #[derive(Clone, Debug, PartialEq, Eq, derive_more::Display, uniffi::Record)]
@@ -151,24 +151,29 @@ fn extract_error_from_error(
     err: ScryptoCompileError,
     expected_network: NetworkID,
 ) -> CommonError {
-    use transaction::manifest::generator::GeneratorError::*;
-    use transaction::manifest::parser::ParserError::*;
+    use radix_transactions::manifest::parser::ParserError;
+    use radix_transactions::manifest::parser::ParserErrorKind::*;
+    use GeneratorError;
+    use GeneratorErrorKind::*;
     let n = expected_network;
     match err {
-        ScryptoCompileError::GeneratorError(gen_err) => match gen_err {
+        ScryptoCompileError::GeneratorError(GeneratorError {
+            error_kind: gen_err,
+            ..
+        }) => match gen_err {
             InvalidPackageAddress(a) => extract_error_from_addr(a, n),
-            InvalidComponentAddress(a) => extract_error_from_addr(a, n),
             InvalidResourceAddress(a) => extract_error_from_addr(a, n),
             InvalidGlobalAddress(a) => extract_error_from_addr(a, n),
             _ => CommonError::InvalidInstructionsString {
                 underlying: format!("GeneratorError: {:?}", gen_err),
             },
         },
-        ScryptoCompileError::ParserError(MaxDepthExceeded(max)) => {
-            CommonError::InvalidTransactionMaxSBORDepthExceeded {
-                max: max as u16,
-            }
-        }
+        ScryptoCompileError::ParserError(ParserError {
+            error_kind: MaxDepthExceeded { max, .. },
+            ..
+        }) => CommonError::InvalidTransactionMaxSBORDepthExceeded {
+            max: max as u16,
+        },
         _ => CommonError::InvalidInstructionsString {
             underlying: format!("{:?}", err),
         },
@@ -324,7 +329,7 @@ mod tests {
         assert_eq!(
             extract_error_from_error(
                 ScryptoCompileError::LexerError(
-                    transaction::manifest::lexer::LexerError::UnexpectedEof
+                    radix_transactions::manifest::lexer::LexerError { error_kind: radix_transactions::manifest::lexer::LexerErrorKind::UnexpectedEof, span: Span { start: Position { full_index: 0, line_idx: 0, line_char_index: 0 }, end: Position { full_index: 0, line_idx: 0, line_char_index: 0 } } }
                 ),
                 NetworkID::Simulator
             ),
@@ -354,10 +359,28 @@ mod tests {
     fn extract_error_from_error_gen_non_addr_err() {
         assert_eq!(
             extract_error_from_error(
-                ScryptoCompileError::GeneratorError(transaction::manifest::generator::GeneratorError::BlobNotFound("dead".to_owned())),
+                ScryptoCompileError::GeneratorError(GeneratorError {
+                    error_kind: GeneratorErrorKind::BlobNotFound(
+                        "dead".to_owned()
+                    ),
+                    span: Span {
+                        start: Position {
+                            full_index: 0,
+                            line_idx: 0,
+                            line_char_index: 0
+                        },
+                        end: Position {
+                            full_index: 0,
+                            line_idx: 0,
+                            line_char_index: 0
+                        }
+                    }
+                }),
                 NetworkID::Simulator
             ),
-            CommonError::InvalidInstructionsString { underlying: "GeneratorError: BlobNotFound(\"dead\")".to_owned() }
+            CommonError::InvalidInstructionsString {
+                underlying: "GeneratorError: BlobNotFound(\"dead\")".to_owned()
+            }
         );
     }
 
@@ -365,21 +388,29 @@ mod tests {
     fn extract_error_from_error_gen_err_package_addr() {
         assert_eq!(
             extract_error_from_error(
-                ScryptoCompileError::GeneratorError(transaction::manifest::generator::GeneratorError::InvalidPackageAddress(PackageAddress::sample().to_string())),
+                ScryptoCompileError::GeneratorError(GeneratorError {
+                    error_kind: GeneratorErrorKind::InvalidPackageAddress(
+                        PackageAddress::sample().to_string()
+                    ),
+                    span: Span {
+                        start: Position {
+                            full_index: 0,
+                            line_idx: 0,
+                            line_char_index: 0
+                        },
+                        end: Position {
+                            full_index: 0,
+                            line_idx: 0,
+                            line_char_index: 0
+                        }
+                    }
+                }),
                 NetworkID::Simulator
             ),
-            CommonError::InvalidInstructionsWrongNetwork { found_in_instructions: NetworkID::Mainnet, specified_to_instructions_ctor: NetworkID::Simulator }
-        );
-    }
-
-    #[test]
-    fn extract_error_from_error_gen_err_component_addr() {
-        assert_eq!(
-            extract_error_from_error(
-                ScryptoCompileError::GeneratorError(transaction::manifest::generator::GeneratorError::InvalidComponentAddress(ComponentAddress::sample().to_string())),
-                NetworkID::Simulator
-            ),
-            CommonError::InvalidInstructionsWrongNetwork { found_in_instructions: NetworkID::Mainnet, specified_to_instructions_ctor: NetworkID::Simulator }
+            CommonError::InvalidInstructionsWrongNetwork {
+                found_in_instructions: NetworkID::Mainnet,
+                specified_to_instructions_ctor: NetworkID::Simulator
+            }
         );
     }
 
@@ -387,10 +418,29 @@ mod tests {
     fn extract_error_from_error_gen_err_resource_addr() {
         assert_eq!(
             extract_error_from_error(
-                ScryptoCompileError::GeneratorError(transaction::manifest::generator::GeneratorError::InvalidResourceAddress(ResourceAddress::sample().to_string())),
+                ScryptoCompileError::GeneratorError(GeneratorError {
+                    error_kind: GeneratorErrorKind::InvalidResourceAddress(
+                        ResourceAddress::sample().to_string()
+                    ),
+                    span: Span {
+                        start: Position {
+                            full_index: 0,
+                            line_idx: 0,
+                            line_char_index: 0
+                        },
+                        end: Position {
+                            full_index: 0,
+                            line_idx: 0,
+                            line_char_index: 0
+                        }
+                    }
+                }),
                 NetworkID::Simulator
             ),
-            CommonError::InvalidInstructionsWrongNetwork { found_in_instructions: NetworkID::Mainnet, specified_to_instructions_ctor: NetworkID::Simulator }
+            CommonError::InvalidInstructionsWrongNetwork {
+                found_in_instructions: NetworkID::Mainnet,
+                specified_to_instructions_ctor: NetworkID::Simulator
+            }
         );
     }
 

--- a/src/wrapped_radix_engine_toolkit/low_level/transaction_manifest/instructions/instructions.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/transaction_manifest/instructions/instructions.rs
@@ -328,13 +328,25 @@ mod tests {
     fn extract_error_from_error_non_gen_err() {
         assert_eq!(
             extract_error_from_error(
-                ScryptoCompileError::LexerError(
-                    radix_transactions::manifest::lexer::LexerError { error_kind: radix_transactions::manifest::lexer::LexerErrorKind::UnexpectedEof, span: Span { start: Position { full_index: 0, line_idx: 0, line_char_index: 0 }, end: Position { full_index: 0, line_idx: 0, line_char_index: 0 } } }
-                ),
+                ScryptoCompileError::LexerError(LexerError {
+                    error_kind: LexerErrorKind::UnexpectedEof,
+                    span: Span {
+                        start: Position {
+                            full_index: 0,
+                            line_idx: 0,
+                            line_char_index: 0
+                        },
+                        end: Position {
+                            full_index: 0,
+                            line_idx: 0,
+                            line_char_index: 0
+                        }
+                    }
+                }),
                 NetworkID::Simulator
             ),
             CommonError::InvalidInstructionsString {
-                underlying: "LexerError(UnexpectedEof)".to_owned()
+                underlying: "LexerError(LexerError { error_kind: UnexpectedEof, span: Span { start: Position { full_index: 0, line_idx: 0, line_char_index: 0 }, end: Position { full_index: 0, line_idx: 0, line_char_index: 0 } } })".to_owned()
             }
         );
     }

--- a/src/wrapped_radix_engine_toolkit/low_level/transaction_manifest/transaction_manifest.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/transaction_manifest/transaction_manifest.rs
@@ -223,7 +223,7 @@ mod tests {
         ];
         let scrypto = ScryptoTransactionManifest {
             instructions: ins.clone(),
-            blobs: BTreeMap::new(),
+            blobs: Default::default(),
         };
 
         let sut = SUT::with_instructions_and_blobs(

--- a/src/wrapped_radix_engine_toolkit/low_level/transaction_receipt.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/transaction_receipt.rs
@@ -10,7 +10,7 @@ impl TryFrom<BagOfBytes> for TransactionReceipt {
 
     fn try_from(encoded: BagOfBytes) -> Result<Self, Self::Error> {
         Scrypto_scrypto_decode::<ScryptoVersionedTransactionReceipt>(&encoded)
-            .map(|r| r.into_latest())
+            .map(|r| r.fully_update_and_into_latest_version())
             .map_err(|e| {
                 error!("Failed to decode encoded receipt, {:?}", e);
                 CommonError::FailedToDecodeEncodedReceipt


### PR DESCRIPTION
No change in functionality, just updating the version of Scrypto and RET for bottlenose.