### PR TITLE
[ABW-3433] Fix Manifest Crash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2586,7 +2586,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.0.14"
+version = "1.0.15"
 dependencies = [
  "actix-rt",
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "1.0.14"
+version = "1.0.15"
 edition = "2021"
 build = "build.rs"
 

--- a/apple/Sources/Sargon/Extensions/Swiftified/RET/TransactionManifest+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/RET/TransactionManifest+Swiftified.swift
@@ -76,8 +76,8 @@ extension TransactionManifest {
 
     public func modify(
         addGuarantees guarantees: [TransactionGuarantee]
-    ) -> Self {
-        modifyManifestAddGuarantees(
+    ) throws -> Self {
+        try modifyManifestAddGuarantees(
             manifest: self,
             guarantees: guarantees
         )

--- a/apple/Tests/TestCases/RET/ManifestBuilding/ManifestBuildingTests.swift
+++ b/apple/Tests/TestCases/RET/ManifestBuilding/ManifestBuildingTests.swift
@@ -175,7 +175,7 @@ final class ManifestBuildingTests: Test<TransactionManifest> {
 			}
 			XCTAssertFalse(hasLockFee())
 			let fee: Decimal192 = 531
-			manifest = manifest.modify(lockFee: fee, addressOfFeePayer: addressOfFeePayer)
+			manifest = try manifest.modify(lockFee: fee, addressOfFeePayer: addressOfFeePayer)
 			XCTAssertTrue(hasLockFee())
 			XCTAssert(manifest.description.contains(addressOfFeePayer.address))
 		}
@@ -198,7 +198,7 @@ final class ManifestBuildingTests: Test<TransactionManifest> {
 		)
 
 		XCTAssertFalse(manifest.description.contains(guarantee.amount.description))
-		manifest = manifest.modify(addGuarantees: [guarantee])
+		manifest = try manifest.modify(addGuarantees: [guarantee])
 		XCTAssertTrue(manifest.description.contains(guarantee.amount.description))
 		
 	}

--- a/src/core/error/common_error.rs
+++ b/src/core/error/common_error.rs
@@ -493,7 +493,9 @@ pub enum CommonError {
     #[error("Invalid RadixConnectPurpose, bad value: {bad_value}")]
     InvalidRadixConnectPurpose { bad_value: String } = 10137,
 
-    #[error("Index of transaction Guarantee is out of bounds: {index} >= #{count}")]
+    #[error(
+        "Index of transaction Guarantee is out of bounds: {index} >= #{count}"
+    )]
     TXGuaranteeIndexOutOfBounds { index: u64, count: u64 } = 10138,
 }
 

--- a/src/core/error/common_error.rs
+++ b/src/core/error/common_error.rs
@@ -494,7 +494,7 @@ pub enum CommonError {
     InvalidRadixConnectPurpose { bad_value: String } = 10137,
 
     #[error(
-        "Index of transaction Guarantee is out of bounds: {index} >= #{count}"
+        "Transaction Guarantee's 'instruction_index' is out of bounds, the provided manifest contains #{count}, but an 'instruction_index' of {index} was specified."
     )]
     TXGuaranteeIndexOutOfBounds { index: u64, count: u64 } = 10138,
 }

--- a/src/core/error/common_error.rs
+++ b/src/core/error/common_error.rs
@@ -493,8 +493,8 @@ pub enum CommonError {
     #[error("Invalid RadixConnectPurpose, bad value: {bad_value}")]
     InvalidRadixConnectPurpose { bad_value: String } = 10137,
 
-    #[error("Index out of bounds: {index} >= #{count}")]
-    IndexOutOfBounds { index: u64, count: u64 } = 10138,
+    #[error("Index of transaction Guarantee is out of bounds: {index} >= #{count}")]
+    TXGuaranteeIndexOutOfBounds { index: u64, count: u64 } = 10138,
 }
 
 #[uniffi::export]

--- a/src/core/error/common_error.rs
+++ b/src/core/error/common_error.rs
@@ -492,6 +492,9 @@ pub enum CommonError {
 
     #[error("Invalid RadixConnectPurpose, bad value: {bad_value}")]
     InvalidRadixConnectPurpose { bad_value: String } = 10137,
+
+    #[error("Index out of bounds: {index} >= #{count}")]
+    IndexOutOfBounds { index: u64, count: u64 } = 10138,
 }
 
 #[uniffi::export]

