### PR TITLE
DONT MERGE - 'report' PR | Profile as Object is FAST

### DIFF
--- a/apple/Tests/TestCases/Profile/ProfileTests.swift
+++ b/apple/Tests/TestCases/Profile/ProfileTests.swift
@@ -134,11 +134,44 @@ final class ProfileTests: Test<Profile> {
 		}
 	}
 	
+	// Macbook Pro M2: 0.045
+	func test_performance__OBJECT___json_decoding_string() throws {
+		let (_, jsonString) = vectorObj
+		measure {
+			let _ = try! ProfileObject.newProfileFromJsonString(jsonString: jsonString)
+		}
+	}
+	
+	// Macbook Pro M2: 0.000
+	func test_performance_json__OBJECT__encoding_string() throws {
+		let (sut, _) = vectorObj
+		measure {
+			let _ = sut.toJsonString()
+		}
+	}
+	
+	
+	// Macbook Pro M2: 0.000
+	func test_performance__OBJECT___trivial_quer() throws {
+		let (sut, _) = vectorObj
+		measure {
+			let _ = sut.getNumberOfNetworks()
+		}
+	}
+	
 	lazy var vector: (model: Profile, jsonString: String) = {
 		try! jsonString(
 			as: SUT.self,
 			file: "huge_profile_1000_accounts",
 			decode: { try Profile(jsonString: $0) }
+		)
+	}()
+	
+	lazy var vectorObj: (model: ProfileObject, jsonString: String) = {
+		try! jsonString(
+			as: ProfileObject.self,
+			file: "huge_profile_1000_accounts",
+			decode: { try ProfileObject.newProfileFromJsonString(jsonString: $0) }
 		)
 	}()
 

--- a/src/profile/v100/mod.rs
+++ b/src/profile/v100/mod.rs
@@ -9,6 +9,7 @@ mod networks;
 mod profile;
 mod profile_file_contents;
 mod profile_file_contents_uniffi_fn;
+mod profile_object;
 mod profile_uniffi_fn;
 mod proto_profile_maybe_with_legacy_p2p_links;
 
@@ -23,5 +24,6 @@ pub use networks::*;
 pub use profile::*;
 pub use profile_file_contents::*;
 pub use profile_file_contents_uniffi_fn::*;
+pub use profile_object::*;
 pub use profile_uniffi_fn::*;
 pub use proto_profile_maybe_with_legacy_p2p_links::*;

