### PR TITLE
fix third party deposit manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2586,7 +2586,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "actix-rt",
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "1.0.3"
+version = "1.0.4"
 edition = "2021"
 build = "build.rs"
 

--- a/src/wrapped_radix_engine_toolkit/high_level/manifest_building/third_party_deposit_update/manifest_third_party_deposit_update.rs
+++ b/src/wrapped_radix_engine_toolkit/high_level/manifest_building/third_party_deposit_update/manifest_third_party_deposit_update.rs
@@ -75,6 +75,34 @@ mod tests {
     type SUT = TransactionManifest;
 
     #[test]
+    fn test_remove_depositor() {
+        let owner = AccountAddress::sample();
+        let manifest = SUT::third_party_deposit_update_by_delta(
+            &owner,
+            ThirdPartyDepositsDelta::sample(),
+        );
+        manifest_eq(
+            manifest,
+            r#"
+CALL_METHOD
+    Address("account_rdx128y6j78mt0aqv6372evz28hrxp8mn06ccddkr7xppc88hyvynvjdwr")
+    "set_default_deposit_rule"
+    Enum<1u8>()
+;
+CALL_METHOD
+    Address("account_rdx128y6j78mt0aqv6372evz28hrxp8mn06ccddkr7xppc88hyvynvjdwr")
+    "remove_resource_preference"
+    Address("resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd")
+;
+CALL_METHOD
+    Address("account_rdx128y6j78mt0aqv6372evz28hrxp8mn06ccddkr7xppc88hyvynvjdwr")
+    "remove_authorized_depositor"
+    Address("resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd")
+;"#,
+        );
+    }
+
+    #[test]
     fn update_third_party_deposits() {
         let owner:AccountAddress = "account_tdx_2_128x8q5es2dstqtcc8wqm843xdtfs0lgetfcdn62a54wxspj6yhpxkf".into();
         let to_json = r#"

--- a/src/wrapped_radix_engine_toolkit/high_level/manifest_building/third_party_deposit_update/manifest_third_party_deposit_update.rs
+++ b/src/wrapped_radix_engine_toolkit/high_level/manifest_building/third_party_deposit_update/manifest_third_party_deposit_update.rs
@@ -97,7 +97,9 @@ CALL_METHOD
 CALL_METHOD
     Address("account_rdx128y6j78mt0aqv6372evz28hrxp8mn06ccddkr7xppc88hyvynvjdwr")
     "remove_authorized_depositor"
-    Address("resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd")
+    Enum<1u8>(
+        Address("resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd")
+    )
 ;"#,
         );
     }

--- a/src/wrapped_radix_engine_toolkit/high_level/manifest_building/third_party_deposit_update/third_party_deposits_delta.rs
+++ b/src/wrapped_radix_engine_toolkit/high_level/manifest_building/third_party_deposit_update/third_party_deposits_delta.rs
@@ -2,6 +2,7 @@ use crate::prelude::*;
 
 use radix_engine_interface::blueprints::account::{
     AccountAddAuthorizedDepositorInput as ScryptoAccountAddAuthorizedDepositorInput,
+    AccountRemoveAuthorizedDepositorInput as ScryptoAccountRemoveAuthorizedDepositorInput,
     AccountRemoveResourcePreferenceInput as ScryptoAccountRemoveResourcePreferenceInput,
     AccountSetResourcePreferenceInput as ScryptoAccountSetResourcePreferenceInput,
 };
@@ -13,7 +14,7 @@ pub struct ThirdPartyDepositsDelta {
     pub(crate) asset_exceptions_to_add_or_update:
         Vec<ScryptoAccountSetResourcePreferenceInput>,
     pub(crate) depositor_addresses_to_remove:
-        Vec<ScryptoAccountRemoveResourcePreferenceInput>,
+        Vec<ScryptoAccountRemoveAuthorizedDepositorInput>,
     pub(crate) depositor_addresses_to_add:
         Vec<ScryptoAccountAddAuthorizedDepositorInput>,
 }
@@ -69,7 +70,7 @@ impl ThirdPartyDepositsDelta {
                         .into_iter()
                         .contains(x)
                 })
-                .map(ScryptoAccountRemoveResourcePreferenceInput::from)
+                .map(ScryptoAccountRemoveAuthorizedDepositorInput::from)
                 .collect(),
             depositor_addresses_to_add: to
                 .depositors_allow_list
@@ -90,9 +91,18 @@ impl ThirdPartyDepositsDelta {
     }
 }
 
+impl From<ResourceOrNonFungible>
+    for ScryptoAccountRemoveAuthorizedDepositorInput
+{
+    fn from(value: ResourceOrNonFungible) -> Self {
+        Self {
+            badge: value.into(),
+        }
+    }
+}
 impl From<ResourceOrNonFungible> for ScryptoAccountAddAuthorizedDepositorInput {
     fn from(value: ResourceOrNonFungible) -> Self {
-        ScryptoAccountAddAuthorizedDepositorInput {
+        Self {
             badge: value.into(),
         }
     }
@@ -395,7 +405,7 @@ mod tests {
             depositor_addresses
                 .clone()
                 .into_iter()
-                .map(ScryptoAccountRemoveResourcePreferenceInput::from)
+                .map(ScryptoAccountRemoveAuthorizedDepositorInput::from)
                 .collect_vec()
         );
     }
@@ -440,7 +450,7 @@ mod tests {
             expected_depositor_addresses_to_remove
                 .clone()
                 .into_iter()
-                .map(ScryptoAccountRemoveResourcePreferenceInput::from)
+                .map(ScryptoAccountRemoveAuthorizedDepositorInput::from)
                 .collect_vec()
         );
     }


### PR DESCRIPTION
Fix bug present in Production, user is unable to update Third Party Deposit settings by removing `depositor`. 

This fixes that.