--- a/src/wrapped_radix_engine_toolkit/high_level/manifest_building/modify_manifest.rs
+++ b/src/wrapped_radix_engine_toolkit/high_level/manifest_building/modify_manifest.rs
@@ -66,13 +66,13 @@ impl TransactionManifest {
     ///
     /// Also panics if the number of TransactionGuarantee's is larger than the number
     /// of instructions of `manifest` (does not make any sense).
-    pub(crate) fn modify_add_guarantees<I>(self, guarantees: I) -> Self
+    pub(crate) fn modify_add_guarantees<I>(self, guarantees: I) -> Result<TransactionManifest>
     where
         I: IntoIterator<Item = TransactionGuarantee>,
     {
         let guarantees = guarantees.into_iter().collect_vec();
         if guarantees.is_empty() {
-            return self;
+            return Ok(self);
         };
 
         let instruction_count = self.instructions().len() as u64;
@@ -114,7 +114,7 @@ impl TransactionManifest {
             offset.add_assign(1);
         }
 
-        manifest
+        Ok(manifest)
     }
 
     pub(crate) fn modify_add_lock_fee(
@@ -226,7 +226,8 @@ CALL_METHOD
             index,
             resource,
             divisibility,
-        )]);
+        )])
+        .unwrap();
         let instructions = manifest.instructions().to_owned();
         let instruction = instructions[index as usize + 1].clone();
         assert_eq!(
@@ -354,7 +355,8 @@ CALL_METHOD
                 1,
                 ResourceAddress::sample(),
                 10,
-            )]),
+            )])
+            .unwrap(),
             r#"
             CALL_METHOD
                 Address("account_rdx12yy8n09a0w907vrjyj4hws2yptrm3rdjv84l9sr24e3w7pk7nuxst8")
@@ -392,7 +394,8 @@ CALL_METHOD
                 1,
                 ResourceAddress::sample(),
                 10,
-            )]),
+            )])
+            .unwrap(),
             r#"
             CALL_METHOD
                 Address("account_rdx128y6j78mt0aqv6372evz28hrxp8mn06ccddkr7xppc88hyvynvjdwr")
@@ -427,13 +430,13 @@ CALL_METHOD
     #[test]
     fn test_modify_manifest_add_guarantees_unchanged_if_no_guarantees() {
         let manifest = TransactionManifest::sample();
-        assert_eq!(manifest.clone().modify_add_guarantees([]), manifest);
+        assert_eq!(manifest.clone().modify_add_guarantees([]).unwrap(), manifest);
     }
 
     #[test]
     fn test_modify_manifest_add_guarantees_unchanged_if_instructions_empty() {
         let manifest = TransactionManifest::empty(NetworkID::Mainnet);
-        assert_eq!(manifest.clone().modify_add_guarantees([]), manifest);
+        assert_eq!(manifest.clone().modify_add_guarantees([]).unwrap(), manifest);
     }
 
     #[test]
@@ -452,7 +455,8 @@ CALL_METHOD
                     ResourceAddress::sample(),
                     None
                 )
-            ]),
+            ])
+            .unwrap(),
             manifest
         );
     }
@@ -474,7 +478,8 @@ CALL_METHOD
                     ResourceAddress::sample(),
                     None
                 )]
-            ),
+            )
+            .unwrap(),
             manifest
         );
     }

--- a/src/wrapped_radix_engine_toolkit/high_level/manifest_building/modify_manifest.rs
+++ b/src/wrapped_radix_engine_toolkit/high_level/manifest_building/modify_manifest.rs
@@ -63,10 +63,10 @@ impl TransactionManifest {
     /// # Panics
     /// Panics if any of the TransactionGuarantee's `instruction_index` is out of
     /// bounds.
-    ///
-    /// Also panics if the number of TransactionGuarantee's is larger than the number
-    /// of instructions of `manifest` (does not make any sense).
-    pub(crate) fn modify_add_guarantees<I>(self, guarantees: I) -> Result<TransactionManifest>
+    pub(crate) fn modify_add_guarantees<I>(
+        self,
+        guarantees: I,
+    ) -> Result<TransactionManifest>
     where
         I: IntoIterator<Item = TransactionGuarantee>,
     {

--- a/src/wrapped_radix_engine_toolkit/high_level/manifest_building/modify_manifest.rs
+++ b/src/wrapped_radix_engine_toolkit/high_level/manifest_building/modify_manifest.rs
@@ -556,7 +556,10 @@ CALL_METHOD
                 ResourceAddress::sample(),
                 None
             )]),
