### PR TITLE
Truncate Decimal192 fractional part when it has more than 18 decimals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2586,7 +2586,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.0.9"
+version = "1.0.10"
 dependencies = [
  "actix-rt",
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "1.0.9"
+version = "1.0.10"
 edition = "2021"
 build = "build.rs"
 

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/Decimal192Test.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/Decimal192Test.kt
@@ -147,9 +147,7 @@ class Decimal192Test : SampleTestable<Decimal192> {
             Float.MAX_VALUE.toBigDecimal().toPlainString(),
             Float.MAX_VALUE.toDecimal192().plainString()
         )
-        assertThrows<CommonException.DecimalOverflow> {
-            Float.MIN_VALUE.toDecimal192()
-        }
+        assertEquals(0.toDecimal192().string, Float.MIN_VALUE.toDecimal192().string)
     }
 
     @Test
@@ -163,7 +161,7 @@ class Decimal192Test : SampleTestable<Decimal192> {
         assertNull(Double.MAX_VALUE.toDecimal192OrNull())
         assertNotNull(10.0.toDecimal192OrNull())
 
-        assertNull(Float.MIN_VALUE.toDecimal192OrNull())
+        assertNotNull(Float.MIN_VALUE.toDecimal192OrNull())
         assertNotNull(3.14f.toDecimal192OrNull())
 
         assertNull(Float.MIN_VALUE.toString().toDecimal192OrNull())

--- a/src/core/types/decimal192.rs
+++ b/src/core/types/decimal192.rs
@@ -147,7 +147,7 @@ impl From<f32> for Decimal {
     ///
     /// assert!(Decimal::from(208050.17).to_string() == "208050.17");
     ///
-    /// assert!(Decimal::from(f32::MIN_POSITIVE) == "0");
+    /// assert!(Decimal::from(f32::MIN_POSITIVE).to_string() == "0");
     ///
     /// ```
     fn from(value: f32) -> Self {

--- a/src/core/types/decimal192.rs
+++ b/src/core/types/decimal192.rs
@@ -1248,6 +1248,17 @@ mod test_decimal {
     }
 
     #[test]
+    fn from_str_more_than_18_decimals_is_ok() {
+        assert_eq!(
+            "4.012345678901234567890"
+                .parse::<Decimal192>()
+                .unwrap()
+                .to_string(),
+            "4.012345678901234567"
+        ); // Over 18 decimals is OK (precision lost)
+    }
+
+    #[test]
     fn from_more_than_one_decimal_point_with_more_than_18_decimals_string() {
         assert_eq!(
             "4.0123456789012345678.123".parse::<Decimal192>(),

--- a/src/core/types/decimal192.rs
+++ b/src/core/types/decimal192.rs
@@ -157,10 +157,7 @@ impl TryFrom<f32> for Decimal {
     ///
     /// assert!(Decimal::try_from(208050.17).is_ok());
     ///
-    /// assert_eq!(
-    ///     Decimal::try_from(f32::MIN_POSITIVE),
-    ///     Err(CommonError::DecimalOverflow { bad_value: f32::MIN_POSITIVE.to_string() })
-    /// );
+    /// assert!(Decimal::try_from(f32::MIN_POSITIVE).is_ok());
     /// ```
     fn try_from(value: f32) -> Result<Self, Self::Error> {
         let str_value = value.to_string();
@@ -181,10 +178,7 @@ impl TryFrom<f64> for Decimal {
     ///
     /// assert!(Decimal::try_from(208050.17).is_ok());
     ///
-    /// assert_eq!(
-    ///     Decimal::try_from(f64::MIN_POSITIVE),
-    ///     Err(CommonError::DecimalOverflow { bad_value: f64::MIN_POSITIVE.to_string() })
-    /// );
+    /// assert!(Decimal::try_from(f64::MIN_POSITIVE).is_ok());
     /// ```
     fn try_from(value: f64) -> Result<Self, Self::Error> {
         let str_value = value.to_string();

--- a/src/core/types/decimal192.rs
+++ b/src/core/types/decimal192.rs
@@ -93,16 +93,8 @@ impl Decimal192 {
     fn from_str_by_truncating(s: impl AsRef<str>) -> Result<Self> {
         let str_value = s.as_ref();
         let parts: Vec<&str> = str_value.split('.').collect();
-        let processed_s = if parts.len() == 2 {
-            let fractional_part = parts[1];
-            if fractional_part.len() > 18 {
-                format!("{}.{}", parts[0], &fractional_part[..18])
-            } else {
-                str_value.to_string()
-            }
-        } else {
-            str_value.to_string()
-        };
+        let fractional_part = parts[1];
+        let processed_s = format!("{}.{}", parts[0], &fractional_part[..18]);
 
         processed_s
             .parse::<ScryptoDecimal192>()
@@ -1253,6 +1245,14 @@ mod test_decimal {
         test(123456789.87654321, "123456790");
         test(4.012_346, "4.012346"); // precision lost
         test(4.012_346, "4.012346"); // Over 18 decimals is OK (precision lost)
+    }
+
+    #[test]
+    fn from_more_than_one_decimal_point_with_more_than_18_decimals_string() {
+        assert_eq!(
+            "4.0123456789012345678.123".parse::<Decimal192>(),
+            Err(CommonError::DecimalError)
+        );
     }
 
     #[test]

--- a/src/core/types/decimal192_uniffi_fn.rs
+++ b/src/core/types/decimal192_uniffi_fn.rs
@@ -485,12 +485,7 @@ mod uniffi_tests {
             SUT::try_from(f32::MAX).unwrap().to_string(),
             "340282350000000000000000000000000000000"
         );
-        assert_eq!(
-            SUT::try_from(f32::MIN_POSITIVE),
-            Err(CommonError::DecimalOverflow {
-                bad_value: f32::MIN_POSITIVE.to_string()
-            })
-        );
+        assert_eq!(SUT::try_from(f32::MIN_POSITIVE).unwrap().to_string(), "0");
     }
 
     #[test]
@@ -504,10 +499,8 @@ mod uniffi_tests {
             "340282346638528860000000000000000000000"
         );
         assert_eq!(
-            SUT::try_from(f32::MIN_POSITIVE as f64),
-            Err(CommonError::DecimalOverflow {
-                bad_value: (f32::MIN_POSITIVE as f64).to_string()
-            })
+            SUT::try_from(f32::MIN_POSITIVE as f64).unwrap().to_string(),
+            "0"
         );
     }
 

--- a/src/core/types/decimal192_uniffi_fn.rs
+++ b/src/core/types/decimal192_uniffi_fn.rs
@@ -75,9 +75,9 @@ pub fn decimal_formatted_plain(
 /// extern crate sargon;
 /// use sargon::prelude::*;
 ///
-/// assert!(new_decimal_from_f32(208050.17).is_ok());
+/// assert!(new_decimal_from_f32(208050.17).to_string() == "208050.17");
 ///
-/// assert!(new_decimal_from_f32(f32::MIN_POSITIVE).is_ok());
+/// assert!(new_decimal_from_f32(f32::MIN_POSITIVE).to_string() == "0");
 /// ```
 #[uniffi::export]
 pub fn new_decimal_from_f32(value: f32) -> Decimal192 {

--- a/src/core/types/decimal192_uniffi_fn.rs
+++ b/src/core/types/decimal192_uniffi_fn.rs
@@ -80,8 +80,8 @@ pub fn decimal_formatted_plain(
 /// assert!(new_decimal_from_f32(f32::MIN_POSITIVE).is_ok());
 /// ```
 #[uniffi::export]
-pub fn new_decimal_from_f32(value: f32) -> Result<Decimal192> {
-    value.try_into()
+pub fn new_decimal_from_f32(value: f32) -> Decimal192 {
+    value.into()
 }
 
 /// Creates a new `Decimal192` from a f64 float. Will
@@ -474,7 +474,7 @@ mod uniffi_tests {
         let f: f32 = 208050.17;
         assert_eq!(f.to_string(), "208050.17");
         let sut = new_decimal_from_f32(f);
-        assert_eq!(sut.unwrap().to_string(), "208050.17");
+        assert_eq!(sut.to_string(), "208050.17");
         assert_eq!(
             SUT::try_from(f32::MAX).unwrap().to_string(),
             "340282350000000000000000000000000000000"

--- a/src/core/types/decimal192_uniffi_fn.rs
+++ b/src/core/types/decimal192_uniffi_fn.rs
@@ -77,10 +77,7 @@ pub fn decimal_formatted_plain(
 ///
 /// assert!(new_decimal_from_f32(208050.17).is_ok());
 ///
-/// assert_eq!(
-///     new_decimal_from_f32(f32::MIN_POSITIVE),
-///     Err(CommonError::DecimalOverflow { bad_value: f32::MIN_POSITIVE.to_string() })
-/// );
+/// assert!(new_decimal_from_f32(f32::MIN_POSITIVE).is_ok());
 /// ```
 #[uniffi::export]
 pub fn new_decimal_from_f32(value: f32) -> Result<Decimal192> {
@@ -97,10 +94,7 @@ pub fn new_decimal_from_f32(value: f32) -> Result<Decimal192> {
 ///
 /// assert!(new_decimal_from_f64(208050.17).is_ok());
 ///
-/// assert_eq!(
-///     new_decimal_from_f64(f64::MIN_POSITIVE),
-///     Err(CommonError::DecimalOverflow { bad_value: f64::MIN_POSITIVE.to_string() })
-/// );
+/// assert!(new_decimal_from_f64(f64::MIN_POSITIVE).is_ok());
 /// ```
 #[uniffi::export]
 pub fn new_decimal_from_f64(value: f64) -> Result<Decimal192> {


### PR DESCRIPTION
Update `Decimal192` parsing to truncate the fractional part to 18 decimals when parsing into the `ScryptoDecimal192` fails with the specific `ParseDecimalError::MoreThanEighteenDecimalPlaces`.