### PR TITLE
Fix android mnemonic  serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2586,7 +2586,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "actix-rt",
  "aes-gcm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2586,7 +2586,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "0.7.18"
+version = "0.7.19"
 dependencies = [
  "actix-rt",
  "aes-gcm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2586,7 +2586,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "0.7.20"
+version = "1.0.0"
 dependencies = [
  "actix-rt",
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "0.7.18"
+version = "0.7.19"
 edition = "2021"
 build = "build.rs"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 build = "build.rs"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "0.7.20"
+version = "1.0.0"
 edition = "2021"
 build = "build.rs"
 

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/MnemonicWithPassphrase.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/MnemonicWithPassphrase.kt
@@ -77,7 +77,7 @@ fun MnemonicWithPassphrase.sign(
 private data class AndroidMnemonicWithPassphrase(
     @SerialName("mnemonic")
     val phrase: String,
-    @SerialName("Bip39Passphrase")
+    @SerialName("bip39Passphrase")
     val passphrase: String
 ) {
 

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/MnemonicWithPassphraseTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/MnemonicWithPassphraseTest.kt
@@ -41,7 +41,7 @@ class MnemonicWithPassphraseTest {
     @Test
     fun testFromAndroidJson() {
         val androidJsonWithoutPassphrase =
-            """{"mnemonic":"remind index lift gun sleep inner double leopard exist sugar item whisper coast duty leopard law radar neutral odor tape finger position capital track","Bip39Passphrase":""}""".trimIndent()
+            """{"mnemonic":"remind index lift gun sleep inner double leopard exist sugar item whisper coast duty leopard law radar neutral odor tape finger position capital track","bip39Passphrase":""}""".trimIndent()
         assertEquals(
             MnemonicWithPassphrase(
                 mnemonic = Mnemonic.init(phrase = "remind index lift gun sleep inner double leopard exist sugar item whisper coast duty leopard law radar neutral odor tape finger position capital track"),
@@ -52,7 +52,7 @@ class MnemonicWithPassphraseTest {
 
         val androidJsonWithoutPassphrasePrettyPrinted = """{
               "mnemonic": "remind index lift gun sleep inner double leopard exist sugar item whisper coast duty leopard law radar neutral odor tape finger position capital track",
-              "Bip39Passphrase": ""
+              "bip39Passphrase": ""
             }""".trimIndent()
         assertEquals(
             MnemonicWithPassphrase(
@@ -63,7 +63,7 @@ class MnemonicWithPassphraseTest {
         )
 
         val androidJsonWithPassphrase =
-            """{"mnemonic":"remind index lift gun sleep inner double leopard exist sugar item whisper coast duty leopard law radar neutral odor tape finger position capital track","Bip39Passphrase":"super secret"}""".trimIndent()
+            """{"mnemonic":"remind index lift gun sleep inner double leopard exist sugar item whisper coast duty leopard law radar neutral odor tape finger position capital track","bip39Passphrase":"super secret"}""".trimIndent()
         assertEquals(
             MnemonicWithPassphrase(
                 mnemonic = Mnemonic.init(phrase = "remind index lift gun sleep inner double leopard exist sugar item whisper coast duty leopard law radar neutral odor tape finger position capital track"),


### PR DESCRIPTION
It looks like there was a typo in current sargon jvm for backwards compatible android mnemonic.