-            Err(CommonError::TXGuaranteeIndexOutOfBounds { index: 4, count: 4 })
+            Err(CommonError::TXGuaranteeIndexOutOfBounds {
+                index: 4,
+                count: 4
+            })
         );
     }
 
@@ -575,7 +578,10 @@ CALL_METHOD
                     None
                 )]
             ),
-            Err(CommonError::TXGuaranteeIndexOutOfBounds { index: 5, count: 4 })
+            Err(CommonError::TXGuaranteeIndexOutOfBounds {
+                index: 5,
+                count: 4
+            })
         );
     }
 }

--- a/src/wrapped_radix_engine_toolkit/high_level/manifest_building/modify_manifest.rs
+++ b/src/wrapped_radix_engine_toolkit/high_level/manifest_building/modify_manifest.rs
@@ -77,10 +77,6 @@ impl TransactionManifest {
 
         let instruction_count = self.instructions().len() as u64;
 
-        if guarantees.len() > self.instructions().len() {
-            panic!("Does not make sense to add more guarantees than there are instructions.")
-        }
-
         if let Some(oob) = guarantees
             .clone()
             .into_iter()
@@ -442,21 +438,6 @@ CALL_METHOD
 
     #[test]
     #[should_panic(
-        expected = "Does not make sense to add more guarantees than there are instructions."
-    )]
-    fn test_modify_manifest_add_guarantees_panics_if_instructions_empty_but_guarantees_is_not_empty(
-    ) {
-        let manifest = TransactionManifest::empty(NetworkID::Mainnet);
-        assert_eq!(
-            manifest
-                .clone()
-                .modify_add_guarantees([TransactionGuarantee::sample()]),
-            manifest
-        );
-    }
-
-    #[test]
-    #[should_panic(
         expected = "Transaction Guarantee's 'instruction_index' is out of bounds, the provided manifest contains #4, but an 'instruction_index' of 4 was specified."
     )]
     fn test_modify_manifest_add_guarantees_panics_index_equal_to_instruction_count(
@@ -472,29 +453,6 @@ CALL_METHOD
                     None
                 )
             ]),
-            manifest
-        );
-    }
-
-    #[test]
-    #[should_panic(
-        expected = "Does not make sense to add more guarantees than there are instructions."
-    )]
-    fn test_modify_manifest_add_guarantees_panics_if_more_guarantees_than_instructions(
-    ) {
-        let manifest = TransactionManifest::sample();
-        assert_eq!(
-            manifest.clone().modify_add_guarantees(
-                (0u32..manifest.instructions().len() as u32 + 1).map(|i| {
-                    TransactionGuarantee::new(
-                        i,
-                        0,
-                        0,
-                        ResourceAddress::sample(),
-                        None,
-                    )
-                })
-            ),
             manifest
         );
     }

--- a/src/wrapped_radix_engine_toolkit/high_level/manifest_building/modify_manifest.rs
+++ b/src/wrapped_radix_engine_toolkit/high_level/manifest_building/modify_manifest.rs
@@ -220,14 +220,15 @@ CALL_METHOD
             Blobs::default(),
         )
         .unwrap();
