### PR TITLE
[CAP-36] Add encrypted profile legacy P2P links check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2586,7 +2586,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "0.7.17"
+version = "0.7.18"
 dependencies = [
  "actix-rt",
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "0.7.17"
+version = "0.7.18"
 edition = "2021"
 build = "build.rs"
 

--- a/apple/Sources/Sargon/Extensions/Methods/Profile/Profile+Wrap+Functions.swift
+++ b/apple/Sources/Sargon/Extensions/Methods/Profile/Profile+Wrap+Functions.swift
@@ -41,5 +41,9 @@ extension Profile {
 
 	public static func checkIfProfileJsonContainsLegacyP2PLinks(contents: some DataProtocol) -> Bool {
 	    checkIfProfileJsonContainsLegacyP2pLinks(json: Data(contents))
-    }
+	}
+
+	public static func checkIfEncryptedProfileJsonContainsLegacyP2PLinks(contents: some DataProtocol, password: String) -> Bool {
+		checkIfEncryptedProfileJsonContainsLegacyP2pLinks(json: Data(contents), password: password)
+	}
 }

--- a/apple/Tests/TestCases/Profile/ProfileTests.swift
+++ b/apple/Tests/TestCases/Profile/ProfileTests.swift
@@ -113,33 +113,29 @@ final class ProfileTests: Test<Profile> {
 
     func test_check_if_profile_json_contains_legacy_p2p_links_when_p2p_links_are_not_present() {
 		eachSample { sut in
-			XCTAssertEqual(
-				SUT.checkIfProfileJsonContainsLegacyP2PLinks(contents: sut.jsonData()),
-				false
+			XCTAssertFalse(
+				SUT.checkIfProfileJsonContainsLegacyP2PLinks(contents: sut.jsonData())
 			)
 		}
     }
 
 	func test_check_if_profile_json_contains_legacy_p2p_links_when_p2p_links_are_present() throws {
 		let json = try openFile(subPath: "vector", "only_plaintext_profile_snapshot_version_100", extension: "json")
-		XCTAssertEqual(
-			SUT.checkIfProfileJsonContainsLegacyP2PLinks(contents: json),
-			true
+		XCTAssert(
+			SUT.checkIfProfileJsonContainsLegacyP2PLinks(contents: json)
 		)
 	}
 
 	func test_check_if_encrypted_profile_json_contains_legacy_p2p_links_when_empty_json() {
-		XCTAssertEqual(
-			SUT.checkIfEncryptedProfileJsonContainsLegacyP2PLinks(contents: Data(), password: "babylon"),
-			false
+		XCTAssertFalse(
+			SUT.checkIfEncryptedProfileJsonContainsLegacyP2PLinks(contents: Data(), password: "babylon")
 		)
 	}
 
 	func test_check_if_encrypted_profile_json_contains_legacy_p2p_links_when_p2p_links_are_present() throws {
 		let json = try openFile(subPath: "vector", "profile_encrypted_by_password_of_babylon", extension: "json")
-		XCTAssertEqual(
-			SUT.checkIfEncryptedProfileJsonContainsLegacyP2PLinks(contents: json, password: "babylon"),
-			true
+		XCTAssert(
+			SUT.checkIfEncryptedProfileJsonContainsLegacyP2PLinks(contents: json, password: "babylon")
 		)
 	}
 }

--- a/apple/Tests/TestCases/Profile/ProfileTests.swift
+++ b/apple/Tests/TestCases/Profile/ProfileTests.swift
@@ -127,4 +127,19 @@ final class ProfileTests: Test<Profile> {
 			true
 		)
 	}
+
+	func test_check_if_encrypted_profile_json_contains_legacy_p2p_links_when_empty_json() {
+		XCTAssertEqual(
+			SUT.checkIfEncryptedProfileJsonContainsLegacyP2PLinks(contents: Data(), password: "babylon"),
+			false
+		)
+	}
+
+	func test_check_if_encrypted_profile_json_contains_legacy_p2p_links_when_p2p_links_are_present() throws {
+		let json = try openFile(subPath: "vector", "profile_encrypted_by_password_of_babylon", extension: "json")
+		XCTAssertEqual(
+			SUT.checkIfEncryptedProfileJsonContainsLegacyP2PLinks(contents: json, password: "babylon"),
+			true
+		)
+	}
 }

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/Profile.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/Profile.kt
@@ -3,6 +3,7 @@ package com.radixdlt.sargon.extensions
 import com.radixdlt.sargon.FactorSource
 import com.radixdlt.sargon.Profile
 import com.radixdlt.sargon.ProfileFileContents
+import com.radixdlt.sargon.checkIfEncryptedProfileJsonContainsLegacyP2pLinks
 import com.radixdlt.sargon.checkIfProfileJsonContainsLegacyP2pLinks
 import com.radixdlt.sargon.newProfile
 import com.radixdlt.sargon.newProfileFromEncryptionBytes
@@ -41,3 +42,6 @@ fun Profile.toEncryptedJson(encryptionPassword: String) =
 
 fun Profile.Companion.checkIfProfileJsonContainsLegacyP2PLinks(jsonString: String) =
     checkIfProfileJsonContainsLegacyP2pLinks(json = bagOfBytes(fromString = jsonString))
+
+fun Profile.Companion.checkIfEncryptedProfileJsonContainsLegacyP2PLinks(jsonString: String, password: String) =
+    checkIfEncryptedProfileJsonContainsLegacyP2pLinks(json = bagOfBytes(fromString = jsonString), password)

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/ProfileTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/ProfileTest.kt
@@ -3,6 +3,7 @@ package com.radixdlt.sargon
 import com.radixdlt.sargon.extensions.analyzeContentsOfFile
 import com.radixdlt.sargon.extensions.asGeneral
 import com.radixdlt.sargon.extensions.bagOfBytes
+import com.radixdlt.sargon.extensions.checkIfEncryptedProfileJsonContainsLegacyP2PLinks
 import com.radixdlt.sargon.extensions.checkIfProfileJsonContainsLegacyP2PLinks
 import com.radixdlt.sargon.extensions.fromEncryptedJson
 import com.radixdlt.sargon.extensions.init
@@ -126,6 +127,23 @@ class ProfileTest : SampleTestable<Profile> {
         assertEquals(
             true,
             Profile.checkIfProfileJsonContainsLegacyP2PLinks(json)
+        )
+    }
+
+    @Test
+    fun testCheckIfEncryptedProfileJsonContainsLegacyP2PLinksWhenEmptyJson() {
+        assertEquals(
+            false,
+            Profile.checkIfEncryptedProfileJsonContainsLegacyP2PLinks("{}", "babylon"),
+        )
+    }
+
+    @Test
+    fun testCheckIfEncryptedProfileJsonContainsLegacyP2PLinksWhenP2PLinksArePresent() {
+        val json = File("../../" + "fixtures/vector/profile_encrypted_by_password_of_babylon.json").readText()
+        assertEquals(
+            true,
+            Profile.checkIfEncryptedProfileJsonContainsLegacyP2PLinks(json, "babylon")
         )
     }
 }

--- a/src/profile/encrypted/encryption/encrypted_profile_snapshot.rs
+++ b/src/profile/encrypted/encryption/encrypted_profile_snapshot.rs
@@ -33,16 +33,23 @@ pub struct EncryptedProfileSnapshot {
 
 impl EncryptedProfileSnapshot {
     pub fn decrypt(&self, password: impl AsRef<str>) -> Result<Profile> {
+        // decrypt Profile JSON bytes
+        let decrypted = self.decrypt_to_bytes(password)?;
+
+        // JSON decode bytes into Profile
+        Profile::new_from_json_bytes(decrypted)
+    }
+
+    pub fn decrypt_to_bytes(
+        &self,
+        password: impl AsRef<str>,
+    ) -> Result<Vec<u8>> {
         // Derive encryption key based on password
         let mut decryption_key = self.key_derivation_scheme.kdf(password);
 
         // decrypt Profile JSON bytes
-        let decrypted = self
-            .encryption_scheme
-            .decrypt(self.encrypted_snapshot.to_vec(), &mut decryption_key)?;
-
-        // JSON decode bytes into Profile
-        Profile::new_from_json_bytes(decrypted)
+        self.encryption_scheme
+            .decrypt(self.encrypted_snapshot.to_vec(), &mut decryption_key)
     }
 
     pub fn encrypting(

--- a/src/profile/v100/profile.rs
+++ b/src/profile/v100/profile.rs
@@ -566,22 +566,16 @@ mod tests {
             }
           }
         "#;
-        assert_eq!(
-            SUT::check_if_profile_json_contains_legacy_p2p_links(
-                json.as_bytes()
-            ),
-            true
-        );
+        assert!(SUT::check_if_profile_json_contains_legacy_p2p_links(
+            json.as_bytes()
+        ));
     }
 
     #[test]
     fn check_if_profile_json_contains_legacy_p2p_links_when_empty_json() {
-        assert_eq!(
-            SUT::check_if_profile_json_contains_legacy_p2p_links(
-                BagOfBytes::new()
-            ),
-            false
-        );
+        assert!(!SUT::check_if_profile_json_contains_legacy_p2p_links(
+            BagOfBytes::new()
+        ));
     }
 
     #[test]
@@ -594,12 +588,9 @@ mod tests {
             }
           }
         "#;
-        assert_eq!(
-            SUT::check_if_profile_json_contains_legacy_p2p_links(
-                json.as_bytes()
-            ),
-            false
-        );
+        assert!(!SUT::check_if_profile_json_contains_legacy_p2p_links(
+            json.as_bytes()
+        ));
     }
 
     #[test]
