### PR TITLE
Use String for JSON coding of Profile (10x speedup)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2586,7 +2586,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "0.7.18"
+version = "0.7.20"
 dependencies = [
  "actix-rt",
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "0.7.18"
+version = "0.7.20"
 edition = "2021"
 build = "build.rs"
 
@@ -80,7 +80,8 @@ radix-rust = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "397a
 ] }
 radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad" }
 radix-common = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad", features = [
-    "serde", "secp256k1_sign_and_validate"
+    "serde",
+    "secp256k1_sign_and_validate",
 ] }
 radix-common-derive = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad" }
 radix-engine-interface = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad" }

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,6 @@ var swiftSettings: [SwiftSetting] = [
 	.enableExperimentalFeature("StrictConcurrency")
 ]
 
-var strictSwiftSettings: [SwiftSetting] = swiftSettings
 
 let sargonBinaryTargetName = "SargonCoreRS"
 let binaryTarget: Target
@@ -19,12 +18,6 @@ if useLocalFramework {
 		// IMPORTANT: Swift packages importing this locally will not be able to
 		// import SargonCore unless you specify this as a relative path!
 		path: "./target/swift/libsargon-rs.xcframework"
-	)
-	
-	// MUST NOT be part of release, since results in compilation error:
-	// The package product 'Sargon' cannot be used as a dependency of this target because it uses unsafe build flags.
-	strictSwiftSettings.append(
-		.unsafeFlags(["-warnings-as-errors"])
 	)
 } else {
 	let releaseTag = "0.1.0"
@@ -75,7 +68,7 @@ let package = Package(
 				.product(name: "CustomDump", package: "swift-custom-dump"),
 			],
 			path: "apple/Tests",
-			swiftSettings: strictSwiftSettings
+			swiftSettings: swiftSettings
 		),
 	]
 )

--- a/apple/Sources/Sargon/Extensions/Methods/Profile/Profile+Wrap+Functions.swift
+++ b/apple/Sources/Sargon/Extensions/Methods/Profile/Profile+Wrap+Functions.swift
@@ -7,9 +7,28 @@ extension Profile {
 		profileAnalyzeContentsOfFile(bytes: Data(contents))
 	}
 	
