### PR TITLE
Pass serde message information to `FailedToDeserializeJSONToValue`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2586,7 +2586,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.0.12"
+version = "1.0.13"
 dependencies = [
  "actix-rt",
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "1.0.12"
+version = "1.0.13"
 edition = "2021"
 build = "build.rs"
 

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/MnemonicWithPassphrase.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/MnemonicWithPassphrase.kt
@@ -35,7 +35,7 @@ fun MnemonicWithPassphrase.Companion.fromJson(
     throw CommonException.FailedToDeserializeJsonToValue(
         jsonByteCount = fromJson.toByteArray(charset = Charsets.UTF_8).size.toULong(),
         typeName = "MnemonicWithPassphrase",
-        serdeMsg = it.message.orEmpty()
+        serdeMessage = it.message.orEmpty()
     )
 }.getOrThrow()
 

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/MnemonicWithPassphrase.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/MnemonicWithPassphrase.kt
@@ -34,7 +34,8 @@ fun MnemonicWithPassphrase.Companion.fromJson(
 }.onFailure {
     throw CommonException.FailedToDeserializeJsonToValue(
         jsonByteCount = fromJson.toByteArray(charset = Charsets.UTF_8).size.toULong(),
-        typeName = "MnemonicWithPassphrase"
+        typeName = "MnemonicWithPassphrase",
+        serdeMsg = it.message.orEmpty()
     )
 }.getOrThrow()
 

--- a/src/core/error/common_error.rs
+++ b/src/core/error/common_error.rs
@@ -255,6 +255,7 @@ pub enum CommonError {
     FailedToDeserializeJSONToValue {
         json_byte_count: u64,
         type_name: String,
+        message: String,
     } = 10070,
 
     #[error("Failed To create ProfileID (UUID) from string: {bad_value}")]

--- a/src/core/error/common_error.rs
+++ b/src/core/error/common_error.rs
@@ -251,11 +251,11 @@ pub enum CommonError {
     #[error("Failed Serialize value to JSON.")]
     FailedToSerializeToJSON = 10069,
 
-    #[error("Failed deserialize JSON with #{json_byte_count} bytes to value of type {type_name} with error: \"{message}\"")]
+    #[error("Failed deserialize JSON with #{json_byte_count} bytes to value of type {type_name} with error: \"{serde_message}\"")]
     FailedToDeserializeJSONToValue {
         json_byte_count: u64,
         type_name: String,
-        message: String,
+        serde_message: String,
     } = 10070,
 
     #[error("Failed To create ProfileID (UUID) from string: {bad_value}")]

--- a/src/core/error/common_error.rs
+++ b/src/core/error/common_error.rs
@@ -251,7 +251,7 @@ pub enum CommonError {
     #[error("Failed Serialize value to JSON.")]
     FailedToSerializeToJSON = 10069,
 
-    #[error("Failed deserialize JSON with #{json_byte_count} bytes to value of type {type_name}")]
+    #[error("Failed deserialize JSON with #{json_byte_count} bytes to value of type {type_name} with error: \"{message}\"")]
     FailedToDeserializeJSONToValue {
         json_byte_count: u64,
         type_name: String,

--- a/src/core/error/common_error_map.rs
+++ b/src/core/error/common_error_map.rs
@@ -1,0 +1,56 @@
+use de::StdError;
+
+use crate::prelude::*;
+
+pub trait MapToFailedToDeserializeJSONToValue<R> {
+    fn map_failed_to_deserialize_string<T>(
+        self,
+        input: impl AsRef<str>,
+    ) -> Result<R, CommonError>;
+    fn map_failed_to_deserialize_bytes<T>(
+        self,
+        input: &[u8],
+    ) -> Result<R, CommonError>;
+}
+
+impl<R> MapToFailedToDeserializeJSONToValue<R>
+    for Result<R, serde_json::Error>
+{
+    fn map_failed_to_deserialize_string<T>(
+        self,
+        input: impl AsRef<str>,
+    ) -> Result<R, CommonError> {
+        self.map_err(|e| {
+            error!(
+                "Failed to deserialize JSON to {}, from:\n{:?}\nError: {}",
+                type_name::<T>(),
+                input.as_ref(),
+                e
+            );
+            CommonError::FailedToDeserializeJSONToValue {
+                json_byte_count: input.as_ref().len() as u64,
+                type_name: type_name::<T>(),
+                message: format!("{}", e),
+            }
+        })
+    }
+
+    fn map_failed_to_deserialize_bytes<T>(
+        self,
+        input: &[u8],
+    ) -> Result<R, CommonError> {
+        self.map_err(|e| {
+            error!(
+                "Failed to deserialize JSON to {}, from (UTF-8):\n{:?}\nError: {}", 
+                type_name::<T>(),
+                String::from_utf8(input.to_vec()),
+                e
+            );
+            CommonError::FailedToDeserializeJSONToValue {
+                json_byte_count: input.len() as u64,
+                type_name: type_name::<T>(),
+                message: format!("{}", e)
+            }
+        })
+    }
+}

--- a/src/core/error/common_error_map.rs
+++ b/src/core/error/common_error_map.rs
@@ -24,7 +24,7 @@ impl<R> MapToFailedToDeserializeJSONToValue<R>
             error!(
                 "Failed to deserialize JSON to {}, from:\n{:?}\nError: {}",
                 type_name::<T>(),
-                input.as_ref(),
+                input.as_ref().to_string().chars().take(500),
                 e
             );
             CommonError::FailedToDeserializeJSONToValue {
@@ -43,7 +43,7 @@ impl<R> MapToFailedToDeserializeJSONToValue<R>
             error!(
                 "Failed to deserialize JSON to {}, from (UTF-8):\n{:?}\nError: {}", 
                 type_name::<T>(),
-                String::from_utf8(input.to_vec()),
+                String::from_utf8(input.to_vec()).map(|json| json.chars().take(500).collect_vec()),
                 e
             );
             CommonError::FailedToDeserializeJSONToValue {

--- a/src/core/error/common_error_map.rs
+++ b/src/core/error/common_error_map.rs
@@ -30,7 +30,7 @@ impl<R> MapToFailedToDeserializeJSONToValue<R>
             CommonError::FailedToDeserializeJSONToValue {
                 json_byte_count: input.as_ref().len() as u64,
                 type_name: type_name::<T>(),
-                message: format!("{}", e),
+                serde_message: format!("{}", e),
             }
         })
     }
@@ -49,7 +49,7 @@ impl<R> MapToFailedToDeserializeJSONToValue<R>
             CommonError::FailedToDeserializeJSONToValue {
                 json_byte_count: input.len() as u64,
                 type_name: type_name::<T>(),
-                message: format!("{}", e)
+                serde_message: format!("{}", e)
             }
         })
     }

--- a/src/core/error/mod.rs
+++ b/src/core/error/mod.rs
@@ -1,2 +1,5 @@
 mod common_error;
+mod common_error_map;
+
 pub use common_error::*;
+pub use common_error_map::*;

--- a/src/profile/v100/json_data_convertible.rs
+++ b/src/profile/v100/json_data_convertible.rs
@@ -115,7 +115,7 @@ macro_rules! json_data_convertible {
                             );
                         }
                         _ => {
-                            error!("Expected CommonError::FailedToDeserializeJSONToValue but other error occurred")
+                            panic!("Expected CommonError::FailedToDeserializeJSONToValue but other error occurred")
                         }
                     }
                 }
