### PR TITLE
[ABW-3454] iOS - Display proper error messages for Sargon errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2586,7 +2586,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.0.12"
+version = "1.0.13"
 dependencies = [
  "actix-rt",
  "aes-gcm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2586,7 +2586,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "actix-rt",
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "1.0.15"
+version = "1.0.16"
 edition = "2021"
 build = "build.rs"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "1.0.12"
+version = "1.0.13"
 edition = "2021"
 build = "build.rs"
 

--- a/apple/Sources/Sargon/Extensions/Swiftified/Prelude/SargonError+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Prelude/SargonError+Swiftified.swift
@@ -1,3 +1,4 @@
+import Foundation
 import SargonUniFFI
 
 public typealias SargonError = CommonError
@@ -13,5 +14,11 @@ extension SargonError: CustomDebugStringConvertible {
 extension SargonError: CustomStringConvertible {
 	public var description: String {
 		errorMessage
+	}
+}
+
+extension SargonError: LocalizedError {
+	public var errorDescription: String? {
+		"\(errorMessage)\nCode: \(errorCode)"
 	}
 }

--- a/apple/Sources/Sargon/Extensions/Swiftified/Prelude/SargonError+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Prelude/SargonError+Swiftified.swift
@@ -19,6 +19,10 @@ extension SargonError: CustomStringConvertible {
 
 extension SargonError: LocalizedError {
 	public var errorDescription: String? {
-		"\(errorMessage)\nCode: \(errorCode)"
+		let errorCodeFormatted = "Error code: \(errorCode)"
+		let errorMessageFormatted: String? = isSafeToShowErrorMessageFromError(error: self) ? "Error message: \(errorMessage)" : nil
+		return [errorCodeFormatted, errorMessageFormatted]
+					.compactMap { $0 }
+					.joined(separator: "\n")
 	}
 }

--- a/apple/Tests/TestCases/Prelude/SargonErrorTests.swift
+++ b/apple/Tests/TestCases/Prelude/SargonErrorTests.swift
@@ -30,7 +30,7 @@ final class SargonErrorTests: Test<SargonError> {
 	}
 
 	func test_localized_description_for_non_sensitive_error() {
-		let sut = SUT.FailedToDeserializeJsonToValue(jsonByteCount: 100, typeName: "TypeName")
-		XCTAssertEqual(sut.localizedDescription, "Error code: 10070\nError message: Failed deserialize JSON with #100 bytes to value of type TypeName")
+		let sut = SUT.FailedToDeserializeJsonToValue(jsonByteCount: 100, typeName: "TypeName", serdeMessage: "serdeMessage")
+		XCTAssertEqual(sut.localizedDescription, "Error code: 10070\nError message: Failed deserialize JSON with #100 bytes to value of type TypeName with error: \"serdeMessage\"")
 	} 
 }

--- a/apple/Tests/TestCases/Prelude/SargonErrorTests.swift
+++ b/apple/Tests/TestCases/Prelude/SargonErrorTests.swift
@@ -24,8 +24,13 @@ final class SargonErrorTests: Test<SargonError> {
 		XCTAssertEqual(sut.debugDescription, "10049: No network found with id: '99'")
 	}
 
-	func test_localized_description() {
+	func test_localized_description_for_sensitive_error() {
 		let sut = SUT.UnknownNetworkForId(badValue: 99)
-		XCTAssertEqual(sut.localizedDescription, "No network found with id: '99'\nCode: 10049")
+		XCTAssertEqual(sut.localizedDescription, "Error code: 10049")
 	}
+
+	func test_localized_description_for_non_sensitive_error() {
+		let sut = SUT.FailedToDeserializeJsonToValue(jsonByteCount: 100, typeName: "TypeName")
+		XCTAssertEqual(sut.localizedDescription, "Error code: 10070\nError message: Failed deserialize JSON with #100 bytes to value of type TypeName")
+	} 
 }

--- a/apple/Tests/TestCases/Prelude/SargonErrorTests.swift
+++ b/apple/Tests/TestCases/Prelude/SargonErrorTests.swift
@@ -23,4 +23,9 @@ final class SargonErrorTests: Test<SargonError> {
 		let sut = SUT.UnknownNetworkForId(badValue: 99)
 		XCTAssertEqual(sut.debugDescription, "10049: No network found with id: '99'")
 	}
+
+	func test_localized_description() {
+		let sut = SUT.UnknownNetworkForId(badValue: 99)
+		XCTAssertEqual(sut.localizedDescription, "No network found with id: '99'\nCode: 10049")
+	}
 }


### PR DESCRIPTION
Jira ticket: [ABW-3454](https://radixdlt.atlassian.net/browse/ABW-3454)

- Make `SargonError` conform to `LocalizedError` to ensure a proper `localizedDescription` is displayed in the iOS wallet.
- Added a new UniFFI export function `is_safe_to_show_error_message` for hosts to determine if the `error_message` can be displayed to users. For now, the only error we consider "safe" is `FailedToDeserializeJSONToValue`


[ABW-3454]: https://radixdlt.atlassian.net/browse/ABW-3454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