### PR TITLE
Implement RadixConnectSessionStorage for kotlin

### DIFF
--- a/jvm/gradle/libs.versions.toml
+++ b/jvm/gradle/libs.versions.toml
@@ -16,6 +16,8 @@ compose-bom = "2024.02.00"
 kover = "0.7.6"
 datastore = "1.1.1"
 coroutines = "1.8.0"
+androidx-test = "1.5.0"
+androidx-test-junit = "1.1.5"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activity-compose" }
@@ -34,6 +36,9 @@ junit-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref 
 coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidx-test" }
+androidx-test-rules = { module = "androidx.test:rules", version.ref = "androidx-test" }
+androidx-test-junit-ktx = { module = "androidx.test.ext:junit-ktx", version.ref = "androidx-test-junit" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/jvm/gradle/libs.versions.toml
+++ b/jvm/gradle/libs.versions.toml
@@ -14,6 +14,8 @@ material = "1.11.0"
 cargo-ndk = "0.3.4"
 compose-bom = "2024.02.00"
 kover = "0.7.6"
+datastore = "1.1.1"
+coroutines = "1.8.0"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activity-compose" }
@@ -25,9 +27,12 @@ androidx-compose-ui = { module = "androidx.compose.ui:ui" }
 androidx-compose-ui-graphics = { module = "androidx.compose.ui:ui-graphics" }
 androidx-compose-ui-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
 androidx-compose-material3 = { module = "androidx.compose.material3:material3" }
+androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore" }
 material = { module = "com.google.android.material:material", version.ref = "material" }
 junit = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
 junit-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit" }
+coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
+coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 
 [plugins]

--- a/jvm/sargon-android/build.gradle.kts
+++ b/jvm/sargon-android/build.gradle.kts
@@ -103,6 +103,7 @@ dependencies {
     // For Storage implementation
     implementation(libs.androidx.datastore.preferences)
 
+    // Unit tests
     testImplementation(libs.junit)
     testImplementation(libs.junit.params)
     testImplementation(libs.mockk)
@@ -110,6 +111,12 @@ dependencies {
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testDebugRuntimeOnly(project(":sargon-desktop-debug"))
     testReleaseRuntimeOnly(project(":sargon-desktop-release"))
+
+    // Integration tests
+    androidTestImplementation(libs.androidx.test.runner)
+    androidTestImplementation(libs.androidx.test.rules)
+    androidTestImplementation(libs.androidx.test.junit.ktx)
+    androidTestImplementation(libs.coroutines.test)
 }
 
 publishing {

--- a/jvm/sargon-android/build.gradle.kts
+++ b/jvm/sargon-android/build.gradle.kts
@@ -73,6 +73,7 @@ koverReport {
         includes {
             packages("com.radixdlt.sargon.extensions")
             packages("com.radixdlt.sargon.antenna")
+            packages("com.radixdlt.sargon.os")
         }
     }
 
@@ -89,7 +90,7 @@ dependencies {
     implementation("net.java.dev.jna:jna:5.13.0@aar")
 
     // For Coroutines support
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.0")
+    implementation(libs.coroutines.android)
 
     // For Serialization extensions
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
@@ -99,9 +100,13 @@ dependencies {
     implementation("com.squareup.okhttp3:okhttp")
     implementation("com.squareup.okhttp3:okhttp-coroutines")
 
+    // For Storage implementation
+    implementation(libs.androidx.datastore.preferences)
+
     testImplementation(libs.junit)
     testImplementation(libs.junit.params)
     testImplementation(libs.mockk)
+    testImplementation(libs.coroutines.test)
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testDebugRuntimeOnly(project(":sargon-desktop-debug"))
     testReleaseRuntimeOnly(project(":sargon-desktop-release"))

--- a/jvm/sargon-android/src/androidTest/kotlin/com/radixdlt/sargon/os/radixconnect/RadixConnectSessionStorageTest.kt
+++ b/jvm/sargon-android/src/androidTest/kotlin/com/radixdlt/sargon/os/radixconnect/RadixConnectSessionStorageTest.kt
@@ -1,0 +1,33 @@
+package com.radixdlt.sargon.os.radixconnect
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.SmallTest
+import androidx.test.platform.app.InstrumentationRegistry
+import com.radixdlt.sargon.SessionId
+import com.radixdlt.sargon.extensions.randomBagOfBytes
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@SmallTest
+class RadixConnectSessionStorageTest {
+
+    private val sut = RadixConnectSessionStorage(
+        context = InstrumentationRegistry.getInstrumentation().context
+    )
+
+    @Test
+    fun testRoundtrip() = runTest(context = StandardTestDispatcher()) {
+        val sessionId = SessionId.randomUUID()
+        val sessionBytes = randomBagOfBytes(32)
+
+        assertNull(sut.loadSession(sessionId))
+        sut.saveSession(sessionId, sessionBytes)
+        assertEquals(sessionBytes, sut.loadSession(sessionId))
+    }
+
+}

--- a/jvm/sargon-android/src/androidTest/kotlin/com/radixdlt/sargon/os/storage/EncryptionHelperWithSpecKeyTest.kt
+++ b/jvm/sargon-android/src/androidTest/kotlin/com/radixdlt/sargon/os/storage/EncryptionHelperWithSpecKeyTest.kt
@@ -1,0 +1,61 @@
+package com.radixdlt.sargon.os.storage
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.SmallTest
+import com.radixdlt.sargon.extensions.then
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@SmallTest
+class EncryptionHelperWithSpecKeyTest {
+    @Test
+    fun roundtripForString() {
+        val message = "A message needing encryption"
+        val spec = KeySpec.RadixConnect()
+
+        assertEquals(
+            message,
+            message.encrypt(keySpec = spec).then {
+                it.decrypt(keySpec = spec)
+            }.getOrThrow()
+        )
+    }
+
+    @Test
+    fun roundtripForByteArray() {
+        val message = "A message needing encryption".toByteArray()
+        val spec = KeySpec.RadixConnect()
+
+        assertTrue(
+            message.contentEquals(
+                message.encrypt(keySpec = spec).then {
+                    it.decrypt(keySpec = spec)
+                }.getOrThrow()
+            )
+        )
+    }
+
+    @Test
+    fun unsupportedTypeEncrypt() {
+        val message = 10
+        val spec = KeySpec.RadixConnect()
+
+        assertThrows(IllegalArgumentException::class.java) {
+            message.encrypt(keySpec = spec).getOrThrow()
+        }
+    }
+
+    @Test
+    fun unsupportedTypeDecrypt() {
+        val encrypted = 2048
+        val spec = KeySpec.RadixConnect()
+
+        assertThrows(IllegalArgumentException::class.java) {
+            encrypted.decrypt(keySpec = spec).getOrThrow()
+        }
+    }
+}

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/Result.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/Result.kt
@@ -1,0 +1,23 @@
+package com.radixdlt.sargon.extensions
+
+inline fun <FirstResult, SecondResult> Result<FirstResult>.then(
+    other: (FirstResult) -> Result<SecondResult>
+): Result<SecondResult> = fold(
+    onSuccess = { receivedValue ->
+        try {
+            other(receivedValue)
+        } catch (exception: Exception) {
+            Result.failure(exception)
+        }
+    },
+    onFailure = {
+        Result.failure(it)
+    }
+)
+
+inline fun <T> Result<T>.mapError(
+    map: (Throwable) -> Throwable
+): Result<T> = fold(
+    onSuccess = { Result.success(it) },
+    onFailure = { Result.failure(map(it)) }
+)

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/os/radixconnect/RadixConnectSessionStorage.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/os/radixconnect/RadixConnectSessionStorage.kt
@@ -1,0 +1,47 @@
+@file:OptIn(ExperimentalUnsignedTypes::class)
+
+package com.radixdlt.sargon.os.radixconnect
+
+import android.content.Context
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.byteArrayPreferencesKey
+import androidx.datastore.preferences.preferencesDataStoreFile
+import com.radixdlt.sargon.BagOfBytes
+import com.radixdlt.sargon.SessionId
+import com.radixdlt.sargon.SessionStorage
+import com.radixdlt.sargon.annotation.KoverIgnore
+import com.radixdlt.sargon.extensions.toBagOfBytes
+import com.radixdlt.sargon.os.storage.EncryptedPreferencesStorage
+import com.radixdlt.sargon.os.storage.KeySpec
+
+class RadixConnectSessionStorage internal constructor(
+    private val storage: EncryptedPreferencesStorage
+) : SessionStorage {
+
+    @KoverIgnore
+    constructor(context: Context) : this(
+        storage = EncryptedPreferencesStorage(datastore = PreferenceDataStoreFactory.create() {
+            val applicationContext = context.applicationContext
+            applicationContext.preferencesDataStoreFile(STORAGE_FILE_NAME)
+        })
+    )
+
+    override suspend fun saveSession(sessionId: SessionId, encodedSession: BagOfBytes) {
+        storage.set(
+            sessionId.key(),
+            encodedSession.toUByteArray().toByteArray(),
+            KeySpec.RadixConnect()
+        )
+    }
+
+    override suspend fun loadSession(sessionId: SessionId): BagOfBytes? = storage.get(
+        key = sessionId.key(),
+        keySpec = KeySpec.RadixConnect()
+    ).getOrNull()?.toBagOfBytes()
+
+    private fun SessionId.key() = byteArrayPreferencesKey(name = toString())
+
+    companion object {
+        private const val STORAGE_FILE_NAME = "rdx_radix_connect_session_storage"
+    }
+}

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/os/storage/EncryptedPreferencesStorage.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/os/storage/EncryptedPreferencesStorage.kt
@@ -1,0 +1,51 @@
+package com.radixdlt.sargon.os.storage
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.IOException
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import com.radixdlt.sargon.annotation.KoverIgnore
+import com.radixdlt.sargon.extensions.then
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+
+internal class EncryptedPreferencesStorage(
+    private val datastore: DataStore<Preferences>
+) {
+
+    suspend fun <T : Any> get(key: Preferences.Key<T>, keySpec: KeySpec): Result<T?> = runCatching {
+        datastore.data.catchIOException().map { preferences -> preferences[key] }.first()
+    }.then { encrypted ->
+        if (encrypted == null) return@then Result.success(null)
+
+        encrypted.decrypt(keySpec = keySpec)
+    }
+
+    suspend fun <T : Any> set(
+        key: Preferences.Key<T>,
+        value: T,
+        keySpec: KeySpec
+    ): Result<Unit> = value.encrypt(keySpec = keySpec).mapCatching { encrypted ->
+        datastore.edit { preferences ->
+            preferences[key] = encrypted
+        }
+    }
+
+    suspend fun <T : Any> remove(key: Preferences.Key<T>) {
+        datastore.edit { preferences ->
+            preferences.remove(key)
+        }
+    }
+
+    @KoverIgnore
+    private fun Flow<Preferences>.catchIOException() = catch { exception ->
+        if (exception is IOException) {
+            emit(emptyPreferences())
+        } else {
+            throw exception
+        }
+    }
+}

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/os/storage/EncryptionHelper.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/os/storage/EncryptionHelper.kt
@@ -1,0 +1,146 @@
+@file:OptIn(ExperimentalEncodingApi::class)
+
+package com.radixdlt.sargon.os.storage
+
+import com.radixdlt.sargon.extensions.then
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+import java.security.SecureRandom
+import java.security.spec.AlgorithmParameterSpec
+import javax.crypto.Cipher
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.SecretKeySpec
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+
+internal object EncryptionHelper {
+    fun encrypt(
+        input: ByteArray,
+        secretKey: SecretKey
+    ): Result<ByteArray> {
+        return runCatching {
+            val cipher = Cipher.getInstance(AES_GCM_NOPADDING)
+            val ivBytes = ByteArray(GCM_IV_LENGTH)
+            SecureRandom().nextBytes(ivBytes)
+            val parameterSpec = GCMParameterSpec(AUTH_TAG_LENGTH, ivBytes)
+            cipher.init(Cipher.ENCRYPT_MODE, secretKey, parameterSpec)
+
+            val ciphertext: ByteArray = cipher.doFinal(input)
+
+            val byteBuffer = ByteBuffer.allocate(ivBytes.size + ciphertext.size)
+            byteBuffer.put(ivBytes)
+            byteBuffer.put(ciphertext)
+
+            byteBuffer.array()
+        }
+    }
+
+    fun decrypt(
+        input: ByteArray,
+        secretKey: SecretKey
+    ): Result<ByteArray> {
+        return runCatching {
+            val cipher = Cipher.getInstance(AES_GCM_NOPADDING)
+            val gcmIv: AlgorithmParameterSpec =
+                GCMParameterSpec(AUTH_TAG_LENGTH, input, 0, GCM_IV_LENGTH)
+            cipher.init(Cipher.DECRYPT_MODE, secretKey, gcmIv)
+            cipher.doFinal(input, GCM_IV_LENGTH, input.size - GCM_IV_LENGTH)
+        }
+    }
+
+    const val AES_ALGORITHM = "AES"
+    private const val AES_GCM_NOPADDING = "AES/GCM/NoPadding"
+    private const val GCM_IV_LENGTH = 12
+    private const val AUTH_TAG_LENGTH = 128 // bit
+}
+
+/**
+ * Encrypts this value with the provided [secretKey].
+ *
+ * The receiver must be either a [String] or a [ByteArray]. Other types are not supported as
+ * of this moment.
+ */
+@Suppress("UNCHECKED_CAST")
+internal fun <T : Any> T.encrypt(secretKey: SecretKey): Result<T> = runCatching {
+    when (this) {
+        is String -> Base64.encode(
+            source = EncryptionHelper.encrypt(
+                input = toByteArray(),
+                secretKey = secretKey
+            ).getOrThrow()
+        ) as T
+
+        is ByteArray -> EncryptionHelper.encrypt(input = this, secretKey = secretKey)
+            .getOrThrow() as T
+
+        else -> throw UnsupportedOperationException(
+            "Encrypting ${this::class.java} type is not supported"
+        )
+    }
+}
+
+/**
+ * Decrypts this value with the provided [secretKey].
+ *
+ * The receiver must be either a [String] or a [ByteArray]. Other types are not supported as
+ * of this moment.
+ */
+@Suppress("UNCHECKED_CAST")
+internal fun <T : Any> T.decrypt(secretKey: SecretKey): Result<T> = runCatching {
+    when (this) {
+        is String -> String(
+            EncryptionHelper.decrypt(
+                input = Base64.decode(source = this),
+                secretKey = secretKey
+            ).getOrThrow(),
+            StandardCharsets.UTF_8
+        ) as T
+
+        is ByteArray -> EncryptionHelper.decrypt(input = this, secretKey = secretKey)
+            .getOrThrow() as T
+
+        else -> throw UnsupportedOperationException(
+            "Encrypting ${this::class.java} type is not supported"
+        )
+    }
+}
+
+/**
+ * Encrypts this value with the provided [keySpec].
+ *
+ * The receiver must be either a [String] or a [ByteArray]. Other types are not supported as
+ * of this moment.
+ */
+internal fun <T : Any> T.encrypt(keySpec: KeySpec) = keySpec.getOrGenerateSecretKey()
+    .then { encrypt(secretKey = it) }
+
+/**
+ * Decrypts this value with the provided [keySpec].
+ *
+ * The receiver must be either a [String] or a [ByteArray]. Other types are not supported as
+ * of this moment.
+ */
+internal fun <T : Any> T.decrypt(keySpec: KeySpec) = keySpec.getOrGenerateSecretKey()
+    .then { decrypt(secretKey = it) }
+
+/**
+ * Encrypts this value with the provided [encryptionKey].
+ *
+ * The receiver must be either a [String] or a [ByteArray]. Other types are not supported as
+ * of this moment.
+ */
+internal fun <T : Any> T.encrypt(encryptionKey: ByteArray) = encrypt(
+    secretKey = SecretKeySpec(encryptionKey, EncryptionHelper.AES_ALGORITHM)
+)
+
+/**
+ * Decrypts this value with the provided [encryptionKey].
+ *
+ * The receiver must be either a [String] or a [ByteArray]. Other types are not supported as
+ * of this moment.
+ */
+internal fun <T : Any> T.decrypt(encryptionKey: ByteArray) = decrypt(
+    secretKey = SecretKeySpec(encryptionKey, EncryptionHelper.AES_ALGORITHM)
+)
+

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/os/storage/EncryptionHelper.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/os/storage/EncryptionHelper.kt
@@ -74,7 +74,7 @@ internal fun <T : Any> T.encrypt(secretKey: SecretKey): Result<T> = runCatching 
         is ByteArray -> EncryptionHelper.encrypt(input = this, secretKey = secretKey)
             .getOrThrow() as T
 
-        else -> throw UnsupportedOperationException(
+        else -> throw IllegalArgumentException(
             "Encrypting ${this::class.java} type is not supported"
         )
     }
@@ -100,7 +100,7 @@ internal fun <T : Any> T.decrypt(secretKey: SecretKey): Result<T> = runCatching 
         is ByteArray -> EncryptionHelper.decrypt(input = this, secretKey = secretKey)
             .getOrThrow() as T
 
-        else -> throw UnsupportedOperationException(
+        else -> throw IllegalArgumentException(
             "Encrypting ${this::class.java} type is not supported"
         )
     }

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/os/storage/KeySpec.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/os/storage/KeySpec.kt
@@ -1,0 +1,142 @@
+package com.radixdlt.sargon.os.storage
+
+import android.os.Build
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyPermanentlyInvalidatedException
+import android.security.keystore.KeyProperties
+import com.radixdlt.sargon.annotation.KoverIgnore
+import java.security.KeyStore
+import java.security.ProviderException
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+
+// Unfortunately this class relies on Android APIs which are difficult to mock in unit tests.
+// Integration tests can cover it, but they need to run on an actual device.
+@KoverIgnore
+internal sealed class KeySpec(val alias: String) {
+
+    /**
+     * The implementation of these methods are heavily based on this:
+     * https://gist.github.com/patrickfav/7e28d4eb4bf500f7ee8012c4a0cf7bbf
+     * and for a deeper knowledge please read this article:
+     * https://levelup.gitconnected.com/doing-aes-gcm-in-android-adventures-in-the-field-72617401269d
+     */
+    fun getOrGenerateSecretKey(): Result<SecretKey> = getSecretKey()
+        .mapCatching { existingSecretKey ->
+            existingSecretKey ?: generateSecretKey().getOrThrow()
+        }
+
+    internal abstract fun generateSecretKey(): Result<SecretKey>
+
+    internal fun getSecretKey(): Result<SecretKey?> = runCatching {
+        val keyStore = KeyStore.getInstance(PROVIDER).apply { load(null) }
+        (keyStore.getEntry(alias, null) as? KeyStore.SecretKeyEntry)?.secretKey
+    }
+
+    @KoverIgnore
+    class Profile(alias: String = KEY_ALIAS_PROFILE) : KeySpec(alias) {
+        override fun generateSecretKey(): Result<SecretKey> = AesKeyGeneratorBuilder(alias = alias)
+            .build()
+    }
+
+    @KoverIgnore
+    class RadixConnect(alias: String = KEY_ALIAS_RADIX_CONNECT): KeySpec(alias) {
+        override fun generateSecretKey(): Result<SecretKey> = AesKeyGeneratorBuilder(alias = alias)
+            .build()
+    }
+
+    @KoverIgnore
+    class Mnemonic(
+        alias: String = KEY_ALIAS_MNEMONIC,
+        private val authenticationTimeoutSeconds: Int = KEY_AUTHORIZATION_TIMEOUT_SECONDS
+    ) : KeySpec(alias) {
+        override fun generateSecretKey(): Result<SecretKey> = AesKeyGeneratorBuilder(alias = alias)
+            .setAuthenticationRequired(authenticationTimeout = authenticationTimeoutSeconds)
+            .build()
+
+        fun checkIfPermanentlyInvalidated(input: String): Boolean {
+            // on pixel 6 pro when lock screen is removed, key entry for an alias is null
+            val secretKeyResult = getSecretKey()
+            if (secretKeyResult.isFailure || secretKeyResult.getOrNull() == null) return true
+
+            val secretKey = requireNotNull(secretKeyResult.getOrNull())
+            val result = input.encrypt(secretKey = secretKey)
+            // according to documentation this is exception that should be thrown if we try to use
+            // invalidated key, but behavior I saw when removing lock screen is that key is
+            // automatically deleted from the keystore
+            return result.exceptionOrNull() is KeyPermanentlyInvalidatedException
+        }
+    }
+
+    @KoverIgnore
+    private data class AesKeyGeneratorBuilder(
+        private val alias: String,
+    ) {
+        private var authenticationTimeoutSeconds: Int? = null
+
+        fun setAuthenticationRequired(
+            authenticationTimeout: Int
+        ) = apply {
+            require(authenticationTimeout > 0) { "Authentication timeout seconds must be > 0" }
+            authenticationTimeoutSeconds = authenticationTimeout
+        }
+
+        fun build(): Result<SecretKey> = runCatching {
+            val keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, PROVIDER)
+            val keygenParameterSpecBuilder = KeyGenParameterSpec.Builder(
+                alias,
+                KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+            ).setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                // This is required to be able to provide the IV ourselves
+                .setRandomizedEncryptionRequired(false)
+                .setKeySize(AES_KEY_SIZE)
+
+            authenticationTimeoutSeconds?.let { timeout ->
+                keygenParameterSpecBuilder
+                    .setUserAuthenticationRequired(true)
+                    .setInvalidatedByBiometricEnrollment(false)
+
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                    keygenParameterSpecBuilder.setUserAuthenticationParameters(
+                        timeout,
+                        KeyProperties.AUTH_BIOMETRIC_STRONG or KeyProperties.AUTH_DEVICE_CREDENTIAL
+                    )
+                } else {
+                    keygenParameterSpecBuilder.setUserAuthenticationValidityDurationSeconds(
+                        timeout
+                    )
+                }
+
+                keygenParameterSpecBuilder.compatSetIsStrongBoxBacked(true)
+            }
+
+            try {
+                keyGenerator.init(keygenParameterSpecBuilder.build())
+                keyGenerator.generateKey()
+            } catch (e: ProviderException) {
+                keygenParameterSpecBuilder.compatSetIsStrongBoxBacked(false)
+                keyGenerator.init(keygenParameterSpecBuilder.build())
+                keyGenerator.generateKey()
+            }
+        }
+
+        private fun KeyGenParameterSpec.Builder.compatSetIsStrongBoxBacked(isBacked: Boolean) = apply {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                setIsStrongBoxBacked(isBacked)
+            }
+        }
+    }
+
+    companion object {
+        private const val PROVIDER = "AndroidKeyStore"
+        private const val AES_KEY_SIZE = 256
+
+        // seem that some low end devices take very long time to generate BDFS mnemonic
+        private const val KEY_AUTHORIZATION_TIMEOUT_SECONDS = 30
+
+        private const val KEY_ALIAS_PROFILE = "EncryptedProfileAlias"
+        private const val KEY_ALIAS_MNEMONIC = "EncryptedMnemonicAlias"
+        private const val KEY_ALIAS_RADIX_CONNECT = "EncryptedRadixConnectSessionAlias"
+    }
+}

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/Decimal192Test.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/Decimal192Test.kt
@@ -163,6 +163,7 @@ class Decimal192Test : SampleTestable<Decimal192> {
 
         assertNotNull(Float.MIN_VALUE.toDecimal192OrNull())
         assertNotNull(3.14f.toDecimal192OrNull())
+        assertNull(Float.NEGATIVE_INFINITY.toDecimal192OrNull())
 
         assertNull(Float.MIN_VALUE.toString().toDecimal192OrNull())
         assertNotNull("3.14".toDecimal192OrNull())

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/ResultTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/ResultTest.kt
@@ -1,0 +1,64 @@
+package com.radixdlt.sargon
+
+import com.radixdlt.sargon.extensions.mapError
+import com.radixdlt.sargon.extensions.then
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class ResultTest {
+
+    @Test
+    fun testThenAfterSuccess() {
+        val expected = Result.success(10)
+        val plusTen = { value: Int -> Result.success(value + 10) }
+
+        assertEquals(
+            20,
+            expected.then { plusTen(it) }.getOrThrow()
+        )
+    }
+
+    @Test
+    fun testThrowingThenAfterSuccess() {
+        val expected = Result.success(10)
+        val plusTen = { value: Int ->
+            if (value == 10) throw RuntimeException("Some error") else Result.success(value + 10)
+        }
+
+        assertThrows<RuntimeException> {
+            expected.then { plusTen(it) }.getOrThrow()
+        }
+    }
+
+    @Test
+    fun testThenAfterFailure() {
+        val expected = Result.failure<Int>(RuntimeException("An error occurred"))
+        val plusTen = { value: Int -> Result.success(value + 10) }
+
+        assertEquals(
+            expected,
+            expected.then { plusTen(it) }
+        )
+    }
+
+    @Test
+    fun testMapErrorWhenSuccess() {
+        val expected = Result.success(10)
+
+        val result = expected.mapError { it }
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun testMapErrorWhenError() {
+        val expected = Result.failure<Int>(RuntimeException("Some Error"))
+
+        val result = expected.mapError { if (it is RuntimeException) IllegalStateException(it.message) else it  }
+
+        assertThrows<IllegalStateException> {
+            result.getOrThrow()
+        }
+    }
+}

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/os/radixconnect/RadixConnectSessionStorageTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/os/radixconnect/RadixConnectSessionStorageTest.kt
@@ -1,0 +1,76 @@
+package com.radixdlt.sargon.os.radixconnect
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import com.radixdlt.sargon.SessionId
+import com.radixdlt.sargon.extensions.randomBagOfBytes
+import com.radixdlt.sargon.os.storage.EncryptedPreferencesStorage
+import com.radixdlt.sargon.os.storage.EncryptionHelper
+import com.radixdlt.sargon.os.storage.KeySpec
+import io.mockk.every
+import io.mockk.mockkConstructor
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import javax.crypto.spec.SecretKeySpec
+
+@OptIn(ExperimentalUnsignedTypes::class)
+class RadixConnectSessionStorageTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val testScope = TestScope(testDispatcher + Job())
+
+    @field:TempDir
+    lateinit var tmpDir: File
+
+    private val sut = RadixConnectSessionStorage(
+        storage = EncryptedPreferencesStorage(
+            datastore = PreferenceDataStoreFactory.create(scope = testScope) {
+                File(tmpDir, "radix_connect_session_storage.preferences_pb")
+            }
+        )
+    )
+
+    @Test
+    fun testRoundtrip() = runTest(context = testDispatcher) {
+        mockkConstructor(KeySpec.RadixConnect::class)
+        every { anyConstructed<KeySpec.RadixConnect>().getOrGenerateSecretKey() } returns Result.success(
+            SecretKeySpec(
+                randomBagOfBytes(32).toUByteArray().toByteArray(),
+                EncryptionHelper.AES_ALGORITHM
+            )
+        )
+
+        val sessionId = SessionId.randomUUID()
+        val sessionBytes = randomBagOfBytes(32)
+
+        assertNull(sut.loadSession(sessionId))
+        sut.saveSession(sessionId, sessionBytes)
+        assertEquals(sessionBytes, sut.loadSession(sessionId))
+    }
+
+    @Test
+    fun testGetNullDueToKeySpecException() = runTest(context = testDispatcher) {
+        mockkConstructor(KeySpec.RadixConnect::class)
+        every { anyConstructed<KeySpec.RadixConnect>().getOrGenerateSecretKey() } returns Result.success(
+            SecretKeySpec(
+                randomBagOfBytes(32).toUByteArray().toByteArray(),
+                EncryptionHelper.AES_ALGORITHM
+            )
+        )
+
+        val sessionId = SessionId.randomUUID()
+        val sessionBytes = randomBagOfBytes(32)
+        sut.saveSession(sessionId, sessionBytes)
+
+        every { anyConstructed<KeySpec.RadixConnect>().getOrGenerateSecretKey() } returns Result.failure(
+            RuntimeException("Some Error")
+        )
+        assertNull(sut.loadSession(sessionId))
+    }
+}

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/os/storage/EncryptedPreferencesStorageTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/os/storage/EncryptedPreferencesStorageTest.kt
@@ -1,0 +1,82 @@
+package com.radixdlt.sargon.os.storage
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.radixdlt.sargon.extensions.randomBagOfBytes
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import javax.crypto.spec.SecretKeySpec
+
+@OptIn(ExperimentalUnsignedTypes::class)
+class EncryptedPreferencesStorageTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val testScope = TestScope(testDispatcher + Job())
+
+    private val mockKeySpec = mockk<KeySpec>().apply {
+        every { getOrGenerateSecretKey() } returns Result.success(
+            SecretKeySpec(
+                randomBagOfBytes(32).toUByteArray().toByteArray(),
+                EncryptionHelper.AES_ALGORITHM
+            )
+        )
+    }
+
+    @field:TempDir
+    lateinit var tmpDir: File
+
+    private val sut = EncryptedPreferencesStorage(
+        datastore = PreferenceDataStoreFactory.create(scope = testScope) {
+            File(tmpDir, "test.preferences_pb")
+        }
+    )
+
+    @Test
+    fun testRoundtrip() = runTest(context = testDispatcher) {
+        val pair = "some-key" to "Some value to save"
+        sut.set(stringPreferencesKey(pair.first), pair.second, mockKeySpec).getOrThrow()
+
+        val value = sut.get(stringPreferencesKey(pair.first), mockKeySpec).getOrThrow()
+        assertEquals(pair.second, value)
+    }
+
+    @Test
+    fun testGetWithNoSetReturnsNull() = runTest(context = testDispatcher) {
+        val value = sut.get(stringPreferencesKey("some-other-key"), mockKeySpec).getOrThrow()
+        assertNull(value)
+    }
+
+    @Test
+    fun testGetAfterRemovingKeyReturnsNull() = runTest(context = testDispatcher) {
+        val pair = "some-key" to "Some value to save"
+        sut.set(stringPreferencesKey(pair.first), pair.second, mockKeySpec).getOrThrow()
+
+        assertEquals(sut.get(stringPreferencesKey(pair.first), mockKeySpec).getOrThrow(), pair.second)
+
+        sut.remove(stringPreferencesKey(pair.first))
+
+        val value = sut.get(stringPreferencesKey("some-other-key"), mockKeySpec).getOrThrow()
+        assertNull(value)
+    }
+
+    @Test
+    fun testEncryptErrorOnSet() = runTest(context = testDispatcher) {
+        every { mockKeySpec.getOrGenerateSecretKey() } returns Result.failure(RuntimeException("Some Error"))
+
+        val pair = "some-key" to "Some value to save"
+        assertThrows<RuntimeException> {
+            sut.set(stringPreferencesKey(pair.first), pair.second, mockKeySpec).getOrThrow()
+        }
+    }
+
+}

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/os/storage/EncryptionHelperWithEncryptionKeyTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/os/storage/EncryptionHelperWithEncryptionKeyTest.kt
@@ -90,7 +90,7 @@ class EncryptionHelperWithEncryptionKeyTest {
         val message = 10
         val encryptionKey = randomBagOfBytes(byteCount = 32).toUByteArray().toByteArray()
 
-        assertThrows<UnsupportedOperationException> {
+        assertThrows<IllegalArgumentException> {
             message.encrypt(encryptionKey = encryptionKey).getOrThrow()
         }
     }
@@ -100,7 +100,7 @@ class EncryptionHelperWithEncryptionKeyTest {
         val encryptionKey = randomBagOfBytes(byteCount = 32).toUByteArray().toByteArray()
         val encrypted = 2048
 
-        assertThrows<UnsupportedOperationException> {
+        assertThrows<IllegalArgumentException> {
             encrypted.decrypt(encryptionKey = encryptionKey).getOrThrow()
         }
     }

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/os/storage/EncryptionHelperWithEncryptionKeyTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/os/storage/EncryptionHelperWithEncryptionKeyTest.kt
@@ -1,0 +1,107 @@
+package com.radixdlt.sargon.os.storage
+
+import com.radixdlt.sargon.extensions.randomBagOfBytes
+import com.radixdlt.sargon.extensions.then
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+@OptIn(ExperimentalUnsignedTypes::class, ExperimentalStdlibApi::class)
+class EncryptionHelperWithEncryptionKeyTest {
+
+    @Test
+    fun `decrypt with AES GCM NoPadding`() {
+        val encryptedMessageInHex =
+            "6ea80ead36e3fc4f1ad75134776c26534e73086e93f6b3cd7fdbbe390ed428b5c2f0150fd3f16c928e968497060b39ec61660704"
+        val encryptionKey = ByteArray(32) { 0xab.toByte() }
+        assertEquals(
+            "abababababababababababababababababababababababababababababababab",
+            encryptionKey.toHexString()
+        )
+
+
+        val decrypted = encryptedMessageInHex.hexToByteArray().decrypt(
+            encryptionKey = encryptionKey
+        )
+
+        assertEquals(
+            "Hello Android from Swift",
+            String(decrypted.getOrThrow())
+        )
+    }
+
+    @Test
+    fun `ensure that encrypting the same message does not give the same encrypted output`() {
+        val encryptionKeyByteArray = ByteArray(32) { 0xab.toByte() }
+
+        val decryptedMessage = "Hello Android from Swift"
+        val encryptedMessage1 = decryptedMessage.encrypt(
+            encryptionKey = encryptionKeyByteArray
+        ).getOrThrow()
+
+        val encryptedMessage2 = decryptedMessage.encrypt(
+            encryptionKey = encryptionKeyByteArray
+        ).getOrThrow()
+
+        assertNotEquals(encryptedMessage1, encryptedMessage2)
+        assertTrue(
+            decryptedMessage.contentEquals(
+                encryptedMessage1.decrypt(encryptionKey = encryptionKeyByteArray).getOrThrow()
+            ),
+        )
+        assertTrue(
+            decryptedMessage.contentEquals(
+                encryptedMessage2.decrypt(encryptionKey = encryptionKeyByteArray).getOrThrow()
+            ),
+        )
+    }
+
+    @Test
+    fun roundtripForString() {
+        val message = "A message needing encryption"
+        val encryptionKey = randomBagOfBytes(byteCount = 32).toUByteArray().toByteArray()
+
+        assertEquals(
+            message,
+            message.encrypt(encryptionKey = encryptionKey).then {
+                it.decrypt(encryptionKey = encryptionKey)
+            }.getOrThrow()
+        )
+    }
+
+    @Test
+    fun roundtripForByteArray() {
+        val message = "A message needing encryption".toByteArray()
+        val encryptionKey = randomBagOfBytes(byteCount = 32).toUByteArray().toByteArray()
+
+        assertTrue(
+            message.contentEquals(
+                message.encrypt(encryptionKey = encryptionKey).then {
+                    it.decrypt(encryptionKey = encryptionKey)
+                }.getOrThrow()
+            )
+        )
+    }
+
+    @Test
+    fun unsupportedTypeEncrypt() {
+        val message = 10
+        val encryptionKey = randomBagOfBytes(byteCount = 32).toUByteArray().toByteArray()
+
+        assertThrows<UnsupportedOperationException> {
+            message.encrypt(encryptionKey = encryptionKey).getOrThrow()
+        }
+    }
+
+    @Test
+    fun unsupportedTypeDecrypt() {
+        val encryptionKey = randomBagOfBytes(byteCount = 32).toUByteArray().toByteArray()
+        val encrypted = 2048
+
+        assertThrows<UnsupportedOperationException> {
+            encrypted.decrypt(encryptionKey = encryptionKey).getOrThrow()
+        }
+    }
+}


### PR DESCRIPTION
In order to implement such "secure" storage I had to introduce to sargon some logic that existed in Android wallet.

* Some `Result` extensions were needed. Unit tested and made public to replace the ones we have in android wallet.
* `KeySpec` reintroduced. Temporarily became `internal` in order to not introduce a duplicate type to the existing one, but rather lie the foundation for all kinds of secure storages to be implemented when SargonOS will be integrated. * * The only class that is public for construction from wallet host will be `RadixConnectSessionStorage(context: Context)`. The host should instantiate this as a singleton using Hilt.
* Unit tests are difficult when you combine code with methods that exist on Android. Tried to unit test everything. `EncryptionHelper ` can encrypt with either a `KeySpec` directly, or an `encryptionKey: ByteArray`. Only the latter is able to be used in unit tests since it is backed by [Kotlin's `Base64`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.io.encoding/-base64/) implementation instead of [Android's Base64](https://developer.android.com/reference/android/util/Base64). Look at the comment bellow for this one.
* `KeySpec` is ignored from coverage. It is possible to test such code, but this will require an emulator and the test must be in a form of integration test. After discussion with @GhenadieVP we concluded to start simple and decide later what to do for code in sargon jvm that requires an emulator in order to be tested.
* As discussed in previous standup, the `KeySpec.RadixConnect` is configured to not require biometrics. (Implemented similar to `KeySpec.Profile`)

> [!NOTE]
> Target branch is not `main`