@@ -210,7 +210,7 @@ macro_rules! json_string_convertible {
                             );
                         }
                         _ => {
-                            error!("Expected CommonError::FailedToDeserializeJSONToValue but other error occurred")
+                            panic!("Expected CommonError::FailedToDeserializeJSONToValue but other error occurred")
                         }
                     }
                 }

--- a/src/profile/v100/profile.rs
+++ b/src/profile/v100/profile.rs
@@ -529,7 +529,7 @@ mod tests {
             Result::Err(CommonError::FailedToDeserializeJSONToValue {
                 json_byte_count: malformed_profile_snapshot.len() as u64,
                 type_name: "Profile".to_string(),
-                message: "missing field `header` at line 1 column 2"
+                serde_message: "missing field `header` at line 1 column 2"
                     .to_string()
             })
         );
@@ -559,7 +559,7 @@ mod tests {
             Err(CommonError::FailedToDeserializeJSONToValue {
                 json_byte_count: 33,
                 type_name: "EncryptedProfileSnapshot".to_string(),
-                message: "expected value at line 1 column 1".to_string()
+                serde_message: "expected value at line 1 column 1".to_string()
             })
         );
     }

--- a/src/profile/v100/profile_uniffi_fn.rs
+++ b/src/profile/v100/profile_uniffi_fn.rs
@@ -238,7 +238,7 @@ mod uniffi_tests {
             Err(CommonError::FailedToDeserializeJSONToValue {
                 json_byte_count: 0,
                 type_name: "Profile".to_owned(),
-                message: "EOF while parsing a value at line 1 column 0"
+                serde_message: "EOF while parsing a value at line 1 column 0"
                     .to_string()
             })
         )

--- a/src/profile/v100/profile_uniffi_fn.rs
+++ b/src/profile/v100/profile_uniffi_fn.rs
@@ -8,13 +8,8 @@ pub fn new_profile_from_json_string(json_str: String) -> Result<Profile> {
 impl Profile {
     pub fn new_from_json_string(json_str: impl AsRef<str>) -> Result<Profile> {
         let json_str = json_str.as_ref();
-        let json_byte_count = json_str.len() as u64;
-        serde_json::from_str(json_str).map_err(|_| {
-            CommonError::FailedToDeserializeJSONToValue {
-                json_byte_count,
-                type_name: type_name::<Profile>(),
-            }
-        })
+        serde_json::from_str(json_str)
+            .map_failed_to_deserialize_string::<Self>(json_str)
     }
 }
 
@@ -242,7 +237,9 @@ mod uniffi_tests {
             new_profile_from_json_string("".to_owned()),
             Err(CommonError::FailedToDeserializeJSONToValue {
                 json_byte_count: 0,
-                type_name: "Profile".to_owned()
+                type_name: "Profile".to_owned(),
+                message: "EOF while parsing a value at line 1 column 0"
+                    .to_string()
             })
         )
     }

