### PR TITLE
Expose kotlin serde for RadixConnectMobileLinkRequest

### DIFF
--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/RadixConnectMobile.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/RadixConnectMobile.kt
@@ -1,0 +1,17 @@
+package com.radixdlt.sargon.extensions
+
+import android.content.Context
+import com.radixdlt.sargon.RadixConnectMobile
+import com.radixdlt.sargon.annotation.KoverIgnore
+import com.radixdlt.sargon.antenna.SargonNetworkAntenna
+import com.radixdlt.sargon.os.radixconnect.RadixConnectSessionStorage
+import okhttp3.OkHttpClient
+
+@KoverIgnore
+fun RadixConnectMobile.Companion.init(
+    context: Context,
+    okHttpClient: OkHttpClient
+) = RadixConnectMobile(
+    networkAntenna = SargonNetworkAntenna(client = okHttpClient),
+    sessionStorage = RadixConnectSessionStorage(context = context)
+)

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/RadixConnectMobileLinkRequest.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/RadixConnectMobileLinkRequest.kt
@@ -1,0 +1,13 @@
+package com.radixdlt.sargon.extensions
+
+import com.radixdlt.sargon.RadixConnectMobileLinkRequest
+import com.radixdlt.sargon.newRadixConnectMobileLinkRequestFromJsonBytes
+import com.radixdlt.sargon.radixConnectMobileLinkRequestToJsonBytes
+
+@Throws(SargonException::class)
+fun RadixConnectMobileLinkRequest.Companion.fromJson(json: String) =
+    newRadixConnectMobileLinkRequestFromJsonBytes(bagOfBytes(json))
+
+fun RadixConnectMobileLinkRequest.toJson(): String = radixConnectMobileLinkRequestToJsonBytes(
+    radixConnectMobileLinkRequest = this
+).string

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/os/radixconnect/RadixConnectSessionStorage.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/os/radixconnect/RadixConnectSessionStorage.kt
@@ -14,7 +14,7 @@ import com.radixdlt.sargon.extensions.toBagOfBytes
 import com.radixdlt.sargon.os.storage.EncryptedPreferencesStorage
 import com.radixdlt.sargon.os.storage.KeySpec
 
-class RadixConnectSessionStorage internal constructor(
+internal class RadixConnectSessionStorage internal constructor(
     private val storage: EncryptedPreferencesStorage
 ) : SessionStorage {
 

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/RadixConnectMobileLinkRequestSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/RadixConnectMobileLinkRequestSample.kt
@@ -1,0 +1,17 @@
+package com.radixdlt.sargon.samples
+
+import com.radixdlt.sargon.RadixConnectMobileLinkRequest
+import com.radixdlt.sargon.annotation.UsesSampleValues
+import com.radixdlt.sargon.newRadixConnectMobileLinkRequestSample
+import com.radixdlt.sargon.newRadixConnectMobileLinkRequestSampleOther
+
+@UsesSampleValues
+val RadixConnectMobileLinkRequest.Companion.sample: Sample<RadixConnectMobileLinkRequest>
+    get() = object : Sample<RadixConnectMobileLinkRequest> {
+
+        override fun invoke(): RadixConnectMobileLinkRequest =
+            newRadixConnectMobileLinkRequestSample()
+
+        override fun other(): RadixConnectMobileLinkRequest =
+            newRadixConnectMobileLinkRequestSampleOther()
+    }

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/RadixConnectMobileLinkRequestTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/RadixConnectMobileLinkRequestTest.kt
@@ -1,0 +1,22 @@
+package com.radixdlt.sargon
+
+import com.radixdlt.sargon.extensions.fromJson
+import com.radixdlt.sargon.extensions.toJson
+import com.radixdlt.sargon.samples.Sample
+import com.radixdlt.sargon.samples.sample
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class RadixConnectMobileLinkRequestTest: SampleTestable<RadixConnectMobileLinkRequest> {
+    override val samples: List<Sample<RadixConnectMobileLinkRequest>>
+        get() = listOf(RadixConnectMobileLinkRequest.sample)
+
+    @Test
+    fun testJsonRoundtrip() {
+        assertEquals(
+            RadixConnectMobileLinkRequest.sample(),
+            RadixConnectMobileLinkRequest.fromJson(RadixConnectMobileLinkRequest.sample().toJson())
+        )
+    }
+
+}

--- a/src/radix_connect/mobile/deep_link_parsing/link_request.rs
+++ b/src/radix_connect/mobile/deep_link_parsing/link_request.rs
@@ -2,6 +2,8 @@ use crate::prelude::*;
 
 use super::super::session::session_id::SessionID;
 
+json_data_convertible!(RadixConnectMobileLinkRequest);
+
 #[derive(Debug, Serialize, Deserialize, PartialEq, uniffi::Record)]
 pub struct RadixConnectMobileLinkRequest {
     pub origin: Url,
@@ -56,7 +58,7 @@ impl RadixConnectMobileLinkRequest {
 impl HasSampleValues for RadixConnectMobileLinkRequest {
     fn sample() -> Self {
         RadixConnectMobileLinkRequest::new(
-            parse_url("radix://app1").unwrap(),
+            parse_url("http://app1.com").unwrap(),
             SessionID::sample(),
             KeyAgreementPublicKey::sample(),
             "Chrome".into(),
@@ -65,12 +67,24 @@ impl HasSampleValues for RadixConnectMobileLinkRequest {
 
     fn sample_other() -> Self {
         RadixConnectMobileLinkRequest::new(
-            parse_url("radix://app2").unwrap(),
+            parse_url("http://app2.com").unwrap(),
             SessionID::sample_other(),
             KeyAgreementPublicKey::sample_other(),
             "Safari".into(),
         )
     }
+}
+
+#[uniffi::export]
+pub fn new_radix_connect_mobile_link_request_sample(
+) -> RadixConnectMobileLinkRequest {
+    RadixConnectMobileLinkRequest::sample()
+}
+
+#[uniffi::export]
+pub fn new_radix_connect_mobile_link_request_sample_other(
+) -> RadixConnectMobileLinkRequest {
+    RadixConnectMobileLinkRequest::sample_other()
 }
 
 #[cfg(test)]
@@ -89,5 +103,22 @@ mod tests {
     #[test]
     fn inequality() {
         assert_ne!(SUT::sample(), SUT::sample_other());
+    }
+}
+
+#[cfg(test)]
+mod uniffi_tests {
+    use crate::prelude::*;
+
+    #[test]
+    fn sample_values() {
+        assert_eq!(
+            new_radix_connect_mobile_link_request_sample(),
+            RadixConnectMobileLinkRequest::sample()
+        );
+        assert_eq!(
+            new_radix_connect_mobile_link_request_sample_other(),
+            RadixConnectMobileLinkRequest::sample_other()
+        );
     }
 }


### PR DESCRIPTION
* Create kotlin serde for RadixConnectMobileLinkRequest. On Android we need to serialize objects to pass them between different screens.
* Make `RadixConnectSessionStorage` internal as the only starting point for radix connect is `RadixConnectMobile` which got the appropriate initialiser. 