### PR TITLE
Add percentage to TransactionGuarantee 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2586,7 +2586,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "actix-rt",
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "1.0.2"
+version = "1.0.3"
 edition = "2021"
 build = "build.rs"
 

--- a/apple/Tests/TestCases/RET/ManifestBuilding/ManifestBuildingTests.swift
+++ b/apple/Tests/TestCases/RET/ManifestBuilding/ManifestBuildingTests.swift
@@ -190,7 +190,8 @@ final class ManifestBuildingTests: Test<TransactionManifest> {
 		var manifest = try rtm("transfer_1to2_multiple_nf_and_f_tokens")
 		
 		let guarantee = TransactionGuarantee(
-			amount: 642,
+			amount: 642, 
+			percentage: 0.9,
 			instructionIndex: 12,
 			resourceAddress: .sampleStokenetXRD,
 			resourceDivisibility: nil

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/TransactionManifestTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/TransactionManifestTest.kt
@@ -517,6 +517,8 @@ class TransactionManifestTest : SampleTestable<TransactionManifest> {
                                                                                 TransactionGuarantee(
                                                                                                 amount =
                                                                                                                 642.toDecimal192(),
+                                                                                                percentage =
+                                                                                                                1.toDecimal192(),
                                                                                                 instructionIndex =
                                                                                                                 12.toULong(),
                                                                                                 resourceAddress =

--- a/src/wrapped_radix_engine_toolkit/high_level/manifest_building/modify_manifest.rs
+++ b/src/wrapped_radix_engine_toolkit/high_level/manifest_building/modify_manifest.rs
@@ -211,6 +211,7 @@ CALL_METHOD
         let index = 2;
         let resource = ResourceAddress::sample_mainnet_candy();
         let added_guaranteed_amount: Decimal = "0.12344".parse().unwrap();
+        let percentage: Decimal = "0.95".parse().unwrap();
         let divisibility = 4;
         let rounded_guaranteed_amount: Decimal = "0.1234".parse().unwrap();
         assert_eq!(
@@ -225,6 +226,7 @@ CALL_METHOD
         .unwrap();
         manifest = manifest.modify_add_guarantees([TransactionGuarantee::new(
             added_guaranteed_amount,
+            percentage,
             index,
             resource,
             divisibility,
@@ -352,6 +354,7 @@ CALL_METHOD
         manifest_eq(
             manifest.modify_add_guarantees([TransactionGuarantee::new(
                 1337,
+                0,
                 1,
                 ResourceAddress::sample(),
                 10,
@@ -389,6 +392,7 @@ CALL_METHOD
         manifest_eq(
             manifest.modify_add_guarantees([TransactionGuarantee::new(
                 1337,
+                0,
                 1,
                 ResourceAddress::sample(),
                 10,
@@ -462,6 +466,7 @@ CALL_METHOD
             manifest.clone().modify_add_guarantees([
                 TransactionGuarantee::new(
                     0,
+                    0,
                     4,
                     ResourceAddress::sample(),
                     None
@@ -484,6 +489,7 @@ CALL_METHOD
                     TransactionGuarantee::new(
                         i,
                         0,
+                        0,
                         ResourceAddress::sample(),
                         None,
                     )
@@ -504,6 +510,7 @@ CALL_METHOD
             modify_manifest_add_guarantees(
                 manifest.clone(),
                 vec![TransactionGuarantee::new(
+                    0,
                     0,
                     5,
                     ResourceAddress::sample(),

--- a/src/wrapped_radix_engine_toolkit/high_level/ret_api.rs
+++ b/src/wrapped_radix_engine_toolkit/high_level/ret_api.rs
@@ -401,6 +401,7 @@ mod tests {
                 vec![TransactionGuarantee::new(
                     0,
                     0,
+                    0,
                     ResourceAddress::sample(),
                     None,
                 )],

--- a/src/wrapped_radix_engine_toolkit/high_level/sargon_specific_types/transaction_guarantee.rs
+++ b/src/wrapped_radix_engine_toolkit/high_level/sargon_specific_types/transaction_guarantee.rs
@@ -2,7 +2,11 @@ use crate::prelude::*;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, uniffi::Record)]
 pub struct TransactionGuarantee {
+    /// The guaranteed amount to be obtained on this transaction. For manifest & display purposes.
     pub amount: Decimal192,
+
+    /// The percentage the user has selected, which generated the `amount`. For display purposes only.
+    pub percentage: Decimal192,
     pub instruction_index: u64,
     pub resource_address: ResourceAddress,
     pub resource_divisibility: Option<u8>,
@@ -11,12 +15,14 @@ pub struct TransactionGuarantee {
 impl TransactionGuarantee {
     pub fn new(
         amount: impl Into<Decimal192>,
+        percentage: impl Into<Decimal192>,
         instruction_index: u64,
         resource_address: ResourceAddress,
         resource_divisibility: impl Into<Option<u8>>,
     ) -> Self {
         Self {
             amount: amount.into(),
+            percentage: percentage.into(),
             instruction_index,
             resource_address,
             resource_divisibility: resource_divisibility.into(),
@@ -32,11 +38,23 @@ impl TransactionGuarantee {
 
 impl HasSampleValues for TransactionGuarantee {
     fn sample() -> Self {
-        TransactionGuarantee::new(1337, 3, ResourceAddress::sample(), Some(12))
+        TransactionGuarantee::new(
+            1337,
+            "0.95".parse::<Decimal192>().unwrap(),
+            3,
+            ResourceAddress::sample(),
+            Some(12),
+        )
     }
 
     fn sample_other() -> Self {
-        TransactionGuarantee::new(42, 12, ResourceAddress::sample_other(), None)
+        TransactionGuarantee::new(
+            42,
+            "0.90".parse::<Decimal192>().unwrap(),
+            12,
+            ResourceAddress::sample_other(),
+            None,
+        )
     }
 }
 
@@ -60,8 +78,13 @@ mod tests {
 
     #[test]
     fn rounding() {
-        let sut =
-            SUT::new("0.12344", 2, ResourceAddress::sample_mainnet_candy(), 4);
+        let sut = SUT::new(
+            "0.12344",
+            90,
+            2,
+            ResourceAddress::sample_mainnet_candy(),
+            4,
+        );
 
         assert_eq!(sut.rounded_amount(), "0.1234".into());
     }


### PR DESCRIPTION
## Rationale
The `TransactionGuarantee` holds the `amount` that we guarantee as minimum for a transaction. Such value is calculated from the `total` * `percentage`, where the latter comes from user default preferences or a specific value selected for this transaction. 

After a `TransactionGuarantee` has been saved, user could want to edit the percentage selected. Up until now, this value was shown by doing the reverse calculation (`percentage` = `amount` / `total`). However, this would lead to different values than the original user input on certain cases. 

For example, let's say we have a transaction of `20 CANDY`, an asset that has 0 divisibility. If the user sets a percentage of `92%`, the `amount` will be set to `18` (since 18.4 isn't possible for this asset). However, if the user opens the view to edit this guarantee, it would indicate that the percentage is 90% (`18/20 = 0.9`).

The solution then is to keep the user's preference value, so that they get a better UX and doesn't look as we are modifying their selection.

## Related issues
[ABW-3195](https://radixdlt.atlassian.net/browse/ABW-3195)

[ABW-3195]: https://radixdlt.atlassian.net/browse/ABW-3195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