-        manifest = manifest.modify_add_guarantees([TransactionGuarantee::new(
-            added_guaranteed_amount,
-            percentage,
-            index,
-            resource,
-            divisibility,
-        )])
-        .unwrap();
+        manifest = manifest
+            .modify_add_guarantees([TransactionGuarantee::new(
+                added_guaranteed_amount,
+                percentage,
+                index,
+                resource,
+                divisibility,
+            )])
+            .unwrap();
         let instructions = manifest.instructions().to_owned();
         let instruction = instructions[index as usize + 1].clone();
         assert_eq!(
@@ -349,14 +350,15 @@ CALL_METHOD
         let manifest = TransactionManifest::sample_mainnet_without_lock_fee();
 
         manifest_eq(
-            manifest.modify_add_guarantees([TransactionGuarantee::new(
-                1337,
-                0,
-                1,
-                ResourceAddress::sample(),
-                10,
-            )])
-            .unwrap(),
+            manifest
+                .modify_add_guarantees([TransactionGuarantee::new(
+                    1337,
+                    0,
+                    1,
+                    ResourceAddress::sample(),
+                    10,
+                )])
+                .unwrap(),
             r#"
             CALL_METHOD
                 Address("account_rdx12yy8n09a0w907vrjyj4hws2yptrm3rdjv84l9sr24e3w7pk7nuxst8")
@@ -388,14 +390,15 @@ CALL_METHOD
         let manifest = TransactionManifest::sample();
 
         manifest_eq(
-            manifest.modify_add_guarantees([TransactionGuarantee::new(
-                1337,
-                0,
-                1,
-                ResourceAddress::sample(),
-                10,
-            )])
-            .unwrap(),
+            manifest
+                .modify_add_guarantees([TransactionGuarantee::new(
+                    1337,
+                    0,
+                    1,
+                    ResourceAddress::sample(),
+                    10,
+                )])
+                .unwrap(),
             r#"
             CALL_METHOD
                 Address("account_rdx128y6j78mt0aqv6372evz28hrxp8mn06ccddkr7xppc88hyvynvjdwr")
@@ -430,13 +433,19 @@ CALL_METHOD
     #[test]
     fn test_modify_manifest_add_guarantees_unchanged_if_no_guarantees() {
         let manifest = TransactionManifest::sample();
-        assert_eq!(manifest.clone().modify_add_guarantees([]).unwrap(), manifest);
+        assert_eq!(
+            manifest.clone().modify_add_guarantees([]).unwrap(),
+            manifest
+        );
     }
 
     #[test]
     fn test_modify_manifest_add_guarantees_unchanged_if_instructions_empty() {
         let manifest = TransactionManifest::empty(NetworkID::Mainnet);
-        assert_eq!(manifest.clone().modify_add_guarantees([]).unwrap(), manifest);
+        assert_eq!(
+            manifest.clone().modify_add_guarantees([]).unwrap(),
+            manifest
+        );
     }
 
     #[test]
@@ -447,16 +456,16 @@ CALL_METHOD
     ) {
         let manifest = TransactionManifest::sample();
         assert_eq!(
-            manifest.clone().modify_add_guarantees([
-                TransactionGuarantee::new(
+            manifest
+                .clone()
+                .modify_add_guarantees([TransactionGuarantee::new(
                     0,
                     0,
                     4,
                     ResourceAddress::sample(),
                     None
-                )
-            ])
-            .unwrap(),
+                )])
+                .unwrap(),
             manifest
         );
     }

--- a/src/wrapped_radix_engine_toolkit/high_level/manifest_building/modify_manifest.rs
+++ b/src/wrapped_radix_engine_toolkit/high_level/manifest_building/modify_manifest.rs
@@ -78,7 +78,7 @@ impl TransactionManifest {
             .into_iter()
             .find(|g| g.instruction_index >= instruction_count)
         {
-            return Err(CommonError::IndexOutOfBounds {
+            return Err(CommonError::TXGuaranteeIndexOutOfBounds {
                 index: oob.instruction_index,
                 count: instruction_count,
             });
@@ -556,7 +556,7 @@ CALL_METHOD
                 ResourceAddress::sample(),
                 None
             )]),
-            Err(CommonError::IndexOutOfBounds { index: 4, count: 4 })
+            Err(CommonError::TXGuaranteeIndexOutOfBounds { index: 4, count: 4 })
         );
     }
 
@@ -575,7 +575,7 @@ CALL_METHOD
                     None
                 )]
             ),
-            Err(CommonError::IndexOutOfBounds { index: 5, count: 4 })
+            Err(CommonError::TXGuaranteeIndexOutOfBounds { index: 5, count: 4 })
         );
     }
 }

