### PR TITLE
Optional request body for `GET` methods

### DIFF
--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/antenna/SargonNetworkAntenna.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/antenna/SargonNetworkAntenna.kt
@@ -23,9 +23,12 @@ class SargonNetworkAntenna(
     override suspend fun executeNetworkRequest(request: NetworkRequest): NetworkResponse = runCatching {
         val mediaType = request.headers.extractMediaType()
 
-        val requestBody = request.body.toUByteArray().toByteArray().toRequestBody(
-            contentType = mediaType
-        )
+        val requestBody = request.body
+            .toUByteArray()
+            .toByteArray()
+            .takeIf {
+                it.isNotEmpty()
+            }?.toRequestBody(contentType = mediaType)
 
         val okHttpRequest = Request.Builder()
             .url(url = request.url)


### PR DESCRIPTION
* `GET` requests cannot have a request body.
* We initiate a `GET` request when requesting a well-known file.
* In Sargon an empty array is initialised and passed down to kotlin.
* Kotlin side needs to check if `body` is empty, and if it is pass `null` to okHttp.
* Otherwise this error is thrown: `method GET must not have a request body.`

> [!NOTE]
> Target branch is not `main`