### PR TITLE
Truncate display names with longer than 30 chars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2586,7 +2586,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.0.13"
+version = "1.0.14"
 dependencies = [
  "actix-rt",
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "1.0.13"
+version = "1.0.14"
 edition = "2021"
 build = "build.rs"
 

--- a/apple/Tests/TestCases/Prelude/DisplayNameTests.swift
+++ b/apple/Tests/TestCases/Prelude/DisplayNameTests.swift
@@ -5,10 +5,6 @@ import SargonUniFFI
 import XCTest
 
 final class DisplayNameTests: Test<DisplayName> {
-	func test_too_long_throws() {
-		XCTAssertThrowsError(try SUT(validating: "very much too long a name that really does not fit here."))
-	}
-
 	func test_codable() throws {
 		let raw = "\"Spending Account\"".data(using: .utf8)!
 		

--- a/src/core/error/common_error.rs
+++ b/src/core/error/common_error.rs
@@ -230,9 +230,8 @@ pub enum CommonError {
     #[error("Invalid DisplayName cannot be empty.")]
     InvalidDisplayNameEmpty = 10062,
 
-    /// WARNING: UNUSED, can be replaced by any new error.
-    #[error("Invalid DisplayName too long, expected max: {expected}, found: {found}")]
-    InvalidDisplayNameTooLong { expected: u64, found: u64 } = 10063,
+    #[error("FREE")]
+    FREE = 10063,
 
     #[error("Invalid ISO8601 Time string: {bad_value}")]
     InvalidISO8601String { bad_value: String } = 10064,

--- a/src/core/error/common_error.rs
+++ b/src/core/error/common_error.rs
@@ -230,6 +230,7 @@ pub enum CommonError {
     #[error("Invalid DisplayName cannot be empty.")]
     InvalidDisplayNameEmpty = 10062,
 
+    /// WARNING: UNUSED, can be replaced by any new error.
     #[error("Invalid DisplayName too long, expected max: {expected}, found: {found}")]
     InvalidDisplayNameTooLong { expected: u64, found: u64 } = 10063,
 

--- a/src/core/error/common_error_map.rs
+++ b/src/core/error/common_error_map.rs
@@ -24,7 +24,7 @@ impl<R> MapToFailedToDeserializeJSONToValue<R>
             error!(
                 "Failed to deserialize JSON to {}, from:\n{:?}\nError: {}",
                 type_name::<T>(),
-                input.as_ref().to_string().chars().take(500),
+                prefix_str(500, &input),
                 e
             );
             CommonError::FailedToDeserializeJSONToValue {
@@ -43,7 +43,7 @@ impl<R> MapToFailedToDeserializeJSONToValue<R>
             error!(
                 "Failed to deserialize JSON to {}, from (UTF-8):\n{:?}\nError: {}", 
                 type_name::<T>(),
-                String::from_utf8(input.to_vec()).map(|json| json.chars().take(500).collect_vec()),
+                String::from_utf8(input.to_vec()).map(|json| prefix_str(500, json)),
                 e
             );
             CommonError::FailedToDeserializeJSONToValue {

--- a/src/core/utils/string_utils.rs
+++ b/src/core/utils/string_utils.rs
@@ -8,6 +8,12 @@ pub fn suffix_str(n: usize, s: impl AsRef<str>) -> String {
     s.as_ref()[split_pos..].to_string()
 }
 
+/// Returns the first `n` chars of the &str `s`. If `n` is bigger than `s` then
+/// the whole `s` is returned.
+pub fn prefix_str(n: usize, s: impl AsRef<str>) -> String {
+    s.as_ref().chars().take(n).collect()
+}
+
 /// Capitalizes the first character in s.
 pub fn capitalize(s: impl AsRef<str>) -> String {
     let mut c = s.as_ref().chars();
@@ -47,7 +53,28 @@ mod tests {
 
     #[test]
     fn string_suffix() {
-        assert_eq!(suffix_str(7, "By the rivers of Babylon"), "Babylon")
+        assert_eq!(
+            suffix_str(7, String::from("By the rivers of Babylon")),
+            "Babylon"
+        )
+    }
+
+    #[test]
+    fn str_prefix() {
+        assert_eq!(prefix_str(8, "Radix... imagine!"), "Radix...")
+    }
+
+    #[test]
+    fn str_prefix_longer_n() {
+        assert_eq!(prefix_str(32, "Radix... imagine!"), "Radix... imagine!")
+    }
+
+    #[test]
+    fn string_prefix() {
+        assert_eq!(
+            prefix_str(7, String::from("By the rivers of Babylon")),
+            "By the "
+        )
     }
 
     #[test]

--- a/src/profile/v100/entity/display_name.rs
+++ b/src/profile/v100/entity/display_name.rs
@@ -44,13 +44,14 @@ impl DisplayName {
     pub const MAX_LEN: usize = 30;
 
     pub fn new(value: impl AsRef<str>) -> Result<Self> {
-        let mut value = value.as_ref().trim().to_string();
+        let value = value.as_ref().trim().to_string();
         if value.is_empty() {
             return Err(CommonError::InvalidDisplayNameEmpty);
         }
-        value.truncate(Self::MAX_LEN);
 
-        Ok(Self { value })
+        Ok(Self {
+            value: value.chars().take(Self::MAX_LEN).collect(),
+        })
     }
 }
 

--- a/src/profile/v100/entity/display_name.rs
+++ b/src/profile/v100/entity/display_name.rs
@@ -13,6 +13,15 @@ use crate::prelude::*;
 /// assert_eq!("Satoshi".parse::<SUT>().unwrap().to_string(), "Satoshi");
 /// ```
 ///
+/// Names with longer than 30 chars are trimmed.
+/// ```
+/// extern crate sargon;
+/// use sargon::prelude::*;
+/// #[allow(clippy::upper_case_acronyms)]
+/// type SUT = DisplayName;
+/// assert_eq!("A very big name that is over than 30 characters long".parse::<SUT>().unwrap().to_string(), "A very big name that is over t");
+/// ```
+///
 #[derive(
     Clone,
     Debug,
@@ -35,16 +44,11 @@ impl DisplayName {
     pub const MAX_LEN: usize = 30;
 
     pub fn new(value: impl AsRef<str>) -> Result<Self> {
-        let value = value.as_ref().trim().to_string();
+        let mut value = value.as_ref().trim().to_string();
         if value.is_empty() {
             return Err(CommonError::InvalidDisplayNameEmpty);
         }
-        if value.len() > Self::MAX_LEN {
-            return Err(CommonError::InvalidDisplayNameTooLong {
-                expected: Self::MAX_LEN as u64,
-                found: value.len() as u64,
-            });
-        }
+        value.truncate(Self::MAX_LEN);
 
         Ok(Self { value })
     }
@@ -96,11 +100,8 @@ mod tests {
     fn invalid() {
         let s = "this is a much much too long display name";
         assert_eq!(
-            SUT::new(s),
-            Err(CommonError::InvalidDisplayNameTooLong {
-                expected: SUT::MAX_LEN as u64,
-                found: s.len() as u64
-            })
+            SUT::new(s).unwrap().value,
+            "this is a much much too long d"
         );
     }
 
@@ -140,9 +141,6 @@ mod tests {
 
     #[test]
     fn json_fails_for_invalid() {
-        assert_json_value_fails::<SUT>(json!(
-            "this is a much much too long display name"
-        ));
         assert_json_value_fails::<SUT>(json!(""));
         assert_json_value_fails::<SUT>(json!("   "));
     }

--- a/src/profile/v100/entity/display_name.rs
+++ b/src/profile/v100/entity/display_name.rs
@@ -50,7 +50,7 @@ impl DisplayName {
         }
 
         Ok(Self {
-            value: value.chars().take(Self::MAX_LEN).collect(),
+            value: prefix_str(Self::MAX_LEN, value),
         })
     }
 }


### PR DESCRIPTION
* User reported with profile that had display names with longer than 30 chars. This was resulting the deserialisation of the profile to return an error.
* The display names are now truncated.
* Question for @CyonAlexRDX: The `CommonError::InvalidDisplayNameTooLong` in now unused. I purposely did not delete it. Is it safe to remove it and fix the error codes of the rest of the following errors?
* Question to all. I used the [`truncate()`](https://doc.rust-lang.org/std/string/struct.String.html#method.truncate) function. This might panic if "new_len does not lie on a [char](https://doc.rust-lang.org/std/primitive.char.html) boundary." Can someone help with suggestions on how this might fail? Or even suggest a better function?