--- a/src/wrapped_radix_engine_toolkit/high_level/manifest_building/modify_manifest.rs
+++ b/src/wrapped_radix_engine_toolkit/high_level/manifest_building/modify_manifest.rs
@@ -181,7 +181,7 @@ mod tests {
     #[test]
     fn add_guarantees_divisibility_rounding() {
         let instructions_string = r#"
-        CALL_METHOD
+CALL_METHOD
     Address("account_rdx128y6j78mt0aqv6372evz28hrxp8mn06ccddkr7xppc88hyvynvjdwr")
     "lock_fee"
     Decimal("0.61")
@@ -369,6 +369,103 @@ CALL_METHOD
             ASSERT_WORKTOP_CONTAINS
                 Address("resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd")
                 Decimal("1337")
+            ;
+            TAKE_FROM_WORKTOP
+                Address("resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd")
+                Decimal("1337")
+                Bucket("bucket1")
+            ;
+            CALL_METHOD
+                Address("account_rdx129a9wuey40lducsf6yu232zmzk5kscpvnl6fv472r0ja39f3hced69")
+                "try_deposit_or_abort"
+                Bucket("bucket1")
+                Enum<0u8>()
+            ;
+            "#,
+        );
+    }
+
+    #[test]
+    fn test_modify_manifest_add_many_guarantees() {
+        let manifest = TransactionManifest::sample_mainnet_without_lock_fee();
+
+        manifest_eq(
+            manifest
+                .modify_add_guarantees([
+                    TransactionGuarantee::new(
+                        1337,
+                        0,
+                        1,
+                        ResourceAddress::sample(),
+                        10,
+                    ),
+                    TransactionGuarantee::new(
+                        1338,
+                        0,
+                        1,
+                        ResourceAddress::sample(),
+                        10,
+                    ),
+                    TransactionGuarantee::new(
+                        1339,
+                        0,
+                        1,
+                        ResourceAddress::sample(),
+                        10,
+                    ),
+                    TransactionGuarantee::new(
+                        1340,
+                        0,
+                        1,
+                        ResourceAddress::sample(),
+                        10,
+                    ),
+                    TransactionGuarantee::new(
+                        1341,
+                        0,
+                        1,
+                        ResourceAddress::sample(),
+                        10,
+                    ),
+                    TransactionGuarantee::new(
+                        1342,
+                        0,
+                        1,
+                        ResourceAddress::sample(),
+                        10,
+                    ),
+                ])
+                .unwrap(),
+            r#"
+            CALL_METHOD
+                Address("account_rdx12yy8n09a0w907vrjyj4hws2yptrm3rdjv84l9sr24e3w7pk7nuxst8")
+                "withdraw"
+                Address("resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd")
+                Decimal("1337")
+            ;
+            ASSERT_WORKTOP_CONTAINS
+                Address("resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd")
+                Decimal("1337")
+            ;
+            ASSERT_WORKTOP_CONTAINS
+                Address("resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd")
+                Decimal("1338")
+            ;
+            ASSERT_WORKTOP_CONTAINS
+                Address("resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd")
+                Decimal("1339")
+            ;
+            ASSERT_WORKTOP_CONTAINS
+                Address("resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd")
+                Decimal("1340")
+            ;
+            ASSERT_WORKTOP_CONTAINS
+                Address("resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd")
+                Decimal("1341")
+            ;
+            ASSERT_WORKTOP_CONTAINS
+                Address("resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd")
+                Decimal("1342")
             ;
             TAKE_FROM_WORKTOP
                 Address("resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd")

--- a/src/wrapped_radix_engine_toolkit/high_level/ret_api.rs
+++ b/src/wrapped_radix_engine_toolkit/high_level/ret_api.rs
@@ -123,9 +123,6 @@ pub fn modify_manifest_lock_fee(
 /// # Panics
 /// Panics if any of the TransactionGuarantee's `instruction_index` is out of
 /// bounds.
-///
-/// Also panics if the number of TransactionGuarantee's is larger than the number
-/// of instructions of `manifest` (does not make any sense).
 #[uniffi::export]
 pub fn modify_manifest_add_guarantees(
     manifest: TransactionManifest,

--- a/src/wrapped_radix_engine_toolkit/high_level/ret_api.rs
+++ b/src/wrapped_radix_engine_toolkit/high_level/ret_api.rs
@@ -119,10 +119,6 @@ pub fn modify_manifest_lock_fee(
 
 /// Modifies `manifest` by inserting transaction "guarantees", which is the wallet
 /// term for `assert_worktop_contains`.
-///
-/// # Panics
-/// Panics if any of the TransactionGuarantee's `instruction_index` is out of
-/// bounds.
 #[uniffi::export]
 pub fn modify_manifest_add_guarantees(
     manifest: TransactionManifest,

--- a/src/wrapped_radix_engine_toolkit/high_level/ret_api.rs
+++ b/src/wrapped_radix_engine_toolkit/high_level/ret_api.rs
@@ -130,7 +130,7 @@ pub fn modify_manifest_lock_fee(
 pub fn modify_manifest_add_guarantees(
     manifest: TransactionManifest,
     guarantees: Vec<TransactionGuarantee>,
-) -> TransactionManifest {
+) -> Result<TransactionManifest> {
     manifest.modify_add_guarantees(guarantees)
 }
 
@@ -405,7 +405,8 @@ mod tests {
                     ResourceAddress::sample(),
                     None,
                 )],
-            );
+            )
+            .unwrap();
             let idx = modified
                 .instructions()
                 .clone()


### PR DESCRIPTION
Jira ticket: [ABW-3433](https://radixdlt.atlassian.net/browse/ABW-3433)

- Removes the check `guarantees.len() > self.instructions().len()`
- Propagates panics to Swift as thrown errors

[ABW-3433]: https://radixdlt.atlassian.net/browse/ABW-3433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