### PR TITLE
Throw err for invalid manifest instead of crash in summary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2163,7 +2163,7 @@ dependencies = [
 [[package]]
 name = "radix-engine-toolkit"
 version = "2.1.0-dev1"
-source = "git+https://github.com/radixdlt/radix-engine-toolkit?rev=429dd3de58c0860ddbb8a83e9b57e65a1c0765d1#429dd3de58c0860ddbb8a83e9b57e65a1c0765d1"
+source = "git+https://github.com/radixdlt/radix-engine-toolkit?rev=c699783b487e9c1eb78847f9093d918d3dbd5e39#c699783b487e9c1eb78847f9093d918d3dbd5e39"
 dependencies = [
  "bech32",
  "cargo_toml 0.15.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2188,7 +2188,7 @@ dependencies = [
 [[package]]
 name = "radix-engine-toolkit-json"
 version = "2.1.0-dev1"
-source = "git+https://github.com/radixdlt/radix-engine-toolkit?rev=429dd3de58c0860ddbb8a83e9b57e65a1c0765d1#429dd3de58c0860ddbb8a83e9b57e65a1c0765d1"
+source = "git+https://github.com/radixdlt/radix-engine-toolkit?rev=c699783b487e9c1eb78847f9093d918d3dbd5e39#c699783b487e9c1eb78847f9093d918d3dbd5e39"
 dependencies = [
  "bech32",
  "indexmap 1.9.3",
@@ -2586,7 +2586,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "actix-rt",
  "aes-gcm",
@@ -2673,7 +2673,7 @@ dependencies = [
 [[package]]
 name = "sbor-json"
 version = "2.1.0-dev1"
-source = "git+https://github.com/radixdlt/radix-engine-toolkit?rev=429dd3de58c0860ddbb8a83e9b57e65a1c0765d1#429dd3de58c0860ddbb8a83e9b57e65a1c0765d1"
+source = "git+https://github.com/radixdlt/radix-engine-toolkit?rev=c699783b487e9c1eb78847f9093d918d3dbd5e39#c699783b487e9c1eb78847f9093d918d3dbd5e39"
 dependencies = [
  "bech32",
  "radix-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 build = "build.rs"
 
@@ -88,8 +88,8 @@ radix-engine-interface = { git = "https://github.com/radixdlt/radixdlt-scrypto",
 
 radix-transactions = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad" }
 
-radix-engine-toolkit-json = { git = "https://github.com/radixdlt/radix-engine-toolkit", rev = "429dd3de58c0860ddbb8a83e9b57e65a1c0765d1" }
-radix-engine-toolkit = { git = "https://github.com/radixdlt/radix-engine-toolkit", rev = "429dd3de58c0860ddbb8a83e9b57e65a1c0765d1" }
+radix-engine-toolkit-json = { git = "https://github.com/radixdlt/radix-engine-toolkit", rev = "c699783b487e9c1eb78847f9093d918d3dbd5e39" }
+radix-engine-toolkit = { git = "https://github.com/radixdlt/radix-engine-toolkit", rev = "c699783b487e9c1eb78847f9093d918d3dbd5e39" }
 
 # enum-iterator = "1.4.1"
 enum-iterator = { git = "https://github.com/stephaneyfx/enum-iterator/", rev = "9d472a1237cfd03b1c7657fdcba74c8070bfb4ea" }

--- a/src/wrapped_radix_engine_toolkit/low_level/transaction_manifest/transaction_manifest.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/transaction_manifest/transaction_manifest.rs
@@ -235,6 +235,40 @@ mod tests {
     }
 
     #[test]
+    fn non_sensical_manifest_does_not_crash() {
+        // We are passing in an account address instead of resource address as argument
+        // to "withdraw", which does not make any sense. In an earlier version of RET
+        // this caused `summary` call to crash. But the PR adding this test bumps RET to
+        // a version which does not crash. Does not hurt to keep this unit test around.
+        let non_sensical = r#"
+CALL_METHOD
+  Address("account_tdx_2_1c90qdw5e3t3tjyd8axt3zg9zezhhhymt2mr8y4l0k2285mfwhczhdt")
+  "withdraw"
+  Address("account_tdx_2_12y0errvzu4caktegxc5v0ug93u5yat9d90k4zdqkcy6n55pt7wlgmq")
+  Decimal("0.01")
+;
+TAKE_FROM_WORKTOP
+  Address("resource_tdx_2_1thqru9whuem5sjltshg4q7vj3e22xfh27u6s9xvwecz4fallqjny90")
+  Decimal("0.01")
+  Bucket("burn")
+;
+
+BURN_RESOURCE
+  Bucket("burn")
+;
+        "#;
+
+        let manifest = TransactionManifest::new(
+            non_sensical,
+            NetworkID::Stokenet,
+            Blobs::default(),
+        )
+        .unwrap();
+        let summary = manifest.summary();
+        assert_eq!(summary.addresses_of_accounts_deposited_into, []);
+    }
+
+    #[test]
     fn new_from_instructions_string() {
         let instructions_str = r#"CALL_METHOD
         Address("account_sim1cyvgx33089ukm2pl97pv4max0x40ruvfy4lt60yvya744cve475w0q")


### PR DESCRIPTION
Bump `RET` to a version where the non sensical manifest does not crash when calling `summary` on it.

```text
CALL_METHOD
  Address("account_tdx_2_1c90qdw5e3t3tjyd8axt3zg9zezhhhymt2mr8y4l0k2285mfwhczhdt")
  "withdraw"
  Address("account_tdx_2_12y0errvzu4caktegxc5v0ug93u5yat9d90k4zdqkcy6n55pt7wlgmq")
  Decimal("0.01")
;
TAKE_FROM_WORKTOP
  Address("resource_tdx_2_1thqru9whuem5sjltshg4q7vj3e22xfh27u6s9xvwecz4fallqjny90")
  Decimal("0.01")
  Bucket("burn")
;
BURN_RESOURCE
  Bucket("burn")
;
```

The above nonsensical manifest crashed when we called `summary` on it, but not now after bumping RET.