-	public init(jsonData bytes: some DataProtocol) throws {
+#if DEBUG
+	///
+	internal init(jsonData bytes: some DataProtocol) throws {
 		self = try newProfileFromJsonBytes(jsonBytes: Data(bytes))
 	}
+	internal func profileSnapshot() -> Data {
+		profileToJsonBytes(profile: self)
+	}
+	internal func jsonData() -> Data {
+		profileSnapshot()
+	}
+	
+	#endif
+	
+	internal init(jsonString: String) throws {
+		self = try newProfileFromJsonString(json: jsonString)
+	}
+
+	internal func jsonString(prettyPrint: Bool) -> String {
+		profileToJsonString(profile: self, prettyPrinted: prettyPrint)
+	}
+
 	
 	public init(encrypted bytes: some DataProtocol, decryptionPassword: String) throws {
 		self = try newProfileFromEncryptionBytes(
@@ -26,15 +45,7 @@ extension Profile {
 	public func toDebugString() -> String {
 		profileToDebugString(profile: self)
 	}
-	
-	public func profileSnapshot() -> Data {
-		profileToJsonBytes(profile: self)
-	}
-	
-	public func jsonData() -> Data {
-		profileSnapshot()
-	}
-	
+
 	public func encrypt(password: String) -> Data {
 		profileEncryptWithPassword(profile: self, encryptionPassword: password)
 	}

--- a/apple/Tests/TestCases/Profile/Collection/AccountsTests.swift
+++ b/apple/Tests/TestCases/Profile/Collection/AccountsTests.swift
@@ -1,6 +1,6 @@
 import CustomDump
 import Foundation
-import Sargon
+@testable import Sargon
 import SargonUniFFI
 import XCTest
 import SwiftyJSON

--- a/apple/Tests/TestCases/Profile/Collection/FactorSourcesTests.swift
+++ b/apple/Tests/TestCases/Profile/Collection/FactorSourcesTests.swift
@@ -1,6 +1,6 @@
 import CustomDump
 import Foundation
-import Sargon
+@testable import Sargon
 import SargonUniFFI
 import XCTest
 import SwiftyJSON

--- a/apple/Tests/TestCases/Profile/Factor/DeviceFactorSourceTests.swift
+++ b/apple/Tests/TestCases/Profile/Factor/DeviceFactorSourceTests.swift
@@ -1,6 +1,6 @@
 import CustomDump
 import Foundation
-import Sargon
+@testable import Sargon
 import SargonUniFFI
 import XCTest
 import SwiftyJSON

--- a/apple/Tests/TestCases/Profile/ProfileTests.swift
+++ b/apple/Tests/TestCases/Profile/ProfileTests.swift
@@ -109,6 +109,8 @@ final class ProfileTests: Test<Profile> {
 			XCTAssertEqual(encoded, json)
 			let decoded = try SUT(jsonString: json)
 			XCTAssertEqual(decoded, sut)
+			let decodedFromData = try SUT(jsonData: sut.jsonData())
+			XCTAssertEqual(decodedFromData, sut)
 		}
 		var vectors = Array(zip(SUT.sampleValues, SUT.sampleValues.map { $0.toJSONString(prettyPrinted: false) }))
 		vectors.append(vector)

--- a/apple/Tests/TestCases/Profile/ProfileTests.swift
+++ b/apple/Tests/TestCases/Profile/ProfileTests.swift
@@ -36,6 +36,19 @@ final class ProfileTests: Test<Profile> {
 		)
 		XCTAssertNoDifference(decrypted, sut)
 	}
+	
+	func test_encryption_roundtrip_string() throws {
+		let password = "ultra secret"
+		let sut = SUT.sample
+		let encryptedString = sut.encryptedJsonString(
+			password: password
+		)
+		let decrypted = try Profile(
+			encryptedProfileJSONString: encryptedString,
+			decryptionPassword: password
+		)
+		XCTAssertNoDifference(decrypted, sut)
+	}
 
 	func test_init_with_header_and_dfs() {
 		let header = Header.sampleOther
@@ -48,17 +61,17 @@ final class ProfileTests: Test<Profile> {
 	}
 
 	func test_analyze_file_not_profile() {
-		XCTAssertEqual(SUT.analyzeFile(contents: Data()), .notProfile)
+		XCTAssertEqual(SUT.analyzeContents(data: Data()), .notProfile)
 	}
 
 	func test_analyze_file_profile() {
-		func doTest(_ sut: SUT, _ json: Data) {
+		func doTest(_ sut: SUT, _ jsonString: String) {
 			XCTAssertEqual(
-				SUT.analyzeFile(contents: json),
+				SUT.analyzeContents(of: jsonString),
 				.plaintextProfile(sut)
 			)
 		}
-		var vectors = Array(zip(SUT.sampleValues, SUT.sampleValues.map { $0.jsonData() }))
+		var vectors = Array(zip(SUT.sampleValues, SUT.sampleValues.map { $0.toJSONString() }))
 		vectors.append(vector)
 		
 		vectors.forEach(doTest)
@@ -72,9 +85,9 @@ final class ProfileTests: Test<Profile> {
 		let passwords = ["Mellon", "open sesame", "REINDEER FLOTILLA", "swordfish"]
 		func doTest(_ index: Int, _ sut: SUT) {
 			let password = passwords[index % passwords.count]
-			let encrypted = sut.encrypt(password: password)
+			let encrypted = sut.encryptedJsonString(password: password)
 			XCTAssertEqual(
-				SUT.analyzeFile(contents: encrypted),
+				SUT.analyzeContents(of: encrypted),
 				.encryptedProfile
 			)
 		}
@@ -83,8 +96,7 @@ final class ProfileTests: Test<Profile> {
 	}
 
 	func test_encrypted_profile_contents() throws {
-		let encrypted = SUT.sample.encrypt(password: "open sesame")
-		let jsonString = try XCTUnwrap(String(data: encrypted, encoding: .utf8))
+		let jsonString = SUT.sample.encryptedJsonString(password: "open sesame")
 		XCTAssertTrue(jsonString.contains("encryptionScheme"))
 		XCTAssertTrue(jsonString.contains("keyDerivationScheme"))
 		XCTAssertTrue(jsonString.contains("encryptedSnapshot"))
@@ -93,63 +105,45 @@ final class ProfileTests: Test<Profile> {
 	
 	func test_json_roundtrip() throws {
 		func doTest(_ sut: SUT, _ json: String) throws {
-			let encoded = sut.jsonString(prettyPrint: false)
+			let encoded = sut.toJSONString(prettyPrinted: false)
 			XCTAssertEqual(encoded, json)
 			let decoded = try SUT(jsonString: json)
 			XCTAssertEqual(decoded, sut)
 		}
-		var vectors = Array(zip(SUT.sampleValues, SUT.sampleValues.map { $0.jsonString(prettyPrint: false) }))
-		vectors.append((vector.model, String(data: vector.json, encoding: .utf8)!))
+		var vectors = Array(zip(SUT.sampleValues, SUT.sampleValues.map { $0.toJSONString(prettyPrinted: false) }))
+		vectors.append(vector)
 		try vectors.forEach(doTest)
 	}
 	
-	// Macbook Pro M2: 0.64 seconds
-	func test_performance_json_encoding_data() throws {
-		let (sut, _) = vector
-		measure {
-			let _ = sut.jsonData()
-		}
-	}
 	
 	// Macbook Pro M2: 0.06 (10x speedup vs BagOfBytes)
 	func test_performance_json_encoding_string() throws {
 		let (sut, _) = vector
 		measure {
-			let _ = sut.jsonString(prettyPrint: false)
-		}
-	}
-	
-	// Macbook Pro M2: 0.26 seconds
-	func test_performance_json_decoding_data() throws {
-		let (_, jsonData) = vector
-		measure {
-			let _ = try! SUT(jsonData: jsonData)
+			let _ = sut.toJSONString()
 		}
 	}
 	
 	// Macbook Pro M2: 0.1 (2.5x speedup vs BagOfBytes)
 	func test_performance_json_decoding_string() throws {
-		let (_, _jsonData) = vector
-		let jsonString = String(data: _jsonData, encoding: .utf8)!
+		let (_, jsonString) = vector
 		measure {
 			let _ = try! SUT(jsonString: jsonString)
 		}
 	}
 	
-
-	
-	lazy var vector: (model: Profile, json: Data) = {
-		try! jsonFixture(
+	lazy var vector: (model: Profile, jsonString: String) = {
+		try! jsonString(
 			as: SUT.self,
 			file: "huge_profile_1000_accounts",
-			decode: { try Profile(jsonData: $0) }
+			decode: { try Profile(jsonString: $0) }
 		)
 	}()
 
     func test_check_if_profile_json_contains_legacy_p2p_links_when_p2p_links_are_not_present() {
 		eachSample { sut in
 			XCTAssertFalse(
-				SUT.checkIfProfileJsonContainsLegacyP2PLinks(contents: sut.jsonData())
+				SUT.checkIfProfileJsonStringContainsLegacyP2PLinks(jsonString: sut.toJSONString())
 			)
 		}
     }
@@ -163,7 +157,7 @@ final class ProfileTests: Test<Profile> {
 
 	func test_check_if_encrypted_profile_json_contains_legacy_p2p_links_when_empty_json() {
 		XCTAssertFalse(
-			SUT.checkIfEncryptedProfileJsonContainsLegacyP2PLinks(contents: Data(), password: "babylon")
+			SUT.checkIfEncryptedProfileJsonStringContainsLegacyP2PLinks(jsonString: "", password: "babylon")
 		)
 	}
 
@@ -171,6 +165,14 @@ final class ProfileTests: Test<Profile> {
 		let json = try openFile(subPath: "vector", "profile_encrypted_by_password_of_babylon", extension: "json")
 		XCTAssert(
 			SUT.checkIfEncryptedProfileJsonContainsLegacyP2PLinks(contents: json, password: "babylon")
+		)
+	}
+	
+	func test_check_if_encrypted_profile_json_string_contains_legacy_p2p_links_when_p2p_links_are_present() throws {
+		let json = try openFile(subPath: "vector", "profile_encrypted_by_password_of_babylon", extension: "json")
+		let jsonString = try XCTUnwrap(String(data: json, encoding: .utf8))
+		XCTAssert(
+			SUT.checkIfEncryptedProfileJsonStringContainsLegacyP2PLinks(jsonString: jsonString, password: "babylon")
 		)
 	}
 }

--- a/apple/Tests/Utils/Test.swift
+++ b/apple/Tests/Utils/Test.swift
@@ -42,6 +42,17 @@ class TestCase: XCTestCase {
 		return (model, json)
 	}
 	
+	func jsonString<T>(
+		as: T.Type = T.self,
+		file fileName: String,
+		decode: (String) throws -> T
+	) throws -> (model: T, jsonString: String) {
+		let jsonData = try openFile(subPath: "vector", fileName, extension: "json")
+		let jsonString = try XCTUnwrap(String(data: jsonData, encoding: .utf8))
+		let model: T = try decode(jsonString)
+		return (model, jsonString)
+	}
+	
 }
 
 class Test<SUT_: SargonModel>: TestCase {

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/Profile.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/Profile.kt
@@ -21,27 +21,27 @@ fun Profile.Companion.init(
 )
 
 fun Profile.Companion.analyzeContentsOfFile(contents: String): ProfileFileContents =
-    profileAnalyzeContentsOfFile(bytes = bagOfBytes(fromString = contents))
+    profileAnalyzeContentsOfFile(contents = contents)
 
 @Throws(SargonException::class)
 fun Profile.Companion.fromJson(jsonString: String) =
-    newProfileFromJsonBytes(jsonBytes = bagOfBytes(fromString = jsonString))
+    newProfileFromJsonString(jsonStr = jsonString)
 
 @Throws(SargonException::class)
 fun Profile.Companion.fromEncryptedJson(
     jsonString: String,
     decryptionPassword: String
 ) = newProfileFromEncryptionBytes(
-    json = bagOfBytes(fromString = jsonString),
+    jsonString = jsonString,
     decryptionPassword = decryptionPassword
 )
 
-fun Profile.toJson() = profileToJsonBytes(profile = this).string
+fun Profile.toJson(prettyPrinted: Boolean = true) = profileToJsonString(profile = this, prettyPrinted = prettyPrinted)
 fun Profile.toEncryptedJson(encryptionPassword: String) =
-    profileEncryptWithPassword(profile = this, encryptionPassword = encryptionPassword).string
+    profileEncryptWithPassword(profile = this, encryptionPassword = encryptionPassword)
 
 fun Profile.Companion.checkIfProfileJsonContainsLegacyP2PLinks(jsonString: String) =
-    checkIfProfileJsonContainsLegacyP2pLinks(json = bagOfBytes(fromString = jsonString))
+    checkIfProfileJsonContainsLegacyP2pLinks(jsonStr = jsonString)
 
 fun Profile.Companion.checkIfEncryptedProfileJsonContainsLegacyP2PLinks(jsonString: String, password: String) =
-    checkIfEncryptedProfileJsonContainsLegacyP2pLinks(json = bagOfBytes(fromString = jsonString), password)
+    checkIfEncryptedProfileJsonContainsLegacyP2pLinks(jsonStr = jsonString, password)

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/Profile.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/Profile.kt
@@ -7,10 +7,10 @@ import com.radixdlt.sargon.checkIfEncryptedProfileJsonContainsLegacyP2pLinks
 import com.radixdlt.sargon.checkIfProfileJsonContainsLegacyP2pLinks
 import com.radixdlt.sargon.newProfile
 import com.radixdlt.sargon.newProfileFromEncryptionBytes
-import com.radixdlt.sargon.newProfileFromJsonBytes
+import com.radixdlt.sargon.newProfileFromJsonString
 import com.radixdlt.sargon.profileAnalyzeContentsOfFile
 import com.radixdlt.sargon.profileEncryptWithPassword
-import com.radixdlt.sargon.profileToJsonBytes
+import com.radixdlt.sargon.profileToJsonString
 
 fun Profile.Companion.init(
     deviceFactorSource: FactorSource.Device,

--- a/src/profile/v100/json_data_convertible.rs
+++ b/src/profile/v100/json_data_convertible.rs
@@ -71,7 +71,7 @@ macro_rules! json_data_convertible {
             }
 
             #[cfg(test)]
-            mod [< uniffi_test_ $type:snake >] {
+            mod [< uniffi_test_json_as_data_ $type:snake >] {
                 use super::*;
 
                 #[allow(clippy::upper_case_acronyms)]
@@ -86,7 +86,7 @@ macro_rules! json_data_convertible {
             }
 
             #[cfg(test)]
-            mod [< test_ $type:snake >] {
+            mod [< test_json_as_data_ $type:snake >] {
                 use super::*;
 
                 #[allow(clippy::upper_case_acronyms)]
@@ -139,7 +139,7 @@ macro_rules! json_string_convertible {
             }
 
             #[cfg(test)]
-            mod [< uniffi_test_ $type:snake >] {
+            mod [< uniffi_test_json_as_string_ $type:snake >] {
                 use super::*;
 
                 #[allow(clippy::upper_case_acronyms)]
@@ -154,7 +154,7 @@ macro_rules! json_string_convertible {
             }
 
             #[cfg(test)]
-            mod [< test_ $type:snake >] {
+            mod [< test_json_as_string_ $type:snake >] {
                 use super::*;
 
                 #[allow(clippy::upper_case_acronyms)]

--- a/src/profile/v100/profile.rs
+++ b/src/profile/v100/profile.rs
@@ -48,14 +48,15 @@ pub struct Profile {
 
 impl Profile {
     pub fn analyze_contents_of_file(
-        bytes: impl AsRef<[u8]>,
+        json_string: impl AsRef<str>,
     ) -> ProfileFileContents {
-        let json = bytes.as_ref();
-        if let Ok(profile) = Profile::new_from_json_bytes(json) {
+        let json_string = json_string.as_ref();
+        if let Ok(profile) = Profile::new_from_json_string(json_string) {
             return ProfileFileContents::PlaintextProfile(profile);
         };
 
-        if serde_json::from_slice::<EncryptedProfileSnapshot>(json).is_ok() {
+        if serde_json::from_str::<EncryptedProfileSnapshot>(json_string).is_ok()
+        {
             return ProfileFileContents::EncryptedProfile;
         };
 
@@ -125,25 +126,29 @@ impl Profile {
         }
     }
 
-    pub fn new_from_encryption_bytes(
-        json: impl AsRef<[u8]>,
+    pub fn new_from_encrypted_profile_json_string(
+        json_string: impl AsRef<str>,
         password: impl AsRef<str>,
     ) -> Result<Self> {
-        let json = json.as_ref();
-        serde_json::from_slice::<EncryptedProfileSnapshot>(json)
+        let json_string = json_string.as_ref();
+        let json_byte_count = json_string.len() as u64;
+        serde_json::from_str::<EncryptedProfileSnapshot>(json_string)
 		.map_err(|e| {
 			error!("Failed to deserialize JSON as EncryptedProfileSnapshot, error: {:?}", e);
             CommonError::FailedToDeserializeJSONToValue {
-                json_byte_count: json.len() as u64,
+                json_byte_count,
                 type_name: type_name::<EncryptedProfileSnapshot>(),
             }})
 		    .and_then(|encrypted| encrypted.decrypt(password))
     }
 
-    pub fn to_encryption_bytes(&self, password: impl AsRef<str>) -> Vec<u8> {
+    pub fn to_encrypted_profile_json_str(
+        &self,
+        password: impl AsRef<str>,
+    ) -> String {
         let encrypted =
             EncryptedProfileSnapshot::encrypting(self, password, None, None);
-        serde_json::to_vec(&encrypted).expect(
+        serde_json::to_string(&encrypted).expect(
             "JSON serialization of EncryptedProfileSnapshot should never fail.",
         )
     }
@@ -190,31 +195,49 @@ impl Profile {
     }
 }
 
+impl ProtoProfileMaybeWithLegacyP2PLinks {
+    pub fn contains_legacy_links(&self) -> bool {
+        !self.app_preferences.p2p_links.is_empty()
+    }
+}
+
 impl Profile {
     pub fn check_if_profile_json_contains_legacy_p2p_links(
+        json_str: impl AsRef<str>,
+    ) -> bool {
+        let json_str = json_str.as_ref();
+        serde_json::from_str::<ProtoProfileMaybeWithLegacyP2PLinks>(json_str)
+            .map_or_else(|_| false, |s| s.contains_legacy_links())
+    }
+
+    pub fn check_if_profile_json_bytes_contains_legacy_p2p_links(
         json: impl AsRef<[u8]>,
     ) -> bool {
         let json = json.as_ref();
         serde_json::from_slice::<ProtoProfileMaybeWithLegacyP2PLinks>(json)
-            .map_or_else(|_| false, |s| !s.app_preferences.p2p_links.is_empty())
+            .map_or_else(|_| false, |s| s.contains_legacy_links())
     }
 
     pub fn check_if_encrypted_profile_json_contains_legacy_p2p_links(
-        json: impl AsRef<[u8]>,
+        json_string: impl AsRef<str>,
         password: impl AsRef<str>,
     ) -> bool {
-        let json = json.as_ref();
-        serde_json::from_slice::<EncryptedProfileSnapshot>(json)
+        let json_string = json_string.as_ref();
+        let json_byte_count = json_string.len() as u64;
+        serde_json::from_str::<EncryptedProfileSnapshot>(json_string)
 		.map_err(|e| {
 			error!("Failed to deserialize JSON as EncryptedProfileSnapshot, error: {:?}", e);
             CommonError::FailedToDeserializeJSONToValue {
-                json_byte_count: json.len() as u64,
+                json_byte_count,
                 type_name: type_name::<EncryptedProfileSnapshot>(),
             }})
 		    .and_then(|encrypted| encrypted.decrypt_to_bytes(password))
-			.map_or_else(|_| false, Profile::check_if_profile_json_contains_legacy_p2p_links)
+			.map_or_else(|_| false, Profile::check_if_profile_json_bytes_contains_legacy_p2p_links)
     }
 }
+
+impl JsonDataDeserializing for Profile {}
+impl JsonDataSerializing for Profile {}
 
 impl HasSampleValues for Profile {
     fn sample() -> Self {
@@ -425,22 +448,22 @@ mod tests {
     #[test]
     fn test_analyze_contents_of_file_plaintext_profile() {
         let sut = SUT::sample();
-        let bytes = sut.to_json_bytes();
-        let contents = SUT::analyze_contents_of_file(bytes);
+        let json_str = sut.to_json_string(false);
+        let contents = SUT::analyze_contents_of_file(json_str);
         assert_eq!(contents, ProfileFileContents::PlaintextProfile(sut));
     }
 
     #[test]
     fn test_analyze_contents_of_file_encrypted_profile() {
         let sut = SUT::sample();
-        let bytes = sut.to_encryption_bytes("super secret");
-        let contents = SUT::analyze_contents_of_file(bytes);
+        let json_str = sut.to_encrypted_profile_json_str("super secret");
+        let contents = SUT::analyze_contents_of_file(json_str);
         assert_eq!(contents, ProfileFileContents::EncryptedProfile);
     }
 
     #[test]
     fn test_analyze_contents_of_file_not_profile() {
-        let contents = SUT::analyze_contents_of_file(Exactly32Bytes::sample());
+        let contents = SUT::analyze_contents_of_file("bello");
         assert_eq!(contents, ProfileFileContents::NotProfile);
     }
 
@@ -515,10 +538,12 @@ mod tests {
     }
 
     #[test]
-    fn from_encryption_bytes_valid() {
-        let json =
-            serde_json::to_vec(&EncryptedProfileSnapshot::sample()).unwrap();
-        let sut = SUT::new_from_encryption_bytes(json, "babylon").unwrap();
+    fn from_encrypted_profile_json_str_valid() {
+        let json_str =
+            serde_json::to_string(&EncryptedProfileSnapshot::sample()).unwrap();
+        let sut =
+            SUT::new_from_encrypted_profile_json_string(json_str, "babylon")
+                .unwrap();
         assert_eq!(
             sut.header.id,
             ProfileID::from_str("e5e4477b-e47b-4b64-bbc8-f8f40e8beb74")
@@ -527,14 +552,14 @@ mod tests {
     }
 
     #[test]
-    fn from_encryption_bytes_invalid_is_err() {
+    fn from_encrypted_profile_json_str_invalid_is_err() {
         assert_eq!(
-            SUT::new_from_encryption_bytes(
-                Vec::from_iter([0xde, 0xad, 0xbe, 0xef]),
-                "invalid"
+            SUT::new_from_encrypted_profile_json_string(
+                "We came we saw we kicked its ass!",
+                "Mellon"
             ),
             Err(CommonError::FailedToDeserializeJSONToValue {
-                json_byte_count: 4,
+                json_byte_count: 33,
                 type_name: type_name::<EncryptedProfileSnapshot>()
             })
         );
@@ -544,9 +569,10 @@ mod tests {
     fn encryption_roundtrip() {
         let sut = SUT::sample();
         let password = "super secret";
-        let encryption_bytes = sut.to_encryption_bytes(password);
+        let encrypted = sut.to_encrypted_profile_json_str(password);
         assert_eq!(
-            SUT::new_from_encryption_bytes(encryption_bytes, password).unwrap(),
+            SUT::new_from_encrypted_profile_json_string(encrypted, password)
+                .unwrap(),
             sut
         );
     }
@@ -566,16 +592,12 @@ mod tests {
             }
           }
         "#;
-        assert!(SUT::check_if_profile_json_contains_legacy_p2p_links(
-            json.as_bytes()
-        ));
+        assert!(SUT::check_if_profile_json_contains_legacy_p2p_links(json));
     }
 
     #[test]
-    fn check_if_profile_json_contains_legacy_p2p_links_when_empty_json() {
-        assert!(!SUT::check_if_profile_json_contains_legacy_p2p_links(
-            BagOfBytes::new()
-        ));
+    fn check_if_profile_json_contains_legacy_p2p_links_when_empty_json_str() {
+        assert!(!SUT::check_if_profile_json_contains_legacy_p2p_links(""));
     }
 
     #[test]
@@ -588,9 +610,7 @@ mod tests {
             }
           }
         "#;
-        assert!(!SUT::check_if_profile_json_contains_legacy_p2p_links(
-            json.as_bytes()
-        ));
+        assert!(!SUT::check_if_profile_json_contains_legacy_p2p_links(json));
     }
 
     #[test]
@@ -600,16 +620,14 @@ mod tests {
             env!("FIXTURES_VECTOR"),
             "only_plaintext_profile_snapshot_version_100.json"
         ));
-        assert!(SUT::check_if_profile_json_contains_legacy_p2p_links(
-            json.as_bytes()
-        ));
+        assert!(SUT::check_if_profile_json_contains_legacy_p2p_links(json));
     }
 
     #[test]
     fn check_if_encrypted_profile_json_contains_legacy_p2p_links_when_p2p_links_are_present(
     ) {
         let json =
-            serde_json::to_vec(&EncryptedProfileSnapshot::sample()).unwrap();
+            serde_json::to_string(&EncryptedProfileSnapshot::sample()).unwrap();
         let password = "babylon";
         assert!(
             SUT::check_if_encrypted_profile_json_contains_legacy_p2p_links(
@@ -624,8 +642,7 @@ mod tests {
         let password = "babylon";
         assert!(
             !SUT::check_if_encrypted_profile_json_contains_legacy_p2p_links(
-                BagOfBytes::new(),
-                password
+                "", password
             )
         );
     }

--- a/src/profile/v100/profile_uniffi_fn.rs
+++ b/src/profile/v100/profile_uniffi_fn.rs
@@ -1,15 +1,21 @@
 use crate::prelude::*;
 
-json_data_convertible!(Profile);
-
 #[uniffi::export]
-pub fn new_profile_from_json_string(json: String) -> Result<Profile> {
-    serde_json::from_str(&json).map_err(|_| {
-        CommonError::FailedToDeserializeJSONToValue {
-            json_byte_count: json.len() as u64,
-            type_name: type_name::<Profile>(),
-        }
-    })
+pub fn new_profile_from_json_string(json_str: String) -> Result<Profile> {
+    Profile::new_from_json_string(json_str)
+}
+
+impl Profile {
+    pub fn new_from_json_string(json_str: impl AsRef<str>) -> Result<Profile> {
+        let json_str = json_str.as_ref();
+        let json_byte_count = json_str.len() as u64;
+        serde_json::from_str(json_str).map_err(|_| {
+            CommonError::FailedToDeserializeJSONToValue {
+                json_byte_count,
+                type_name: type_name::<Profile>(),
+            }
+        })
+    }
 }
 
 #[uniffi::export]
@@ -17,12 +23,18 @@ pub fn profile_to_json_string(
     profile: &Profile,
     pretty_printed: bool,
 ) -> String {
-    if pretty_printed {
-        serde_json::to_string_pretty(profile)
-    } else {
-        serde_json::to_string(profile)
+    profile.to_json_string(pretty_printed)
+}
+
+impl Profile {
+    pub fn to_json_string(&self, pretty_printed: bool) -> String {
+        if pretty_printed {
+            serde_json::to_string_pretty(self)
+        } else {
+            serde_json::to_string(self)
+        }
+        .expect("Should always be able to JSON encode Profile.")
     }
-    .expect("Should always be able to JSON encode Profile.")
 }
 
 #[uniffi::export]
@@ -59,18 +71,21 @@ pub fn profile_to_debug_string(profile: &Profile) -> String {
 
 #[uniffi::export]
 pub fn new_profile_from_encryption_bytes(
-    json: BagOfBytes,
+    json_string: String,
     decryption_password: String,
 ) -> Result<Profile> {
-    Profile::new_from_encryption_bytes(json.to_vec(), decryption_password)
+    Profile::new_from_encrypted_profile_json_string(
+        json_string,
+        decryption_password,
+    )
 }
 
 #[uniffi::export]
 pub fn profile_encrypt_with_password(
     profile: &Profile,
     encryption_password: String,
-) -> BagOfBytes {
-    profile.to_encryption_bytes(encryption_password).into()
+) -> String {
+    profile.to_encrypted_profile_json_str(encryption_password)
 }
 
 // ################
@@ -78,26 +93,25 @@ pub fn profile_encrypt_with_password(
 // ################
 #[uniffi::export]
 pub fn profile_analyze_contents_of_file(
-    bytes: BagOfBytes,
+    contents: String,
 ) -> ProfileFileContents {
-    Profile::analyze_contents_of_file(bytes)
+    Profile::analyze_contents_of_file(contents)
 }
 
 #[uniffi::export]
 pub fn check_if_profile_json_contains_legacy_p2p_links(
-    json: BagOfBytes,
+    json_str: String,
 ) -> bool {
-    Profile::check_if_profile_json_contains_legacy_p2p_links(json.to_vec())
+    Profile::check_if_profile_json_contains_legacy_p2p_links(json_str)
 }
 
 #[uniffi::export]
 pub fn check_if_encrypted_profile_json_contains_legacy_p2p_links(
-    json: BagOfBytes,
+    json_str: String,
     password: String,
 ) -> bool {
     Profile::check_if_encrypted_profile_json_contains_legacy_p2p_links(
-        json.to_vec(),
-        password,
+        json_str, password,
     )
 }
 
@@ -118,7 +132,9 @@ mod uniffi_tests {
     #[test]
     fn test_profile_analyze_contents_of_file() {
         assert_eq!(
-            profile_analyze_contents_of_file(BagOfBytes::sample()),
+            profile_analyze_contents_of_file(
+                "ring ring ring ring ring ring, banana phone!".to_owned()
+            ),
             ProfileFileContents::NotProfile
         )
     }
@@ -147,45 +163,12 @@ mod uniffi_tests {
     }
 
     #[test]
-    fn serialize_deserialize() {
-        let sut = SUT::sample();
-
-        assert_eq!(
-            new_profile_from_json_bytes(&profile_to_json_bytes(&sut)).unwrap(),
-            sut
-        )
-    }
-
-    #[test]
-    fn deserialize_malformed() {
-        let malformed_profile_snapshot = BagOfBytes::from("{}".as_bytes());
-        assert_eq!(
-            new_profile_from_json_bytes(&malformed_profile_snapshot),
-            Result::Err(CommonError::FailedToDeserializeJSONToValue {
-                json_byte_count: malformed_profile_snapshot.len() as u64,
-                type_name: String::from("Profile")
-            })
-        );
-    }
-
-    #[test]
-    fn test_new_profile_from_encryption_bytes() {
-        assert!(new_profile_from_encryption_bytes(
-            BagOfBytes::sample(),
-            "invalid".to_string()
-        )
-        .is_err());
-    }
-
-    #[test]
     fn encryption_roundtrip() {
         let sut = SUT::sample();
         let password = "super secret".to_owned();
-        let encryption_bytes =
-            profile_encrypt_with_password(&sut, password.clone());
+        let encrypted = profile_encrypt_with_password(&sut, password.clone());
         assert_eq!(
-            new_profile_from_encryption_bytes(encryption_bytes, password)
-                .unwrap(),
+            new_profile_from_encryption_bytes(encrypted, password).unwrap(),
             sut
         );
     }
@@ -206,14 +189,14 @@ mod uniffi_tests {
           }
         "#;
         assert!(check_if_profile_json_contains_legacy_p2p_links(
-            BagOfBytes::from(json.as_bytes())
+            json.to_owned()
         ));
     }
 
     #[test]
     fn check_if_profile_json_contains_legacy_p2p_links_when_empty_json() {
         assert!(!check_if_profile_json_contains_legacy_p2p_links(
-            BagOfBytes::new()
+            "".to_owned()
         ));
     }
 
@@ -221,10 +204,10 @@ mod uniffi_tests {
     fn check_if_encrypted_profile_json_contains_legacy_p2p_links_when_p2p_links_are_present(
     ) {
         let json =
-            serde_json::to_vec(&EncryptedProfileSnapshot::sample()).unwrap();
+            serde_json::to_string(&EncryptedProfileSnapshot::sample()).unwrap();
         let password = "babylon";
         assert!(check_if_encrypted_profile_json_contains_legacy_p2p_links(
-            BagOfBytes::from(json),
+            json,
             password.to_owned()
         ));
     }
@@ -234,7 +217,7 @@ mod uniffi_tests {
     ) {
         let password = "babylon";
         assert!(!check_if_encrypted_profile_json_contains_legacy_p2p_links(
-            BagOfBytes::new(),
+            "".to_owned(),
             password.to_owned()
         ));
     }
@@ -251,5 +234,16 @@ mod uniffi_tests {
             new_profile_from_json_string(ugly_string.clone()).unwrap();
         assert_eq!(from_str, sut);
         assert_ne!(pretty_string, ugly_string);
+    }
+
+    #[test]
+    fn profile_from_invalid_json_string_throws() {
+        assert_eq!(
+            new_profile_from_json_string("".to_owned()),
+            Err(CommonError::FailedToDeserializeJSONToValue {
+                json_byte_count: 0,
+                type_name: "Profile".to_owned()
+            })
+        )
     }
 }


### PR DESCRIPTION
# JSON String for Profile
I forgot that we perform 2's complement on **every single byte, byte by byte** in BagOfBytes, which is very costly for large data - such as Profile. Therefore, we SHOULD NOT use JSON Data for Profile API's - but rather JSON String. 

We get an immediate 10x speedup in Swift by doing so.

# Performance gain - 10x speedup
The `vector` is [the huge profile with 1000 accounts](https://github.com/radixdlt/sargon/blob/main/fixtures/vector/huge_profile_1000_accounts.json).

```swift
// Macbook Pro M2: 0.64 seconds
func test_performance_json_encoding_data() throws {
	let (sut, _) = vector
	measure {
		let _ = sut.jsonData()
	}
}

// Macbook Pro M2: 0.06 (10x speedup vs BagOfBytes)
func test_performance_json_encoding_string() throws {
	let (sut, _) = vector
	measure {
		let _ = sut.jsonString(prettyPrint: false)
	}
}

// Macbook Pro M2: 0.26 seconds
func test_performance_json_decoding_data() throws {
	let (_, jsonData) = vector
	measure {
		let _ = try! SUT(jsonData: jsonData)
	}
}

// Macbook Pro M2: 0.1 (2.5x speedup vs BagOfBytes)
func test_performance_json_decoding_string() throws {
	let (_, _jsonData) = vector
	let jsonString = String(data: _jsonData, encoding: .utf8)!
	measure {
		let _ = try! SUT(jsonString: jsonString)
	}
}
```

# Base64 - not worth it
I also tried Base64, it does in fact give a 11x speedup instead of 10x speed up for encoding, i.e. a 10% speedup vs Json String - however, for decoding it was 50% slower than using Json String. 

So I figured, maybe Base64 performance increase will be much larger for a 1MB attached blob. So I temporarily added a `blob: Vec<u8>` (avoided `BagOfBytes` for max performance) to Profile root and then generated test vectors (base64 string) for a sample Profile with such a blob of 1MB, and measured performance of that. Then YES using Bas64 is faster for both encoding **and decoding**, but decoding is only 10% faster, so still not worth it.