### PR TITLE
Implement device info serde in Kotlin

### DIFF
--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/DeviceInfo.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/DeviceInfo.kt
@@ -1,0 +1,61 @@
+package com.radixdlt.sargon.extensions
+
+import android.content.Context
+import android.os.Build
+import android.provider.Settings
+import com.radixdlt.sargon.DeviceInfo
+import com.radixdlt.sargon.Timestamp
+import com.radixdlt.sargon.annotation.KoverIgnore
+import com.radixdlt.sargon.deviceInfoToJsonBytes
+import com.radixdlt.sargon.newDeviceInfoFromJsonBytes
+import java.util.Locale
+import java.util.UUID
+
+@KoverIgnore
+fun DeviceInfo.Companion.generate(context: Context) = DeviceInfo(
+    id = UUID.randomUUID(),
+    date = Timestamp.now(),
+    description = DeviceDescription(context).description
+)
+
+fun DeviceInfo.Companion.fromJson(json: String) = newDeviceInfoFromJsonBytes(
+    jsonBytes = bagOfBytes(fromString = json)
+)
+
+fun DeviceInfo.toJson() = deviceInfoToJsonBytes(deviceInfo = this).string
+
+@KoverIgnore
+class DeviceDescription private constructor(
+    val name: String,
+    val manufacturer: String,
+    val model: String
+) {
+
+    constructor(context: Context) : this(
+        name = Settings.Global.getString(
+            context.contentResolver,
+            Settings.Global.DEVICE_NAME
+        ).orEmpty(),
+        manufacturer = Build.MANUFACTURER.replaceFirstChar {
+            if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString()
+        },
+        model = Build.MODEL.replaceFirstChar {
+            if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString()
+        }
+    )
+
+    private val commercialName: String
+        get() = if (model.startsWith(manufacturer)) {
+            model
+        } else {
+            "$manufacturer $model"
+        }
+
+    val description: String
+        get() = if (name.isBlank()) {
+            commercialName
+        } else {
+            "$name $commercialName"
+        }
+
+}

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/DeviceInfoSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/DeviceInfoSample.kt
@@ -1,0 +1,23 @@
+package com.radixdlt.sargon.samples
+
+import com.radixdlt.sargon.DeviceInfo
+import com.radixdlt.sargon.Timestamp
+import com.radixdlt.sargon.annotation.UsesSampleValues
+import java.util.UUID
+
+@UsesSampleValues
+val DeviceInfo.Companion.sample: Sample<DeviceInfo>
+    get() = object : Sample<DeviceInfo> {
+        override fun invoke(): DeviceInfo = DeviceInfo(
+            id = UUID.fromString("6b3b43cd-135f-418b-9673-aef82cd016b5"),
+            date = Timestamp.parse("2024-05-28T15:01:49.067Z"),
+            description = "Michael's Google Pixel 8 XL",
+        )
+
+        override fun other(): DeviceInfo = DeviceInfo(
+            id = UUID.fromString("2b8d3513-7e77-4a5a-b486-68877042c57e"),
+            date = Timestamp.parse("2024-05-28T15:02:32.324Z"),
+            description = "Michael's Google Pixel 5",
+        )
+
+    }

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/DeviceInfoTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/DeviceInfoTest.kt
@@ -1,0 +1,20 @@
+package com.radixdlt.sargon
+
+import com.radixdlt.sargon.extensions.fromJson
+import com.radixdlt.sargon.extensions.toJson
+import com.radixdlt.sargon.samples.Sample
+import com.radixdlt.sargon.samples.sample
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class DeviceInfoTest: SampleTestable<DeviceInfo> {
+    override val samples: List<Sample<DeviceInfo>>
+        get() = listOf(DeviceInfo.sample)
+
+    @Test
+    fun testJsonRoundtrip() {
+        val device = DeviceInfo.sample()
+
+        assertEquals(device, DeviceInfo.fromJson(device.toJson()))
+    }
+}


### PR DESCRIPTION
This PR also exports in Sargon the `DeviceDescription` (previously known as DeviceInfo on Android).