--- a/src/radix_connect/wallet_interaction/dapp_wallet_interaction/dapp_to_wallet/interaction_uniffi_fn.rs
+++ b/src/radix_connect/wallet_interaction/dapp_wallet_interaction/dapp_to_wallet/interaction_uniffi_fn.rs
@@ -97,7 +97,7 @@ mod tests {
             Err(CommonError::FailedToDeserializeJSONToValue {
                 json_byte_count: 0,
                 type_name: "DappToWalletInteractionUnvalidated".to_owned(),
-                message: "EOF while parsing a value at line 1 column 0"
+                serde_message: "EOF while parsing a value at line 1 column 0"
                     .to_string()
             })
         )

--- a/src/radix_connect/wallet_interaction/dapp_wallet_interaction/dapp_to_wallet/interaction_uniffi_fn.rs
+++ b/src/radix_connect/wallet_interaction/dapp_wallet_interaction/dapp_to_wallet/interaction_uniffi_fn.rs
@@ -15,13 +15,8 @@ impl DappToWalletInteractionUnvalidated {
         json_str: impl AsRef<str>,
     ) -> Result<DappToWalletInteractionUnvalidated> {
         let json_str = json_str.as_ref();
-        let json_byte_count = json_str.len() as u64;
-        serde_json::from_str(json_str).map_err(|_| {
-            CommonError::FailedToDeserializeJSONToValue {
-                json_byte_count,
-                type_name: type_name::<DappToWalletInteractionUnvalidated>(),
-            }
-        })
+        serde_json::from_str(json_str)
+            .map_failed_to_deserialize_string::<Self>(json_str)
     }
 }
 
@@ -101,7 +96,9 @@ mod tests {
             ),
             Err(CommonError::FailedToDeserializeJSONToValue {
                 json_byte_count: 0,
-                type_name: "DappToWalletInteractionUnvalidated".to_owned()
+                type_name: "DappToWalletInteractionUnvalidated".to_owned(),
+                message: "EOF while parsing a value at line 1 column 0"
+                    .to_string()
             })
         )
     }

--- a/src/wallet/secure_storage/wallet_client_storage.rs
+++ b/src/wallet/secure_storage/wallet_client_storage.rs
@@ -53,18 +53,8 @@ impl WalletClientStorage {
     {
         self.interface.load_data(key).and_then(|o| match o {
             None => Ok(None),
-            Some(j) => serde_json::from_slice(j.as_slice()).map_err(|_| {
-                let type_name = std::any::type_name::<T>().to_string();
-                error!(
-                    "Deserialize json to type: {}\nJSON (utf8):\n{:?}",
-                    &type_name,
-                    String::from_utf8(j.clone())
-                );
-                CommonError::FailedToDeserializeJSONToValue {
-                    json_byte_count: j.len() as u64,
-                    type_name,
-                }
-            }),
+            Some(j) => serde_json::from_slice(j.as_slice())
+                .map_failed_to_deserialize_bytes::<T>(&j),
         })
     }
 
@@ -190,8 +180,8 @@ mod tests {
             sut.load::<Profile>(SecureStorageKey::ActiveProfileID),
             Err(CommonError::FailedToDeserializeJSONToValue {
                 json_byte_count: 1,
-                type_name: "sargon::profile::v100::profile::Profile"
-                    .to_string()
+                type_name: "Profile".to_string(),
+                message: "invalid type: integer `0`, expected struct Profile at line 1 column 1".to_string()
             })
         );
     }

--- a/src/wallet/secure_storage/wallet_client_storage.rs
+++ b/src/wallet/secure_storage/wallet_client_storage.rs
@@ -181,7 +181,7 @@ mod tests {
             Err(CommonError::FailedToDeserializeJSONToValue {
                 json_byte_count: 1,
                 type_name: "Profile".to_string(),
-                message: "invalid type: integer `0`, expected struct Profile at line 1 column 1".to_string()
+                serde_message: "invalid type: integer `0`, expected struct Profile at line 1 column 1".to_string()
             })
         );
     }


### PR DESCRIPTION
`FailedToDeserializeJSONToValue` was missing meaningful information that hosts could log, in order to find out what the problem is when deserialising a value.

2 methods can be applied on each `Result<*, serde_json::Error>` that can extract all needed information about deserialisation for both strings and byte arrays.

The aim is to use the `message` in hosts to extract logs.