### PR TITLE
just bump to 1.0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2586,7 +2586,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.0.4"
+version = "1.0.6"
 dependencies = [
  "actix-rt",
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "1.0.4"
+version = "1.0.6"
 edition = "2021"
 build = "build.rs"
 


### PR DESCRIPTION
something got messed up with sargon release versions. main branch has 1.0.4 version in toml, but last release tag is 1.0.5 and last merge to main did not result in an iOS release....