@@ -609,12 +600,9 @@ mod tests {
             env!("FIXTURES_VECTOR"),
             "only_plaintext_profile_snapshot_version_100.json"
         ));
-        assert_eq!(
-            SUT::check_if_profile_json_contains_legacy_p2p_links(
-                json.as_bytes()
-            ),
-            true
-        );
+        assert!(SUT::check_if_profile_json_contains_legacy_p2p_links(
+            json.as_bytes()
+        ));
     }
 
     #[test]
@@ -623,11 +611,10 @@ mod tests {
         let json =
             serde_json::to_vec(&EncryptedProfileSnapshot::sample()).unwrap();
         let password = "babylon";
-        assert_eq!(
+        assert!(
             SUT::check_if_encrypted_profile_json_contains_legacy_p2p_links(
                 json, password
-            ),
-            true
+            )
         );
     }
 
@@ -635,12 +622,11 @@ mod tests {
     fn check_if_encrypted_profile_json_contains_legacy_p2p_links_when_empty_json(
     ) {
         let password = "babylon";
-        assert_eq!(
-            SUT::check_if_encrypted_profile_json_contains_legacy_p2p_links(
+        assert!(
+            !SUT::check_if_encrypted_profile_json_contains_legacy_p2p_links(
                 BagOfBytes::new(),
                 password
-            ),
-            false
+            )
         );
     }
 

--- a/src/profile/v100/profile_uniffi_fn.rs
+++ b/src/profile/v100/profile_uniffi_fn.rs
@@ -67,6 +67,17 @@ pub fn check_if_profile_json_contains_legacy_p2p_links(
     Profile::check_if_profile_json_contains_legacy_p2p_links(json.to_vec())
 }
 
+#[uniffi::export]
+pub fn check_if_encrypted_profile_json_contains_legacy_p2p_links(
+    json: BagOfBytes,
+    password: String,
+) -> bool {
+    Profile::check_if_encrypted_profile_json_contains_legacy_p2p_links(
+        json.to_vec(),
+        password,
+    )
+}
+
 #[cfg(test)]
 mod uniffi_tests {
 
@@ -183,6 +194,34 @@ mod uniffi_tests {
     fn check_if_profile_json_contains_legacy_p2p_links_when_empty_json() {
         assert_eq!(
             check_if_profile_json_contains_legacy_p2p_links(BagOfBytes::new()),
+            false
+        );
+    }
+
+    #[test]
+    fn check_if_encrypted_profile_json_contains_legacy_p2p_links_when_p2p_links_are_present(
+    ) {
+        let json =
+            serde_json::to_vec(&EncryptedProfileSnapshot::sample()).unwrap();
+        let password = "babylon";
+        assert_eq!(
+            check_if_encrypted_profile_json_contains_legacy_p2p_links(
+                BagOfBytes::from(json),
+                password.to_owned()
+            ),
+            true
+        );
+    }
+
+    #[test]
+    fn check_if_encrypted_profile_json_contains_legacy_p2p_links_when_empty_json(
+    ) {
+        let password = "babylon";
+        assert_eq!(
+            check_if_encrypted_profile_json_contains_legacy_p2p_links(
+                BagOfBytes::new(),
+                password.to_owned()
+            ),
             false
         );
     }

--- a/src/profile/v100/profile_uniffi_fn.rs
+++ b/src/profile/v100/profile_uniffi_fn.rs
@@ -182,20 +182,16 @@ mod uniffi_tests {
             }
           }
         "#;
-        assert_eq!(
-            check_if_profile_json_contains_legacy_p2p_links(BagOfBytes::from(
-                json.as_bytes()
-            )),
-            true
-        );
+        assert!(check_if_profile_json_contains_legacy_p2p_links(
+            BagOfBytes::from(json.as_bytes())
+        ));
     }
 
     #[test]
     fn check_if_profile_json_contains_legacy_p2p_links_when_empty_json() {
-        assert_eq!(
-            check_if_profile_json_contains_legacy_p2p_links(BagOfBytes::new()),
-            false
-        );
+        assert!(!check_if_profile_json_contains_legacy_p2p_links(
+            BagOfBytes::new()
+        ));
     }
 
     #[test]
@@ -204,25 +200,19 @@ mod uniffi_tests {
         let json =
             serde_json::to_vec(&EncryptedProfileSnapshot::sample()).unwrap();
         let password = "babylon";
-        assert_eq!(
-            check_if_encrypted_profile_json_contains_legacy_p2p_links(
-                BagOfBytes::from(json),
-                password.to_owned()
-            ),
-            true
-        );
+        assert!(check_if_encrypted_profile_json_contains_legacy_p2p_links(
+            BagOfBytes::from(json),
+            password.to_owned()
+        ));
     }
 
     #[test]
     fn check_if_encrypted_profile_json_contains_legacy_p2p_links_when_empty_json(
     ) {
         let password = "babylon";
-        assert_eq!(
-            check_if_encrypted_profile_json_contains_legacy_p2p_links(
-                BagOfBytes::new(),
-                password.to_owned()
-            ),
-            false
-        );
+        assert!(!check_if_encrypted_profile_json_contains_legacy_p2p_links(
+            BagOfBytes::new(),
+            password.to_owned()
+        ));
     }
 }

--- a/src/radix_connect/p2p_links/radix_connect_purpose.rs
+++ b/src/radix_connect/p2p_links/radix_connect_purpose.rs
@@ -104,13 +104,13 @@ mod tests {
     #[test]
     fn from_str_default_value_general() {
         let s = "general";
-        assert_eq!(SUT::from_str_default_value(&s), SUT::General);
+        assert_eq!(SUT::from_str_default_value(s), SUT::General);
     }
 
     #[test]
     fn from_str_default_value_unknown() {
         let s = "unknown radix connect purpose kind!";
-        assert_eq!(SUT::from_str_default_value(&s), SUT::Unknown);
+        assert_eq!(SUT::from_str_default_value(s), SUT::Unknown);
     }
 
     #[test]


### PR DESCRIPTION
Adds a new function that checks if an encrypted profile contains legacy P2P links.