### PR TITLE
Add 'regenerate' argument to build and test gradle tasks 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2586,7 +2586,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.0.8"
+version = "1.0.9"
 dependencies = [
  "actix-rt",
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "1.0.8"
+version = "1.0.9"
 edition = "2021"
 build = "build.rs"
 

--- a/jvm/sargon-android/build.gradle.kts
+++ b/jvm/sargon-android/build.gradle.kts
@@ -157,6 +157,12 @@ android.libraryVariants.all {
         "generate${buildTypeUpper}UniFFIBindings",
         Exec::class
     ) {
+        val rebuild = properties["rebuild"] ?: true
+        
+        onlyIf {
+            rebuild == true || !File("${buildDir}/generated/src/${buildType}/java").exists()
+        }
+
         group = BasePlugin.BUILD_GROUP
 
         workingDir = rootDir.parentFile

--- a/jvm/sargon-android/build.gradle.kts
+++ b/jvm/sargon-android/build.gradle.kts
@@ -157,10 +157,10 @@ android.libraryVariants.all {
         "generate${buildTypeUpper}UniFFIBindings",
         Exec::class
     ) {
-        val rebuild = properties["regenerate"] ?: true
+        val regenerate = properties["regenerate"] ?: true //TODO improve by using gradle outputs
 
         onlyIf {
-            rebuild == true || !File("${buildDir}/generated/src/${buildType}/java").exists()
+            regenerate == true || !File("${buildDir}/generated/src/${buildType}/java").exists()
         }
 
         group = BasePlugin.BUILD_GROUP

--- a/jvm/sargon-android/build.gradle.kts
+++ b/jvm/sargon-android/build.gradle.kts
@@ -157,8 +157,8 @@ android.libraryVariants.all {
         "generate${buildTypeUpper}UniFFIBindings",
         Exec::class
     ) {
-        val rebuild = properties["rebuild"] ?: true
-        
+        val rebuild = properties["regenerate"] ?: true
+
         onlyIf {
             rebuild == true || !File("${buildDir}/generated/src/${buildType}/java").exists()
         }


### PR DESCRIPTION
This is an attempt to improve consecutive builds time by adding `regenerate` boolean argument to build gradle tasks. If you don't pass any arg to the gradle task, it will follow the same steps as before (generating uniffi bindings which takes long and re-run even if there are no changes in rust), but if passing `regenerate=false` to gradle task, it skips this step entirely and rely upon previously generated bindings:

`./jvm/gradlew -p jvm/sargon-android testDebugUnitTest -Pregenerate=false`