--- a/src/profile/v100/profile_object.rs
+++ b/src/profile/v100/profile_object.rs
@@ -1,0 +1,945 @@
+use crate::prelude::*;
+
+#[derive(
+    Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash, uniffi::Object,
+)]
+#[serde(rename_all = "camelCase")]
+pub struct ProfileObject {
+    /// The header of a Profile(Snapshot) contains crucial metadata
+    /// about this Profile, such as which JSON data format it is
+    /// compatible with and which device was used to create it and
+    /// a hint about its contents.
+    pub header: Header,
+
+    /// All sources of factors, used for authorization such as spending funds, contains no
+    /// secrets.
+    pub factor_sources: FactorSources,
+
+    /// Settings for this profile in the app, contains default security configs
+    /// as well as display settings.
+    pub app_preferences: AppPreferences,
+
+    /// An ordered mapping of NetworkID -> `Profile.Network`, containing
+    /// all the users Accounts, Personas and AuthorizedDapps the user
+    /// has created and interacted with on this network.
+    pub networks: ProfileNetworks,
+}
+
+impl ProfileObject {
+    pub fn with(
+        header: Header,
+        factor_sources: FactorSources,
+        app_preferences: AppPreferences,
+        networks: ProfileNetworks,
+    ) -> Self {
+        if factor_sources.is_empty() {
+            panic!("FactorSources MUST NOT be empty.")
+        }
+        Self {
+            header,
+            factor_sources,
+            app_preferences,
+            networks,
+        }
+    }
+}
+
+impl HasSampleValues for ProfileObject {
+    fn sample() -> Self {
+        let networks = ProfileNetworks::sample();
+        let mut header = Header::sample();
+        header.content_hint = networks.content_hint();
+        Self::with(
+            header,
+            FactorSources::sample(),
+            AppPreferences::sample(),
+            networks,
+        )
+    }
+
+    fn sample_other() -> Self {
+        let networks = ProfileNetworks::sample_other();
+        let mut header = Header::sample_other();
+        header.content_hint = networks.content_hint();
+        Self::with(
+            header,
+            FactorSources::sample_other(),
+            AppPreferences::sample_other(),
+            networks,
+        )
+    }
+}
+
+#[uniffi::export]
+impl ProfileObject {
+    #[uniffi::constructor]
+    pub fn new_profile_from_json_string(
+        json_string: String,
+    ) -> Result<Arc<Self>> {
+        let profile = serde_json::from_str::<Self>(&json_string)
+            .map_err(|_| CommonError::Unknown)?;
+        Ok(Arc::new(profile))
+    }
+
+    pub fn get_number_of_networks(self: Arc<Self>) -> u8 {
+        self.networks.len() as u8
+    }
+
+    pub fn to_json_string(self: Arc<Self>) -> String {
+        serde_json::to_string(&self).unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[allow(clippy::upper_case_acronyms)]
+    type SUT = ProfileObject;
+
+    #[test]
+    fn inequality() {
+        assert_ne!(SUT::sample(), SUT::sample_other());
+    }
+
+    #[test]
+    fn json_roundtrip_and_record() {
+        let test = |sut: Arc<SUT>, record: Profile| {
+            let json_str = sut.clone().to_json_string();
+            let roundtripped =
+                SUT::new_profile_from_json_string(json_str.clone()).unwrap();
+            assert_eq!(roundtripped, sut.clone());
+
+            let to_record =
+                Profile::new_from_json_string(json_str.clone()).unwrap();
+            assert_eq!(to_record, record);
+            let json_from_record = record.to_json_string(false);
+            assert_eq!(
+                SUT::new_profile_from_json_string(json_from_record).unwrap(),
+                sut
+            );
+        };
+        test(Arc::new(SUT::sample()), Profile::sample());
+        test(Arc::new(SUT::sample_other()), Profile::sample_other());
+    }
+
+    #[test]
+    fn equality() {
+        assert_eq!(SUT::sample(), SUT::sample());
+        assert_eq!(SUT::sample_other(), SUT::sample_other());
+    }
+
+    #[test]
+    fn json_roundtrip() {
+        let sut = SUT::sample();
+        assert_eq_after_json_roundtrip(
+            &sut,
+            r#"
+            {
+				"header": {
+					"snapshotVersion": 100,
+					"id": "12345678-bbbb-cccc-dddd-abcd12345678",
+					"creatingDevice": {
+						"id": "66f07ca2-a9d9-49e5-8152-77aca3d1dd74",
+						"date": "2023-09-11T16:05:56.000Z",
+						"description": "iPhone"
+					},
+					"lastUsedOnDevice": {
+						"id": "66f07ca2-a9d9-49e5-8152-77aca3d1dd74",
+						"date": "2023-09-11T16:05:56.000Z",
+						"description": "iPhone"
+					},
+					"lastModified": "2023-09-11T16:05:56.000Z",
+					"contentHint": {
+						"numberOfAccountsOnAllNetworksInTotal": 4,
+						"numberOfPersonasOnAllNetworksInTotal": 0,
+						"numberOfNetworks": 2
+					}
+				},
+				"factorSources": [
+					{
+						"discriminator": "device",
+						"device": {
+							"id": {
+								"kind": "device",
+								"body": "3c986ebf9dcd9167a97036d3b2c997433e85e6cc4e4422ad89269dac7bfea240"
+							},
+							"common": {
+								"cryptoParameters": {
+									"supportedCurves": [
+										"curve25519"
+									],
+									"supportedDerivationPathSchemes": [
+										"cap26"
+									]
+								},
+								"addedOn": "2023-09-11T16:05:56.000Z",
+								"lastUsedOn": "2023-09-11T16:05:56.000Z",
+								"flags": [
+									"main"
+								]
+							},
+							"hint": {
+								"name": "Unknown Name",
+								"model": "iPhone",
+								"mnemonicWordCount": 24
+							}
+						}
+					},
+					{
+						"discriminator": "ledgerHQHardwareWallet",
+						"ledgerHQHardwareWallet": {
+							"id": {
+								"kind": "ledgerHQHardwareWallet",
+								"body": "3c986ebf9dcd9167a97036d3b2c997433e85e6cc4e4422ad89269dac7bfea240"
+							},
+							"common": {
+								"cryptoParameters": {
+									"supportedCurves": [
+										"curve25519"
+									],
+									"supportedDerivationPathSchemes": [
+										"cap26"
+									]
+								},
+								"addedOn": "2023-09-11T16:05:56.000Z",
+								"lastUsedOn": "2023-09-11T16:05:56.000Z",
+								"flags": [
+									"main"
+								]
+							},
+							"hint": {
+								"name": "Orange, scratched",
+								"model": "nanoS+"
+							}
+						}
+					}
+				],
+				"appPreferences": {
+					"display": {
+						"isCurrencyAmountVisible": true,
+						"fiatCurrencyPriceTarget": "usd"
+					},
+					"gateways": {
+						"current": "https://rcnet-v3.radixdlt.com/",
+						"saved": [
+							{
+								"network": {
+									"name": "zabanet",
+									"id": 14,
+									"displayDescription": "RCnet-V3 (Test Network)"
+								},
+								"url": "https://rcnet-v3.radixdlt.com/"
+							},
+							{
+								"network": {
+									"name": "mainnet",
+									"id": 1,
+									"displayDescription": "Mainnet"
+								},
+								"url": "https://mainnet.radixdlt.com/"
+							},
+							{
+								"network": {
+									"name": "stokenet",
+									"id": 2,
+									"displayDescription": "Stokenet"
+								},
+								"url": "https://babylon-stokenet-gateway.radixdlt.com/"
+							}
+						]
+					},
+					"security": {
+						"isCloudProfileSyncEnabled": true,
+						"isDeveloperModeEnabled": true,
+						"structureConfigurationReferences": []
+					},
+					"transaction": {
+						"defaultDepositGuarantee": "0.975"
+					}
+				},
+				"networks": [
+					{
+						"networkID": 1,
+						"accounts": [
+							{
+								"networkID": 1,
+								"address": "account_rdx12yy8n09a0w907vrjyj4hws2yptrm3rdjv84l9sr24e3w7pk7nuxst8",
+								"displayName": "Alice",
+								"securityState": {
+									"discriminator": "unsecured",
+									"unsecuredEntityControl": {
+										"transactionSigning": {
+											"factorSourceID": {
+												"discriminator": "fromHash",
+												"fromHash": {
+													"kind": "device",
+													"body": "3c986ebf9dcd9167a97036d3b2c997433e85e6cc4e4422ad89269dac7bfea240"
+												}
+											},
+											"badge": {
+												"discriminator": "virtualSource",
+												"virtualSource": {
+													"discriminator": "hierarchicalDeterministicPublicKey",
+													"hierarchicalDeterministicPublicKey": {
+														"publicKey": {
+															"curve": "curve25519",
+															"compressedData": "d24cc6af91c3f103d7f46e5691ce2af9fea7d90cfb89a89d5bba4b513b34be3b"
+														},
+														"derivationPath": {
+															"scheme": "cap26",
+															"path": "m/44H/1022H/1H/525H/1460H/0H"
+														}
+													}
+												}
+											}
+										}
+									}
+								},
+								"appearanceID": 0,
+								"flags": [],
+								"onLedgerSettings": {
+									"thirdPartyDeposits": {
+										"depositRule": "acceptAll",
+										"assetsExceptionList": [],
+										"depositorsAllowList": []
+									}
+								}
+							},
+							{
+								"networkID": 1,
+								"address": "account_rdx129a9wuey40lducsf6yu232zmzk5kscpvnl6fv472r0ja39f3hced69",
+								"displayName": "Bob",
+								"securityState": {
+									"discriminator": "unsecured",
+									"unsecuredEntityControl": {
+										"transactionSigning": {
+											"factorSourceID": {
+												"discriminator": "fromHash",
+												"fromHash": {
+													"kind": "device",
+													"body": "3c986ebf9dcd9167a97036d3b2c997433e85e6cc4e4422ad89269dac7bfea240"
+												}
+											},
+											"badge": {
+												"discriminator": "virtualSource",
+												"virtualSource": {
+													"discriminator": "hierarchicalDeterministicPublicKey",
+													"hierarchicalDeterministicPublicKey": {
+														"publicKey": {
+															"curve": "curve25519",
+															"compressedData": "08740a2fd178c40ce71966a6537f780978f7f00548cfb59196344b5d7d67e9cf"
+														},
+														"derivationPath": {
+															"scheme": "cap26",
+															"path": "m/44H/1022H/1H/525H/1460H/1H"
+														}
+													}
+												}
+											}
+										}
+									}
+								},
+								"appearanceID": 1,
+								"flags": [],
+								"onLedgerSettings": {
+									"thirdPartyDeposits": {
+										"depositRule": "acceptAll",
+										"assetsExceptionList": [],
+										"depositorsAllowList": []
+									}
+								}
+							}
+						],
+						"personas": [
+							{
+								"networkID": 1,
+								"address": "identity_rdx122kttqch0eehzj6f9nkkxcw7msfeg9udurq5u0ysa0e92c59w0mg6x",
+								"displayName": "Satoshi",
+								"securityState": {
+									"discriminator": "unsecured",
+									"unsecuredEntityControl": {
+										"transactionSigning": {
+											"factorSourceID": {
+												"discriminator": "fromHash",
+												"fromHash": {
+													"kind": "device",
+													"body": "3c986ebf9dcd9167a97036d3b2c997433e85e6cc4e4422ad89269dac7bfea240"
+												}
+											},
+											"badge": {
+												"discriminator": "virtualSource",
+												"virtualSource": {
+													"discriminator": "hierarchicalDeterministicPublicKey",
+													"hierarchicalDeterministicPublicKey": {
+														"publicKey": {
+															"curve": "curve25519",
+															"compressedData": "983ab1d3a77dd6b30bb8a5d59d490a0380cc0aa9ab464983d3fc581fcf64543f"
+														},
+														"derivationPath": {
+															"scheme": "cap26",
+															"path": "m/44H/1022H/1H/618H/1460H/0H"
+														}
+													}
+												}
+											}
+										}
+									}
+								},
+								"flags": [],
+								"personaData": {
+									"name": {
+										"id": "00000000-0000-0000-0000-000000000000",
+										"value": {
+											"variant": "eastern",
+											"familyName": "Nakamoto",
+											"givenNames": "Satoshi",
+											"nickname": "Satoshi"
+										}
+									},
+									"phoneNumbers": [
+										{
+											"id": "00000000-0000-0000-0000-000000000001",
+											"value": "+46123456789"
+										},
+										{
+											"id": "00000000-0000-0000-0000-000000000002",
+											"value": "+44987654321"
+										}
+									],
+									"emailAddresses": [
+										{
+											"id": "00000000-0000-0000-0000-000000000003",
+											"value": "sat@os.hi"
+										},
+										{
+											"id": "00000000-0000-0000-0000-000000000004",
+											"value": "satoshi@nakamoto.btc"
+										}
+									]
+								}
+							},
+							{
+								"networkID": 1,
+								"address": "identity_rdx12gcd4r799jpvztlffgw483pqcen98pjnay988n8rmscdswd872xy62",
+								"displayName": "Batman",
+								"securityState": {
+									"discriminator": "unsecured",
+									"unsecuredEntityControl": {
+										"transactionSigning": {
+											"factorSourceID": {
+												"discriminator": "fromHash",
+												"fromHash": {
+													"kind": "device",
+													"body": "3c986ebf9dcd9167a97036d3b2c997433e85e6cc4e4422ad89269dac7bfea240"
+												}
+											},
+											"badge": {
+												"discriminator": "virtualSource",
+												"virtualSource": {
+													"discriminator": "hierarchicalDeterministicPublicKey",
+													"hierarchicalDeterministicPublicKey": {
+														"publicKey": {
+															"curve": "curve25519",
+															"compressedData": "1fe80badc0520334ee339e4010491d417ca3aed0c9621698b10655529f0ee506"
+														},
+														"derivationPath": {
+															"scheme": "cap26",
+															"path": "m/44H/1022H/1H/618H/1460H/1H"
+														}
+													}
+												}
+											}
+										}
+									}
+								},
+								"flags": [],
+								"personaData": {
+									"name": {
+										"id": "00000000-0000-0000-0000-000000000000",
+										"value": {
+											"variant": "western",
+											"familyName": "Wayne",
+											"givenNames": "Bruce",
+											"nickname": "Batman"
+										}
+									},
+									"phoneNumbers": [
+										{
+											"id": "00000000-0000-0000-0000-000000000001",
+											"value": "+1 13 371 337"
+										}
+									],
+									"emailAddresses": [
+										{
+											"id": "00000000-0000-0000-0000-000000000002",
+											"value": "bat@m.an"
+										}
+									]
+								}
+							}
+						],
+						"authorizedDapps": [
+							{
+								"networkID": 1,
+								"dAppDefinitionAddress": "account_rdx12x0xfz2yumu2qsh6yt0v8xjfc7et04vpsz775kc3yd3xvle4w5d5k5",
+								"displayName": "Radix Dashboard",
+								"referencesToAuthorizedPersonas": [
+									{
+										"identityAddress": "identity_rdx122kttqch0eehzj6f9nkkxcw7msfeg9udurq5u0ysa0e92c59w0mg6x",
+										"lastLogin": "2024-01-31T14:23:45.000Z",
+										"sharedAccounts": {
+											"request": {
+												"quantifier": "exactly",
+												"quantity": 2
+											},
+											"ids": [
+												"account_rdx12yy8n09a0w907vrjyj4hws2yptrm3rdjv84l9sr24e3w7pk7nuxst8",
+												"account_rdx129a9wuey40lducsf6yu232zmzk5kscpvnl6fv472r0ja39f3hced69"
+											]
+										},
+										"sharedPersonaData": {
+											"name": "00000000-0000-0000-0000-000000000000",
+											"emailAddresses": {
+												"request": {
+													"quantifier": "exactly",
+													"quantity": 2
+												},
+												"ids": [
+													"00000000-0000-0000-0000-000000000003",
+													"00000000-0000-0000-0000-000000000004"
+												]
+											},
+											"phoneNumbers": {
+												"request": {
+													"quantifier": "exactly",
+													"quantity": 2
+												},
+												"ids": [
+													"00000000-0000-0000-0000-000000000001",
+													"00000000-0000-0000-0000-000000000002"
+												]
+											}
+										}
+									},
+									{
+										"identityAddress": "identity_rdx12gcd4r799jpvztlffgw483pqcen98pjnay988n8rmscdswd872xy62",
+										"lastLogin": "2024-01-31T14:23:45.000Z",
+										"sharedAccounts": {
+											"request": {
+												"quantifier": "atLeast",
+												"quantity": 1
+											},
+											"ids": [
+												"account_rdx129a9wuey40lducsf6yu232zmzk5kscpvnl6fv472r0ja39f3hced69"
+											]
+										},
+										"sharedPersonaData": {
+											"name": "00000000-0000-0000-0000-000000000000",
+											"emailAddresses": {
+												"request": {
+													"quantifier": "exactly",
+													"quantity": 1
+												},
+												"ids": [
+													"00000000-0000-0000-0000-000000000002"
+												]
+											},
+											"phoneNumbers": {
+												"request": {
+													"quantifier": "exactly",
+													"quantity": 1
+												},
+												"ids": [
+													"00000000-0000-0000-0000-000000000001"
+												]
+											}
+										}
+									}
+								]
+							},
+							{
+								"networkID": 1,
+								"dAppDefinitionAddress": "account_rdx12xuhw6v30chdkhcu7qznz9vu926vxefr4h4tdvc0mdckg9rq4afx9t",
+								"displayName": "Gumball Club",
+								"referencesToAuthorizedPersonas": [
+									{
+										"identityAddress": "identity_rdx12gcd4r799jpvztlffgw483pqcen98pjnay988n8rmscdswd872xy62",
+										"lastLogin": "2024-01-31T14:23:45.000Z",
+										"sharedAccounts": {
+											"request": {
+												"quantifier": "atLeast",
+												"quantity": 1
+											},
+											"ids": [
+												"account_rdx129a9wuey40lducsf6yu232zmzk5kscpvnl6fv472r0ja39f3hced69"
+											]
+										},
+										"sharedPersonaData": {
+											"name": "00000000-0000-0000-0000-000000000000",
+											"emailAddresses": {
+												"request": {
+													"quantifier": "exactly",
+													"quantity": 1
+												},
+												"ids": [
+													"00000000-0000-0000-0000-000000000002"
+												]
+											},
+											"phoneNumbers": {
+												"request": {
+													"quantifier": "exactly",
+													"quantity": 1
+												},
+												"ids": [
+													"00000000-0000-0000-0000-000000000001"
+												]
+											}
+										}
+									}
+								]
+							}
+						]
+					},
+					{
+						"networkID": 2,
+						"accounts": [
+							{
+								"networkID": 2,
+								"address": "account_tdx_2_1289zm062j788dwrjefqkfgfeea5tkkdnh8htqhdrzdvjkql4kxceql",
+								"displayName": "Nadia",
+								"securityState": {
+									"discriminator": "unsecured",
+									"unsecuredEntityControl": {
+										"transactionSigning": {
+											"factorSourceID": {
+												"discriminator": "fromHash",
+												"fromHash": {
+													"kind": "device",
+													"body": "3c986ebf9dcd9167a97036d3b2c997433e85e6cc4e4422ad89269dac7bfea240"
+												}
+											},
+											"badge": {
+												"discriminator": "virtualSource",
+												"virtualSource": {
+													"discriminator": "hierarchicalDeterministicPublicKey",
+													"hierarchicalDeterministicPublicKey": {
+														"publicKey": {
+															"curve": "curve25519",
+															"compressedData": "18c7409458a82281711b668f833b0485e8fb58a3ceb8a728882bf6b83d3f06a9"
+														},
+														"derivationPath": {
+															"scheme": "cap26",
+															"path": "m/44H/1022H/2H/525H/1460H/0H"
+														}
+													}
+												}
+											}
+										}
+									}
+								},
+								"appearanceID": 0,
+								"flags": [],
+								"onLedgerSettings": {
+									"thirdPartyDeposits": {
+										"depositRule": "acceptAll",
+										"assetsExceptionList": [],
+										"depositorsAllowList": []
+									}
+								}
+							},
+							{
+								"networkID": 2,
+								"address": "account_tdx_2_129663ef7fj8azge3y6sl73lf9vyqt53ewzlf7ul2l76mg5wyqlqlpr",
+								"displayName": "Olivia",
+								"securityState": {
+									"discriminator": "unsecured",
+									"unsecuredEntityControl": {
+										"transactionSigning": {
+											"factorSourceID": {
+												"discriminator": "fromHash",
+												"fromHash": {
+													"kind": "device",
+													"body": "3c986ebf9dcd9167a97036d3b2c997433e85e6cc4e4422ad89269dac7bfea240"
+												}
+											},
+											"badge": {
+												"discriminator": "virtualSource",
+												"virtualSource": {
+													"discriminator": "hierarchicalDeterministicPublicKey",
+													"hierarchicalDeterministicPublicKey": {
+														"publicKey": {
+															"curve": "curve25519",
+															"compressedData": "26b3fd7f65f01ff8e418a56722fde9cc6fc18dc983e0474e6eb6c1cf3bd44f23"
+														},
+														"derivationPath": {
+															"scheme": "cap26",
+															"path": "m/44H/1022H/2H/525H/1460H/1H"
+														}
+													}
+												}
+											}
+										}
+									}
+								},
+								"appearanceID": 1,
+								"flags": [
+									"deletedByUser"
+								],
+								"onLedgerSettings": {
+									"thirdPartyDeposits": {
+										"depositRule": "acceptAll",
+										"assetsExceptionList": [],
+										"depositorsAllowList": []
+									}
+								}
+							}
+						],
+						"personas": [
+							{
+								"networkID": 2,
+								"address": "identity_tdx_2_12fk6qyu2860xyx2jk7j6ex464ccrnxrve4kpaa8qyxx99y5627ahhc",
+								"displayName": "Skywalker",
+								"securityState": {
+									"discriminator": "unsecured",
+									"unsecuredEntityControl": {
+										"transactionSigning": {
+											"factorSourceID": {
+												"discriminator": "fromHash",
+												"fromHash": {
+													"kind": "device",
+													"body": "3c986ebf9dcd9167a97036d3b2c997433e85e6cc4e4422ad89269dac7bfea240"
+												}
+											},
+											"badge": {
+												"discriminator": "virtualSource",
+												"virtualSource": {
+													"discriminator": "hierarchicalDeterministicPublicKey",
+													"hierarchicalDeterministicPublicKey": {
+														"publicKey": {
+															"curve": "curve25519",
+															"compressedData": "3c4d6f1267485854313c1ed81aea193b8f750cd081e3aa4dea29b93c34ca2261"
+														},
+														"derivationPath": {
+															"scheme": "cap26",
+															"path": "m/44H/1022H/2H/618H/1460H/0H"
+														}
+													}
+												}
+											}
+										}
+									}
+								},
+								"flags": [],
+								"personaData": {
+									"name": {
+										"id": "00000000-0000-0000-0000-000000000000",
+										"value": {
+											"variant": "eastern",
+											"familyName": "Skywalker",
+											"givenNames": "Leia",
+											"nickname": "Princess Leia"
+										}
+									},
+									"phoneNumbers": [
+										{
+											"id": "00000000-0000-0000-0000-000000000001",
+											"value": "+42 3 456 789"
+										}
+									],
+									"emailAddresses": [
+										{
+											"id": "00000000-0000-0000-0000-000000000002",
+											"value": "leia@sky.walker"
+										}
+									]
+								}
+							},
+							{
+								"networkID": 2,
+								"address": "identity_tdx_2_12gr0d9da3jvye7mdrreljyqs35esjyjsl9r8t5v96hq6fq367cln08",
+								"displayName": "Granger",
+								"securityState": {
+									"discriminator": "unsecured",
+									"unsecuredEntityControl": {
+										"transactionSigning": {
+											"factorSourceID": {
+												"discriminator": "fromHash",
+												"fromHash": {
+													"kind": "device",
+													"body": "3c986ebf9dcd9167a97036d3b2c997433e85e6cc4e4422ad89269dac7bfea240"
+												}
+											},
+											"badge": {
+												"discriminator": "virtualSource",
+												"virtualSource": {
+													"discriminator": "hierarchicalDeterministicPublicKey",
+													"hierarchicalDeterministicPublicKey": {
+														"publicKey": {
+															"curve": "curve25519",
+															"compressedData": "b6885032393165d56cce19850c2a3dbb80733d21c78c7314223e9c3a75f64c8d"
+														},
+														"derivationPath": {
+															"scheme": "cap26",
+															"path": "m/44H/1022H/2H/618H/1460H/1H"
+														}
+													}
+												}
+											}
+										}
+									}
+								},
+								"flags": [
+									"deletedByUser"
+								],
+								"personaData": {
+									"name": {
+										"id": "00000000-0000-0000-0000-000000000000",
+										"value": {
+											"variant": "western",
+											"familyName": "Granger",
+											"givenNames": "Hermione",
+											"nickname": "Hermy"
+										}
+									},
+									"phoneNumbers": [
+										{
+											"id": "00000000-0000-0000-0000-000000000001",
+											"value": "+44 123 456 77"
+										}
+									],
+									"emailAddresses": [
+										{
+											"id": "00000000-0000-0000-0000-000000000002",
+											"value": "granger.h@hogwarts.uk.co"
+										}
+									]
+								}
+							}
+						],
+						"authorizedDapps": [
+							{
+								"networkID": 2,
+								"dAppDefinitionAddress": "account_tdx_2_128evrrwfp8gj9240qq0m06ukhwaj2cmejluxxreanzjwq62vmlf8r4",
+								"displayName": "Dev Console",
+								"referencesToAuthorizedPersonas": [
+									{
+										"identityAddress": "identity_tdx_2_12fk6qyu2860xyx2jk7j6ex464ccrnxrve4kpaa8qyxx99y5627ahhc",
+										"lastLogin": "2024-01-31T14:23:45.000Z",
+										"sharedAccounts": {
+											"request": {
+												"quantifier": "exactly",
+												"quantity": 2
+											},
+											"ids": [
+												"account_tdx_2_1289zm062j788dwrjefqkfgfeea5tkkdnh8htqhdrzdvjkql4kxceql",
+												"account_tdx_2_129663ef7fj8azge3y6sl73lf9vyqt53ewzlf7ul2l76mg5wyqlqlpr"
+											]
+										},
+										"sharedPersonaData": {
+											"name": "00000000-0000-0000-0000-000000000000",
+											"emailAddresses": {
+												"request": {
+													"quantifier": "exactly",
+													"quantity": 1
+												},
+												"ids": [
+													"00000000-0000-0000-0000-000000000002"
+												]
+											},
+											"phoneNumbers": {
+												"request": {
+													"quantifier": "exactly",
+													"quantity": 1
+												},
+												"ids": [
+													"00000000-0000-0000-0000-000000000001"
+												]
+											}
+										}
+									},
+									{
+										"identityAddress": "identity_tdx_2_12gr0d9da3jvye7mdrreljyqs35esjyjsl9r8t5v96hq6fq367cln08",
+										"lastLogin": "2024-01-31T14:23:45.000Z",
+										"sharedAccounts": {
+											"request": {
+												"quantifier": "atLeast",
+												"quantity": 1
+											},
+											"ids": [
+												"account_tdx_2_129663ef7fj8azge3y6sl73lf9vyqt53ewzlf7ul2l76mg5wyqlqlpr"
+											]
+										},
+										"sharedPersonaData": {
+											"name": "00000000-0000-0000-0000-000000000000",
+											"emailAddresses": {
+												"request": {
+													"quantifier": "exactly",
+													"quantity": 1
+												},
+												"ids": [
+													"00000000-0000-0000-0000-000000000002"
+												]
+											},
+											"phoneNumbers": {
+												"request": {
+													"quantifier": "exactly",
+													"quantity": 1
+												},
+												"ids": [
+													"00000000-0000-0000-0000-000000000001"
+												]
+											}
+										}
+									}
+								]
+							},
+							{
+								"networkID": 2,
+								"dAppDefinitionAddress": "account_tdx_2_12yf9gd53yfep7a669fv2t3wm7nz9zeezwd04n02a433ker8vza6rhe",
+								"displayName": "Sandbox",
+								"referencesToAuthorizedPersonas": [
+									{
+										"identityAddress": "identity_tdx_2_12gr0d9da3jvye7mdrreljyqs35esjyjsl9r8t5v96hq6fq367cln08",
+										"lastLogin": "2024-01-31T14:23:45.000Z",
+										"sharedAccounts": {
+											"request": {
+												"quantifier": "atLeast",
+												"quantity": 1
+											},
+											"ids": [
+												"account_tdx_2_129663ef7fj8azge3y6sl73lf9vyqt53ewzlf7ul2l76mg5wyqlqlpr"
+											]
+										},
+										"sharedPersonaData": {
+											"name": "00000000-0000-0000-0000-000000000000",
+											"emailAddresses": {
+												"request": {
+													"quantifier": "exactly",
+													"quantity": 1
+												},
+												"ids": [
+													"00000000-0000-0000-0000-000000000002"
+												]
+											},
+											"phoneNumbers": {
+												"request": {
+													"quantifier": "exactly",
+													"quantity": 1
+												},
+												"ids": [
+													"00000000-0000-0000-0000-000000000001"
+												]
+											}
+										}
+									}
+								]
+							}
+						]
+					}
+				]
+			}
+            "#,
+        );
+    }
+}


### PR DESCRIPTION
# Profile as `uniffi::Object` is fast!

If we use `uniffi::Record` on the rust `Profile` struct, we get amazing speedups.

JSON Decoding is more than 2x as fast compared to `uniffi::Record` - `0.045s` for 1000 account large Profile instead of 0.1 seconds.

JSON Encoding is **⚡️INSTANT⚡️** instead of `0.06s` for the same large Profile.

If we call a trivial method `pub fn profile_number_of_networks(profile: Profile) -> u8`, passing the Profile accross the UniFFI boundary, it takes `0.06s` using `uniffi::Record`, but if we use `uniffi::Object` this too is **⚡️INSTANT⚡️**.

# Tests
```swift
// Macbook Pro M2: 0.045s instead of 0.1s | over 2x speedup!
func test_performance__OBJECT___json_decoding_string() throws {
	let (_, jsonString) = vectorObj
	measure {
		let _ = try! ProfileObject.newProfileFromJsonString(jsonString: jsonString)
	}
}

// Macbook Pro M2: 0.000 (Instant! ⚡️)
func test_performance_json__OBJECT__encoding_string() throws {
	let (sut, _) = vectorObj
	measure {
		let _ = sut.toJsonString()
	}
}


// Macbook Pro M2: 0.000 (Instant! ⚡️)
func test_performance__OBJECT___trivial_query() throws {
	let (sut, _) = vectorObj
	measure {
		let _ = sut.getNumberOfNetworks()
	}
}
```