### PR TITLE
Add some extra metadata fields when creating token

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2586,7 +2586,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.0.16"
+version = "1.0.17"
 dependencies = [
  "actix-rt",
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "1.0.16"
+version = "1.0.17"
 edition = "2021"
 build = "build.rs"
 

--- a/apple/Tests/TestCases/RET/ManifestBuilding/ManifestBuildingTests.swift
+++ b/apple/Tests/TestCases/RET/ManifestBuilding/ManifestBuildingTests.swift
@@ -88,7 +88,9 @@ final class ManifestBuildingTests: Test<TransactionManifest> {
             oneOf(initialSupply.formattedPlain(locale: .test))
             oneOf(accountAddress.address)
         }
-        AccountAddress.sampleValues.forEach(doTest)
+		// We are not testing with AccountAddress.sampleValues since sampleMainnet & sampleMainnetOther are used
+		// to build the prefilled the dummy metadata extra fields (so they will appear more than once in the manifest).
+		[AccountAddress.sampleStokenet, .sampleStokenetOther].forEach(doTest)
     }
 	
 	func test_create_single_fungible_token() {

--- a/fixtures/transaction/create_3_nft_collections.rtm
+++ b/fixtures/transaction/create_3_nft_collections.rtm
@@ -136,6 +136,126 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
+            "extra_bool_0" => Tuple(
+                Enum<1u8>(
+                    Enum<1u8>(
+                        true
+                    )
+                ),
+                false
+            ),
+            "extra_bool_1" => Tuple(
+                Enum<1u8>(
+                    Enum<1u8>(
+                        false
+                    )
+                ),
+                false
+            ),
+            "extra_bool_2" => Tuple(
+                Enum<1u8>(
+                    Enum<1u8>(
+                        true
+                    )
+                ),
+                false
+            ),
+            "extra_bool_3" => Tuple(
+                Enum<1u8>(
+                    Enum<1u8>(
+                        false
+                    )
+                ),
+                false
+            ),
+            "extra_bool_4" => Tuple(
+                Enum<1u8>(
+                    Enum<1u8>(
+                        true
+                    )
+                ),
+                false
+            ),
+            "extra_i32_0" => Tuple(
+                Enum<1u8>(
+                    Enum<5u8>(
+                        0i32
+                    )
+                ),
+                false
+            ),
+            "extra_i32_1" => Tuple(
+                Enum<1u8>(
+                    Enum<5u8>(
+                        1i32
+                    )
+                ),
+                false
+            ),
+            "extra_i32_2" => Tuple(
+                Enum<1u8>(
+                    Enum<5u8>(
+                        2i32
+                    )
+                ),
+                false
+            ),
+            "extra_i32_3" => Tuple(
+                Enum<1u8>(
+                    Enum<5u8>(
+                        3i32
+                    )
+                ),
+                false
+            ),
+            "extra_i32_4" => Tuple(
+                Enum<1u8>(
+                    Enum<5u8>(
+                        4i32
+                    )
+                ),
+                false
+            ),
+            "extra_string_0" => Tuple(
+                Enum<1u8>(
+                    Enum<0u8>(
+                        "value_0"
+                    )
+                ),
+                false
+            ),
+            "extra_string_1" => Tuple(
+                Enum<1u8>(
+                    Enum<0u8>(
+                        "value_1"
+                    )
+                ),
+                false
+            ),
+            "extra_string_2" => Tuple(
+                Enum<1u8>(
+                    Enum<0u8>(
+                        "value_2"
+                    )
+                ),
+                false
+            ),
+            "extra_string_3" => Tuple(
+                Enum<1u8>(
+                    Enum<0u8>(
+                        "value_3"
+                    )
+                ),
+                false
+            ),
+            "extra_string_4" => Tuple(
+                Enum<1u8>(
+                    Enum<0u8>(
+                        "value_4"
+                    )
+                ),
+                false
+            ),
             "icon_url" => Tuple(
                 Enum<1u8>(
                     Enum<13u8>(
@@ -315,6 +435,126 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
+            "extra_bool_0" => Tuple(
+                Enum<1u8>(
+                    Enum<1u8>(
+                        true
+                    )
+                ),
+                false
+            ),
+            "extra_bool_1" => Tuple(
+                Enum<1u8>(
+                    Enum<1u8>(
+                        false
+                    )
+                ),
+                false
+            ),
+            "extra_bool_2" => Tuple(
+                Enum<1u8>(
+                    Enum<1u8>(
+                        true
+                    )
+                ),
+                false
+            ),
+            "extra_bool_3" => Tuple(
+                Enum<1u8>(
+                    Enum<1u8>(
+                        false
+                    )
+                ),
+                false
+            ),
+            "extra_bool_4" => Tuple(
+                Enum<1u8>(
+                    Enum<1u8>(
+                        true
+                    )
+                ),
+                false
+            ),
+            "extra_i32_0" => Tuple(
+                Enum<1u8>(
+                    Enum<5u8>(
+                        0i32
+                    )
+                ),
+                false
+            ),
+            "extra_i32_1" => Tuple(
+                Enum<1u8>(
+                    Enum<5u8>(
+                        1i32
+                    )
+                ),
+                false
+            ),
+            "extra_i32_2" => Tuple(
+                Enum<1u8>(
+                    Enum<5u8>(
+                        2i32
+                    )
+                ),
+                false
+            ),
+            "extra_i32_3" => Tuple(
+                Enum<1u8>(
+                    Enum<5u8>(
+                        3i32
+                    )
+                ),
+                false
+            ),
+            "extra_i32_4" => Tuple(
+                Enum<1u8>(
+                    Enum<5u8>(
+                        4i32
+                    )
+                ),
+                false
+            ),
+            "extra_string_0" => Tuple(
+                Enum<1u8>(
+                    Enum<0u8>(
+                        "value_0"
+                    )
+                ),
+                false
+            ),
+            "extra_string_1" => Tuple(
+                Enum<1u8>(
+                    Enum<0u8>(
+                        "value_1"
+                    )
+                ),
+                false
+            ),
+            "extra_string_2" => Tuple(
+                Enum<1u8>(
+                    Enum<0u8>(
+                        "value_2"
+                    )
+                ),
+                false
+            ),
+            "extra_string_3" => Tuple(
+                Enum<1u8>(
+                    Enum<0u8>(
+                        "value_3"
+                    )
+                ),
+                false
+            ),
+            "extra_string_4" => Tuple(
+                Enum<1u8>(
+                    Enum<0u8>(
+                        "value_4"
+                    )
+                ),
+                false
+            ),
             "icon_url" => Tuple(
                 Enum<1u8>(
                     Enum<13u8>(
@@ -490,6 +730,126 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 Enum<1u8>(
                     Enum<0u8>(
                         "Able: An amazingly innovative and rare NFT collection"
+                    )
+                ),
+                false
+            ),
+            "extra_bool_0" => Tuple(
+                Enum<1u8>(
+                    Enum<1u8>(
+                        true
+                    )
+                ),
+                false
+            ),
+            "extra_bool_1" => Tuple(
+                Enum<1u8>(
+                    Enum<1u8>(
+                        false
+                    )
+                ),
+                false
+            ),
+            "extra_bool_2" => Tuple(
+                Enum<1u8>(
+                    Enum<1u8>(
+                        true
+                    )
+                ),
+                false
+            ),
+            "extra_bool_3" => Tuple(
+                Enum<1u8>(
+                    Enum<1u8>(
+                        false
+                    )
+                ),
+                false
+            ),
+            "extra_bool_4" => Tuple(
+                Enum<1u8>(
+                    Enum<1u8>(
+                        true
+                    )
+                ),
+                false
+            ),
+            "extra_i32_0" => Tuple(
+                Enum<1u8>(
+                    Enum<5u8>(
+                        0i32
+                    )
+                ),
+                false
+            ),
+            "extra_i32_1" => Tuple(
+                Enum<1u8>(
+                    Enum<5u8>(
+                        1i32
+                    )
+                ),
+                false
+            ),
+            "extra_i32_2" => Tuple(
+                Enum<1u8>(
+                    Enum<5u8>(
+                        2i32
+                    )
+                ),
+                false
+            ),
+            "extra_i32_3" => Tuple(
+                Enum<1u8>(
+                    Enum<5u8>(
+                        3i32
+                    )
+                ),
+                false
+            ),
+            "extra_i32_4" => Tuple(
+                Enum<1u8>(
+                    Enum<5u8>(
+                        4i32
+                    )
+                ),
+                false
+            ),
+            "extra_string_0" => Tuple(
+                Enum<1u8>(
+                    Enum<0u8>(
+                        "value_0"
+                    )
+                ),
+                false
+            ),
+            "extra_string_1" => Tuple(
+                Enum<1u8>(
+                    Enum<0u8>(
+                        "value_1"
+                    )
+                ),
+                false
+            ),
+            "extra_string_2" => Tuple(
+                Enum<1u8>(
+                    Enum<0u8>(
+                        "value_2"
+                    )
+                ),
+                false
+            ),
+            "extra_string_3" => Tuple(
+                Enum<1u8>(
+                    Enum<0u8>(
+                        "value_3"
+                    )
+                ),
+                false
+            ),
+            "extra_string_4" => Tuple(
+                Enum<1u8>(
+                    Enum<0u8>(
+                        "value_4"
                     )
                 ),
                 false

--- a/fixtures/transaction/create_3_nft_collections.rtm
+++ b/fixtures/transaction/create_3_nft_collections.rtm
@@ -136,7 +136,280 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_bool_0" => Tuple(
+            "extra_BoolArray" => Tuple(
+                Enum<1u8>(
+                    Enum<129u8>(
+                        Array<Bool>(
+                            true,
+                            false
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_Decimal" => Tuple(
+                Enum<1u8>(
+                    Enum<7u8>(
+                        Decimal("8")
+                    )
+                ),
+                false
+            ),
+            "extra_DecimalArray" => Tuple(
+                Enum<1u8>(
+                    Enum<135u8>(
+                        Array<Decimal>(
+                            Decimal("1"),
+                            Decimal("2")
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_GlobalAddress" => Tuple(
+                Enum<1u8>(
+                    Enum<8u8>(
+                        Address("account_tdx_2_128y6j78mt0aqv6372evz28hrxp8mn06ccddkr7xppc88hyvyqrllae")
+                    )
+                ),
+                false
+            ),
+            "extra_GlobalAddressArray" => Tuple(
+                Enum<1u8>(
+                    Enum<136u8>(
+                        Array<Address>(
+                            Address("account_tdx_2_128y6j78mt0aqv6372evz28hrxp8mn06ccddkr7xppc88hyvyqrllae"),
+                            Address("account_tdx_2_12xkzynhzgtpnnd02tudw2els2g9xl73yk54ppw8xekt2sdrlwkwcf0")
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_I32Array" => Tuple(
+                Enum<1u8>(
+                    Enum<133u8>(
+                        Array<I32>(
+                            32i32,
+                            33i32,
+                            34i32,
+                            35i32
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_I64Array" => Tuple(
+                Enum<1u8>(
+                    Enum<134u8>(
+                        Array<I64>(
+                            64i64,
+                            65i64,
+                            66i64,
+                            67i64
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_Instant" => Tuple(
+                Enum<1u8>(
+                    Enum<12u8>(
+                        1891i64
+                    )
+                ),
+                false
+            ),
+            "extra_InstantArray" => Tuple(
+                Enum<1u8>(
+                    Enum<140u8>(
+                        Array<I64>(
+                            5i64,
+                            1891i64
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_NonFungibleGlobalId" => Tuple(
+                Enum<1u8>(
+                    Enum<10u8>(
+                        NonFungibleGlobalId("resource_tdx_2_1nfyg2f68jw7hfdlg5hzvd8ylsa7e0kjl68t5t62v3ttamtejs3wnhg:<Member_237>")
+                    )
+                ),
+                false
+            ),
+            "extra_NonFungibleGlobalIdArray" => Tuple(
+                Enum<1u8>(
+                    Enum<138u8>(
+                        Array<Tuple>(
+                            NonFungibleGlobalId("resource_tdx_2_1nfyg2f68jw7hfdlg5hzvd8ylsa7e0kjl68t5t62v3ttamtejs3wnhg:<Member_237>"),
+                            NonFungibleGlobalId("resource_tdx_2_1n2ekdd2m0jsxjt9wasmu3p49twy2yfalpaa6wf08md46sk8dp0lpzc:<foobar>")
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_NonFungibleLocalId" => Tuple(
+                Enum<1u8>(
+                    Enum<11u8>(
+                        NonFungibleLocalId("{deaddeaddeaddead-deaddeaddeaddead-deaddeaddeaddead-deaddeaddeaddead}")
+                    )
+                ),
+                false
+            ),
+            "extra_NonFungibleLocalIdArray" => Tuple(
+                Enum<1u8>(
+                    Enum<139u8>(
+                        Array<NonFungibleLocalId>(
+                            NonFungibleLocalId("{deaddeaddeaddead-deaddeaddeaddead-deaddeaddeaddead-deaddeaddeaddead}"),
+                            NonFungibleLocalId("<foobar>")
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_Origin" => Tuple(
+                Enum<1u8>(
+                    Enum<14u8>(
+                        "https://radixdlt.com"
+                    )
+                ),
+                false
+            ),
+            "extra_OriginArray" => Tuple(
+                Enum<1u8>(
+                    Enum<142u8>(
+                        Array<String>(
+                            "https://radixdlt.com",
+                            "https://ociswap.com"
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_PublicKey" => Tuple(
+                Enum<1u8>(
+                    Enum<9u8>(
+                        Enum<1u8>(
+                            Bytes("ec172b93ad5e563bf4932c70e1245034c35467ef2efd4d64ebf819683467e2bf")
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_PublicKeyArray" => Tuple(
+                Enum<1u8>(
+                    Enum<137u8>(
+                        Array<Enum>(
+                            Enum<1u8>(
+                                Bytes("ec172b93ad5e563bf4932c70e1245034c35467ef2efd4d64ebf819683467e2bf")
+                            ),
+                            Enum<0u8>(
+                                Bytes("033083620d1596d3f8988ff3270e42970dd2a031e2b9b6488052a4170ff999f3e8")
+                            )
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_PublicKeyHash" => Tuple(
+                Enum<1u8>(
+                    Enum<15u8>(
+                        Enum<1u8>(
+                            Bytes("f4e18c034e069baee91ada4764fdfcf2438b8f976861df00557d4cc9e7")
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_PublicKeyHashArray" => Tuple(
+                Enum<1u8>(
+                    Enum<143u8>(
+                        Array<Enum>(
+                            Enum<1u8>(
+                                Bytes("f4e18c034e069baee91ada4764fdfcf2438b8f976861df00557d4cc9e7")
+                            ),
+                            Enum<0u8>(
+                                Bytes("4a5004504dbbc08c65ba86fcd7592a3ac48db81d217fe2356e75b37f31")
+                            )
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_String" => Tuple(
+                Enum<1u8>(
+                    Enum<0u8>(
+                        "foo bar"
+                    )
+                ),
+                false
+            ),
+            "extra_StringArray" => Tuple(
+                Enum<1u8>(
+                    Enum<128u8>(
+                        Array<String>(
+                            "foo",
+                            "bar"
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_U32Array" => Tuple(
+                Enum<1u8>(
+                    Enum<131u8>(
+                        Array<U32>(
+                            32u32,
+                            33u32,
+                            34u32,
+                            35u32
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_U64Array" => Tuple(
+                Enum<1u8>(
+                    Enum<132u8>(
+                        Array<U64>(
+                            64u64,
+                            65u64,
+                            66u64,
+                            67u64
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_U8Array" => Tuple(
+                Enum<1u8>(
+                    Enum<130u8>(
+                        Bytes("08090a0b")
+                    )
+                ),
+                false
+            ),
+            "extra_Url" => Tuple(
+                Enum<1u8>(
+                    Enum<13u8>(
+                        "https://radixdlt.com"
+                    )
+                ),
+                false
+            ),
+            "extra_UrlArray" => Tuple(
+                Enum<1u8>(
+                    Enum<141u8>(
+                        Array<String>(
+                            "https://radixdlt.com",
+                            "https://ociswap.com"
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_bool" => Tuple(
                 Enum<1u8>(
                     Enum<1u8>(
                         true
@@ -144,114 +417,42 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_bool_1" => Tuple(
-                Enum<1u8>(
-                    Enum<1u8>(
-                        false
-                    )
-                ),
-                false
-            ),
-            "extra_bool_2" => Tuple(
-                Enum<1u8>(
-                    Enum<1u8>(
-                        true
-                    )
-                ),
-                false
-            ),
-            "extra_bool_3" => Tuple(
-                Enum<1u8>(
-                    Enum<1u8>(
-                        false
-                    )
-                ),
-                false
-            ),
-            "extra_bool_4" => Tuple(
-                Enum<1u8>(
-                    Enum<1u8>(
-                        true
-                    )
-                ),
-                false
-            ),
-            "extra_i32_0" => Tuple(
+            "extra_i32" => Tuple(
                 Enum<1u8>(
                     Enum<5u8>(
-                        0i32
+                        32i32
                     )
                 ),
                 false
             ),
-            "extra_i32_1" => Tuple(
+            "extra_i64" => Tuple(
                 Enum<1u8>(
-                    Enum<5u8>(
-                        1i32
+                    Enum<6u8>(
+                        64i64
                     )
                 ),
                 false
             ),
-            "extra_i32_2" => Tuple(
+            "extra_u32" => Tuple(
                 Enum<1u8>(
-                    Enum<5u8>(
-                        2i32
+                    Enum<3u8>(
+                        32u32
                     )
                 ),
                 false
             ),
-            "extra_i32_3" => Tuple(
+            "extra_u64" => Tuple(
                 Enum<1u8>(
-                    Enum<5u8>(
-                        3i32
+                    Enum<4u8>(
+                        64u64
                     )
                 ),
                 false
             ),
-            "extra_i32_4" => Tuple(
+            "extra_u8" => Tuple(
                 Enum<1u8>(
-                    Enum<5u8>(
-                        4i32
-                    )
-                ),
-                false
-            ),
-            "extra_string_0" => Tuple(
-                Enum<1u8>(
-                    Enum<0u8>(
-                        "value_0"
-                    )
-                ),
-                false
-            ),
-            "extra_string_1" => Tuple(
-                Enum<1u8>(
-                    Enum<0u8>(
-                        "value_1"
-                    )
-                ),
-                false
-            ),
-            "extra_string_2" => Tuple(
-                Enum<1u8>(
-                    Enum<0u8>(
-                        "value_2"
-                    )
-                ),
-                false
-            ),
-            "extra_string_3" => Tuple(
-                Enum<1u8>(
-                    Enum<0u8>(
-                        "value_3"
-                    )
-                ),
-                false
-            ),
-            "extra_string_4" => Tuple(
-                Enum<1u8>(
-                    Enum<0u8>(
-                        "value_4"
+                    Enum<2u8>(
+                        8u8
                     )
                 ),
                 false
@@ -435,7 +636,280 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_bool_0" => Tuple(
+            "extra_BoolArray" => Tuple(
+                Enum<1u8>(
+                    Enum<129u8>(
+                        Array<Bool>(
+                            true,
+                            false
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_Decimal" => Tuple(
+                Enum<1u8>(
+                    Enum<7u8>(
+                        Decimal("8")
+                    )
+                ),
+                false
+            ),
+            "extra_DecimalArray" => Tuple(
+                Enum<1u8>(
+                    Enum<135u8>(
+                        Array<Decimal>(
+                            Decimal("1"),
+                            Decimal("2")
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_GlobalAddress" => Tuple(
+                Enum<1u8>(
+                    Enum<8u8>(
+                        Address("account_tdx_2_128y6j78mt0aqv6372evz28hrxp8mn06ccddkr7xppc88hyvyqrllae")
+                    )
+                ),
+                false
+            ),
+            "extra_GlobalAddressArray" => Tuple(
+                Enum<1u8>(
+                    Enum<136u8>(
+                        Array<Address>(
+                            Address("account_tdx_2_128y6j78mt0aqv6372evz28hrxp8mn06ccddkr7xppc88hyvyqrllae"),
+                            Address("account_tdx_2_12xkzynhzgtpnnd02tudw2els2g9xl73yk54ppw8xekt2sdrlwkwcf0")
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_I32Array" => Tuple(
+                Enum<1u8>(
+                    Enum<133u8>(
+                        Array<I32>(
+                            32i32,
+                            33i32,
+                            34i32,
+                            35i32
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_I64Array" => Tuple(
+                Enum<1u8>(
+                    Enum<134u8>(
+                        Array<I64>(
+                            64i64,
+                            65i64,
+                            66i64,
+                            67i64
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_Instant" => Tuple(
+                Enum<1u8>(
+                    Enum<12u8>(
+                        1891i64
+                    )
+                ),
+                false
+            ),
+            "extra_InstantArray" => Tuple(
+                Enum<1u8>(
+                    Enum<140u8>(
+                        Array<I64>(
+                            5i64,
+                            1891i64
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_NonFungibleGlobalId" => Tuple(
+                Enum<1u8>(
+                    Enum<10u8>(
+                        NonFungibleGlobalId("resource_tdx_2_1nfyg2f68jw7hfdlg5hzvd8ylsa7e0kjl68t5t62v3ttamtejs3wnhg:<Member_237>")
+                    )
+                ),
+                false
+            ),
+            "extra_NonFungibleGlobalIdArray" => Tuple(
+                Enum<1u8>(
+                    Enum<138u8>(
+                        Array<Tuple>(
+                            NonFungibleGlobalId("resource_tdx_2_1nfyg2f68jw7hfdlg5hzvd8ylsa7e0kjl68t5t62v3ttamtejs3wnhg:<Member_237>"),
+                            NonFungibleGlobalId("resource_tdx_2_1n2ekdd2m0jsxjt9wasmu3p49twy2yfalpaa6wf08md46sk8dp0lpzc:<foobar>")
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_NonFungibleLocalId" => Tuple(
+                Enum<1u8>(
+                    Enum<11u8>(
+                        NonFungibleLocalId("{deaddeaddeaddead-deaddeaddeaddead-deaddeaddeaddead-deaddeaddeaddead}")
+                    )
+                ),
+                false
+            ),
+            "extra_NonFungibleLocalIdArray" => Tuple(
+                Enum<1u8>(
+                    Enum<139u8>(
+                        Array<NonFungibleLocalId>(
+                            NonFungibleLocalId("{deaddeaddeaddead-deaddeaddeaddead-deaddeaddeaddead-deaddeaddeaddead}"),
+                            NonFungibleLocalId("<foobar>")
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_Origin" => Tuple(
+                Enum<1u8>(
+                    Enum<14u8>(
+                        "https://radixdlt.com"
+                    )
+                ),
+                false
+            ),
+            "extra_OriginArray" => Tuple(
+                Enum<1u8>(
+                    Enum<142u8>(
+                        Array<String>(
+                            "https://radixdlt.com",
+                            "https://ociswap.com"
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_PublicKey" => Tuple(
+                Enum<1u8>(
+                    Enum<9u8>(
+                        Enum<1u8>(
+                            Bytes("ec172b93ad5e563bf4932c70e1245034c35467ef2efd4d64ebf819683467e2bf")
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_PublicKeyArray" => Tuple(
+                Enum<1u8>(
+                    Enum<137u8>(
+                        Array<Enum>(
+                            Enum<1u8>(
+                                Bytes("ec172b93ad5e563bf4932c70e1245034c35467ef2efd4d64ebf819683467e2bf")
+                            ),
+                            Enum<0u8>(
+                                Bytes("033083620d1596d3f8988ff3270e42970dd2a031e2b9b6488052a4170ff999f3e8")
+                            )
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_PublicKeyHash" => Tuple(
+                Enum<1u8>(
+                    Enum<15u8>(
+                        Enum<1u8>(
+                            Bytes("f4e18c034e069baee91ada4764fdfcf2438b8f976861df00557d4cc9e7")
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_PublicKeyHashArray" => Tuple(
+                Enum<1u8>(
+                    Enum<143u8>(
+                        Array<Enum>(
+                            Enum<1u8>(
+                                Bytes("f4e18c034e069baee91ada4764fdfcf2438b8f976861df00557d4cc9e7")
+                            ),
+                            Enum<0u8>(
+                                Bytes("4a5004504dbbc08c65ba86fcd7592a3ac48db81d217fe2356e75b37f31")
+                            )
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_String" => Tuple(
+                Enum<1u8>(
+                    Enum<0u8>(
+                        "foo bar"
+                    )
+                ),
+                false
+            ),
+            "extra_StringArray" => Tuple(
+                Enum<1u8>(
+                    Enum<128u8>(
+                        Array<String>(
+                            "foo",
+                            "bar"
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_U32Array" => Tuple(
+                Enum<1u8>(
+                    Enum<131u8>(
+                        Array<U32>(
+                            32u32,
+                            33u32,
+                            34u32,
+                            35u32
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_U64Array" => Tuple(
+                Enum<1u8>(
+                    Enum<132u8>(
+                        Array<U64>(
+                            64u64,
+                            65u64,
+                            66u64,
+                            67u64
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_U8Array" => Tuple(
+                Enum<1u8>(
+                    Enum<130u8>(
+                        Bytes("08090a0b")
+                    )
+                ),
+                false
+            ),
+            "extra_Url" => Tuple(
+                Enum<1u8>(
+                    Enum<13u8>(
+                        "https://radixdlt.com"
+                    )
+                ),
+                false
+            ),
+            "extra_UrlArray" => Tuple(
+                Enum<1u8>(
+                    Enum<141u8>(
+                        Array<String>(
+                            "https://radixdlt.com",
+                            "https://ociswap.com"
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_bool" => Tuple(
                 Enum<1u8>(
                     Enum<1u8>(
                         true
@@ -443,114 +917,42 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_bool_1" => Tuple(
-                Enum<1u8>(
-                    Enum<1u8>(
-                        false
-                    )
-                ),
-                false
-            ),
-            "extra_bool_2" => Tuple(
-                Enum<1u8>(
-                    Enum<1u8>(
-                        true
-                    )
-                ),
-                false
-            ),
-            "extra_bool_3" => Tuple(
-                Enum<1u8>(
-                    Enum<1u8>(
-                        false
-                    )
-                ),
-                false
-            ),
-            "extra_bool_4" => Tuple(
-                Enum<1u8>(
-                    Enum<1u8>(
-                        true
-                    )
-                ),
-                false
-            ),
-            "extra_i32_0" => Tuple(
+            "extra_i32" => Tuple(
                 Enum<1u8>(
                     Enum<5u8>(
-                        0i32
+                        32i32
                     )
                 ),
                 false
             ),
-            "extra_i32_1" => Tuple(
+            "extra_i64" => Tuple(
                 Enum<1u8>(
-                    Enum<5u8>(
-                        1i32
+                    Enum<6u8>(
+                        64i64
                     )
                 ),
                 false
             ),
-            "extra_i32_2" => Tuple(
+            "extra_u32" => Tuple(
                 Enum<1u8>(
-                    Enum<5u8>(
-                        2i32
+                    Enum<3u8>(
+                        32u32
                     )
                 ),
                 false
             ),
-            "extra_i32_3" => Tuple(
+            "extra_u64" => Tuple(
                 Enum<1u8>(
-                    Enum<5u8>(
-                        3i32
+                    Enum<4u8>(
+                        64u64
                     )
                 ),
                 false
             ),
-            "extra_i32_4" => Tuple(
+            "extra_u8" => Tuple(
                 Enum<1u8>(
-                    Enum<5u8>(
-                        4i32
-                    )
-                ),
-                false
-            ),
-            "extra_string_0" => Tuple(
-                Enum<1u8>(
-                    Enum<0u8>(
-                        "value_0"
-                    )
-                ),
-                false
-            ),
-            "extra_string_1" => Tuple(
-                Enum<1u8>(
-                    Enum<0u8>(
-                        "value_1"
-                    )
-                ),
-                false
-            ),
-            "extra_string_2" => Tuple(
-                Enum<1u8>(
-                    Enum<0u8>(
-                        "value_2"
-                    )
-                ),
-                false
-            ),
-            "extra_string_3" => Tuple(
-                Enum<1u8>(
-                    Enum<0u8>(
-                        "value_3"
-                    )
-                ),
-                false
-            ),
-            "extra_string_4" => Tuple(
-                Enum<1u8>(
-                    Enum<0u8>(
-                        "value_4"
+                    Enum<2u8>(
+                        8u8
                     )
                 ),
                 false
@@ -734,7 +1136,280 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_bool_0" => Tuple(
+            "extra_BoolArray" => Tuple(
+                Enum<1u8>(
+                    Enum<129u8>(
+                        Array<Bool>(
+                            true,
+                            false
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_Decimal" => Tuple(
+                Enum<1u8>(
+                    Enum<7u8>(
+                        Decimal("8")
+                    )
+                ),
+                false
+            ),
+            "extra_DecimalArray" => Tuple(
+                Enum<1u8>(
+                    Enum<135u8>(
+                        Array<Decimal>(
+                            Decimal("1"),
+                            Decimal("2")
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_GlobalAddress" => Tuple(
+                Enum<1u8>(
+                    Enum<8u8>(
+                        Address("account_tdx_2_128y6j78mt0aqv6372evz28hrxp8mn06ccddkr7xppc88hyvyqrllae")
+                    )
+                ),
+                false
+            ),
+            "extra_GlobalAddressArray" => Tuple(
+                Enum<1u8>(
+                    Enum<136u8>(
+                        Array<Address>(
+                            Address("account_tdx_2_128y6j78mt0aqv6372evz28hrxp8mn06ccddkr7xppc88hyvyqrllae"),
+                            Address("account_tdx_2_12xkzynhzgtpnnd02tudw2els2g9xl73yk54ppw8xekt2sdrlwkwcf0")
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_I32Array" => Tuple(
+                Enum<1u8>(
+                    Enum<133u8>(
+                        Array<I32>(
+                            32i32,
+                            33i32,
+                            34i32,
+                            35i32
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_I64Array" => Tuple(
+                Enum<1u8>(
+                    Enum<134u8>(
+                        Array<I64>(
+                            64i64,
+                            65i64,
+                            66i64,
+                            67i64
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_Instant" => Tuple(
+                Enum<1u8>(
+                    Enum<12u8>(
+                        1891i64
+                    )
+                ),
+                false
+            ),
+            "extra_InstantArray" => Tuple(
+                Enum<1u8>(
+                    Enum<140u8>(
+                        Array<I64>(
+                            5i64,
+                            1891i64
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_NonFungibleGlobalId" => Tuple(
+                Enum<1u8>(
+                    Enum<10u8>(
+                        NonFungibleGlobalId("resource_tdx_2_1nfyg2f68jw7hfdlg5hzvd8ylsa7e0kjl68t5t62v3ttamtejs3wnhg:<Member_237>")
+                    )
+                ),
+                false
+            ),
+            "extra_NonFungibleGlobalIdArray" => Tuple(
+                Enum<1u8>(
+                    Enum<138u8>(
+                        Array<Tuple>(
+                            NonFungibleGlobalId("resource_tdx_2_1nfyg2f68jw7hfdlg5hzvd8ylsa7e0kjl68t5t62v3ttamtejs3wnhg:<Member_237>"),
+                            NonFungibleGlobalId("resource_tdx_2_1n2ekdd2m0jsxjt9wasmu3p49twy2yfalpaa6wf08md46sk8dp0lpzc:<foobar>")
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_NonFungibleLocalId" => Tuple(
+                Enum<1u8>(
+                    Enum<11u8>(
+                        NonFungibleLocalId("{deaddeaddeaddead-deaddeaddeaddead-deaddeaddeaddead-deaddeaddeaddead}")
+                    )
+                ),
+                false
+            ),
+            "extra_NonFungibleLocalIdArray" => Tuple(
+                Enum<1u8>(
+                    Enum<139u8>(
+                        Array<NonFungibleLocalId>(
+                            NonFungibleLocalId("{deaddeaddeaddead-deaddeaddeaddead-deaddeaddeaddead-deaddeaddeaddead}"),
+                            NonFungibleLocalId("<foobar>")
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_Origin" => Tuple(
+                Enum<1u8>(
+                    Enum<14u8>(
+                        "https://radixdlt.com"
+                    )
+                ),
+                false
+            ),
+            "extra_OriginArray" => Tuple(
+                Enum<1u8>(
+                    Enum<142u8>(
+                        Array<String>(
+                            "https://radixdlt.com",
+                            "https://ociswap.com"
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_PublicKey" => Tuple(
+                Enum<1u8>(
+                    Enum<9u8>(
+                        Enum<1u8>(
+                            Bytes("ec172b93ad5e563bf4932c70e1245034c35467ef2efd4d64ebf819683467e2bf")
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_PublicKeyArray" => Tuple(
+                Enum<1u8>(
+                    Enum<137u8>(
+                        Array<Enum>(
+                            Enum<1u8>(
+                                Bytes("ec172b93ad5e563bf4932c70e1245034c35467ef2efd4d64ebf819683467e2bf")
+                            ),
+                            Enum<0u8>(
+                                Bytes("033083620d1596d3f8988ff3270e42970dd2a031e2b9b6488052a4170ff999f3e8")
+                            )
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_PublicKeyHash" => Tuple(
+                Enum<1u8>(
+                    Enum<15u8>(
+                        Enum<1u8>(
+                            Bytes("f4e18c034e069baee91ada4764fdfcf2438b8f976861df00557d4cc9e7")
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_PublicKeyHashArray" => Tuple(
+                Enum<1u8>(
+                    Enum<143u8>(
+                        Array<Enum>(
+                            Enum<1u8>(
+                                Bytes("f4e18c034e069baee91ada4764fdfcf2438b8f976861df00557d4cc9e7")
+                            ),
+                            Enum<0u8>(
+                                Bytes("4a5004504dbbc08c65ba86fcd7592a3ac48db81d217fe2356e75b37f31")
+                            )
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_String" => Tuple(
+                Enum<1u8>(
+                    Enum<0u8>(
+                        "foo bar"
+                    )
+                ),
+                false
+            ),
+            "extra_StringArray" => Tuple(
+                Enum<1u8>(
+                    Enum<128u8>(
+                        Array<String>(
+                            "foo",
+                            "bar"
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_U32Array" => Tuple(
+                Enum<1u8>(
+                    Enum<131u8>(
+                        Array<U32>(
+                            32u32,
+                            33u32,
+                            34u32,
+                            35u32
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_U64Array" => Tuple(
+                Enum<1u8>(
+                    Enum<132u8>(
+                        Array<U64>(
+                            64u64,
+                            65u64,
+                            66u64,
+                            67u64
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_U8Array" => Tuple(
+                Enum<1u8>(
+                    Enum<130u8>(
+                        Bytes("08090a0b")
+                    )
+                ),
+                false
+            ),
+            "extra_Url" => Tuple(
+                Enum<1u8>(
+                    Enum<13u8>(
+                        "https://radixdlt.com"
+                    )
+                ),
+                false
+            ),
+            "extra_UrlArray" => Tuple(
+                Enum<1u8>(
+                    Enum<141u8>(
+                        Array<String>(
+                            "https://radixdlt.com",
+                            "https://ociswap.com"
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_bool" => Tuple(
                 Enum<1u8>(
                     Enum<1u8>(
                         true
@@ -742,114 +1417,42 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_bool_1" => Tuple(
-                Enum<1u8>(
-                    Enum<1u8>(
-                        false
-                    )
-                ),
-                false
-            ),
-            "extra_bool_2" => Tuple(
-                Enum<1u8>(
-                    Enum<1u8>(
-                        true
-                    )
-                ),
-                false
-            ),
-            "extra_bool_3" => Tuple(
-                Enum<1u8>(
-                    Enum<1u8>(
-                        false
-                    )
-                ),
-                false
-            ),
-            "extra_bool_4" => Tuple(
-                Enum<1u8>(
-                    Enum<1u8>(
-                        true
-                    )
-                ),
-                false
-            ),
-            "extra_i32_0" => Tuple(
+            "extra_i32" => Tuple(
                 Enum<1u8>(
                     Enum<5u8>(
-                        0i32
+                        32i32
                     )
                 ),
                 false
             ),
-            "extra_i32_1" => Tuple(
+            "extra_i64" => Tuple(
                 Enum<1u8>(
-                    Enum<5u8>(
-                        1i32
+                    Enum<6u8>(
+                        64i64
                     )
                 ),
                 false
             ),
-            "extra_i32_2" => Tuple(
+            "extra_u32" => Tuple(
                 Enum<1u8>(
-                    Enum<5u8>(
-                        2i32
+                    Enum<3u8>(
+                        32u32
                     )
                 ),
                 false
             ),
-            "extra_i32_3" => Tuple(
+            "extra_u64" => Tuple(
                 Enum<1u8>(
-                    Enum<5u8>(
-                        3i32
+                    Enum<4u8>(
+                        64u64
                     )
                 ),
                 false
             ),
-            "extra_i32_4" => Tuple(
+            "extra_u8" => Tuple(
                 Enum<1u8>(
-                    Enum<5u8>(
-                        4i32
-                    )
-                ),
-                false
-            ),
-            "extra_string_0" => Tuple(
-                Enum<1u8>(
-                    Enum<0u8>(
-                        "value_0"
-                    )
-                ),
-                false
-            ),
-            "extra_string_1" => Tuple(
-                Enum<1u8>(
-                    Enum<0u8>(
-                        "value_1"
-                    )
-                ),
-                false
-            ),
-            "extra_string_2" => Tuple(
-                Enum<1u8>(
-                    Enum<0u8>(
-                        "value_2"
-                    )
-                ),
-                false
-            ),
-            "extra_string_3" => Tuple(
-                Enum<1u8>(
-                    Enum<0u8>(
-                        "value_3"
-                    )
-                ),
-                false
-            ),
-            "extra_string_4" => Tuple(
-                Enum<1u8>(
-                    Enum<0u8>(
-                        "value_4"
+                    Enum<2u8>(
+                        8u8
                     )
                 ),
                 false

--- a/src/wrapped_radix_engine_toolkit/high_level/manifest_building/manifests_create_tokens.rs
+++ b/src/wrapped_radix_engine_toolkit/high_level/manifest_building/manifests_create_tokens.rs
@@ -373,7 +373,280 @@ mod tests {
                 ),
                 false
             ),
-            "extra_bool_0" => Tuple(
+            "extra_BoolArray" => Tuple(
+                Enum<1u8>(
+                    Enum<129u8>(
+                        Array<Bool>(
+                            true,
+                            false
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_Decimal" => Tuple(
+                Enum<1u8>(
+                    Enum<7u8>(
+                        Decimal("8")
+                    )
+                ),
+                false
+            ),
+            "extra_DecimalArray" => Tuple(
+                Enum<1u8>(
+                    Enum<135u8>(
+                        Array<Decimal>(
+                            Decimal("1"),
+                            Decimal("2")
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_GlobalAddress" => Tuple(
+                Enum<1u8>(
+                    Enum<8u8>(
+                        Address("account_rdx128y6j78mt0aqv6372evz28hrxp8mn06ccddkr7xppc88hyvynvjdwr")
+                    )
+                ),
+                false
+            ),
+            "extra_GlobalAddressArray" => Tuple(
+                Enum<1u8>(
+                    Enum<136u8>(
+                        Array<Address>(
+                            Address("account_rdx128y6j78mt0aqv6372evz28hrxp8mn06ccddkr7xppc88hyvynvjdwr"),
+                            Address("account_rdx12xkzynhzgtpnnd02tudw2els2g9xl73yk54ppw8xekt2sdrlaer264")
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_I32Array" => Tuple(
+                Enum<1u8>(
+                    Enum<133u8>(
+                        Array<I32>(
+                            32i32,
+                            33i32,
+                            34i32,
+                            35i32
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_I64Array" => Tuple(
+                Enum<1u8>(
+                    Enum<134u8>(
+                        Array<I64>(
+                            64i64,
+                            65i64,
+                            66i64,
+                            67i64
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_Instant" => Tuple(
+                Enum<1u8>(
+                    Enum<12u8>(
+                        1891i64
+                    )
+                ),
+                false
+            ),
+            "extra_InstantArray" => Tuple(
+                Enum<1u8>(
+                    Enum<140u8>(
+                        Array<I64>(
+                            5i64,
+                            1891i64
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_NonFungibleGlobalId" => Tuple(
+                Enum<1u8>(
+                    Enum<10u8>(
+                        NonFungibleGlobalId("resource_rdx1nfyg2f68jw7hfdlg5hzvd8ylsa7e0kjl68t5t62v3ttamtejc9wlxa:<Member_237>")
+                    )
+                ),
+                false
+            ),
+            "extra_NonFungibleGlobalIdArray" => Tuple(
+                Enum<1u8>(
+                    Enum<138u8>(
+                        Array<Tuple>(
+                            NonFungibleGlobalId("resource_rdx1nfyg2f68jw7hfdlg5hzvd8ylsa7e0kjl68t5t62v3ttamtejc9wlxa:<Member_237>"),
+                            NonFungibleGlobalId("resource_rdx1n2ekdd2m0jsxjt9wasmu3p49twy2yfalpaa6wf08md46sk8dfmldnd:<foobar>")
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_NonFungibleLocalId" => Tuple(
+                Enum<1u8>(
+                    Enum<11u8>(
+                        NonFungibleLocalId("{deaddeaddeaddead-deaddeaddeaddead-deaddeaddeaddead-deaddeaddeaddead}")
+                    )
+                ),
+                false
+            ),
+            "extra_NonFungibleLocalIdArray" => Tuple(
+                Enum<1u8>(
+                    Enum<139u8>(
+                        Array<NonFungibleLocalId>(
+                            NonFungibleLocalId("{deaddeaddeaddead-deaddeaddeaddead-deaddeaddeaddead-deaddeaddeaddead}"),
+                            NonFungibleLocalId("<foobar>")
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_Origin" => Tuple(
+                Enum<1u8>(
+                    Enum<14u8>(
+                        "https://radixdlt.com"
+                    )
+                ),
+                false
+            ),
+            "extra_OriginArray" => Tuple(
+                Enum<1u8>(
+                    Enum<142u8>(
+                        Array<String>(
+                            "https://radixdlt.com",
+                            "https://ociswap.com"
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_PublicKey" => Tuple(
+                Enum<1u8>(
+                    Enum<9u8>(
+                        Enum<1u8>(
+                            Bytes("ec172b93ad5e563bf4932c70e1245034c35467ef2efd4d64ebf819683467e2bf")
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_PublicKeyArray" => Tuple(
+                Enum<1u8>(
+                    Enum<137u8>(
+                        Array<Enum>(
+                            Enum<1u8>(
+                                Bytes("ec172b93ad5e563bf4932c70e1245034c35467ef2efd4d64ebf819683467e2bf")
+                            ),
+                            Enum<0u8>(
+                                Bytes("033083620d1596d3f8988ff3270e42970dd2a031e2b9b6488052a4170ff999f3e8")
+                            )
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_PublicKeyHash" => Tuple(
+                Enum<1u8>(
+                    Enum<15u8>(
+                        Enum<1u8>(
+                            Bytes("f4e18c034e069baee91ada4764fdfcf2438b8f976861df00557d4cc9e7")
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_PublicKeyHashArray" => Tuple(
+                Enum<1u8>(
+                    Enum<143u8>(
+                        Array<Enum>(
+                            Enum<1u8>(
+                                Bytes("f4e18c034e069baee91ada4764fdfcf2438b8f976861df00557d4cc9e7")
+                            ),
+                            Enum<0u8>(
+                                Bytes("4a5004504dbbc08c65ba86fcd7592a3ac48db81d217fe2356e75b37f31")
+                            )
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_String" => Tuple(
+                Enum<1u8>(
+                    Enum<0u8>(
+                        "foo bar"
+                    )
+                ),
+                false
+            ),
+            "extra_StringArray" => Tuple(
+                Enum<1u8>(
+                    Enum<128u8>(
+                        Array<String>(
+                            "foo",
+                            "bar"
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_U32Array" => Tuple(
+                Enum<1u8>(
+                    Enum<131u8>(
+                        Array<U32>(
+                            32u32,
+                            33u32,
+                            34u32,
+                            35u32
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_U64Array" => Tuple(
+                Enum<1u8>(
+                    Enum<132u8>(
+                        Array<U64>(
+                            64u64,
+                            65u64,
+                            66u64,
+                            67u64
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_U8Array" => Tuple(
+                Enum<1u8>(
+                    Enum<130u8>(
+                        Bytes("08090a0b")
+                    )
+                ),
+                false
+            ),
+            "extra_Url" => Tuple(
+                Enum<1u8>(
+                    Enum<13u8>(
+                        "https://radixdlt.com"
+                    )
+                ),
+                false
+            ),
+            "extra_UrlArray" => Tuple(
+                Enum<1u8>(
+                    Enum<141u8>(
+                        Array<String>(
+                            "https://radixdlt.com",
+                            "https://ociswap.com"
+                        )
+                    )
+                ),
+                false
+            ),
+            "extra_bool" => Tuple(
                 Enum<1u8>(
                     Enum<1u8>(
                         true
@@ -381,114 +654,42 @@ mod tests {
                 ),
                 false
             ),
-            "extra_bool_1" => Tuple(
-                Enum<1u8>(
-                    Enum<1u8>(
-                        false
-                    )
-                ),
-                false
-            ),
-            "extra_bool_2" => Tuple(
-                Enum<1u8>(
-                    Enum<1u8>(
-                        true
-                    )
-                ),
-                false
-            ),
-            "extra_bool_3" => Tuple(
-                Enum<1u8>(
-                    Enum<1u8>(
-                        false
-                    )
-                ),
-                false
-            ),
-            "extra_bool_4" => Tuple(
-                Enum<1u8>(
-                    Enum<1u8>(
-                        true
-                    )
-                ),
-                false
-            ),
-            "extra_i32_0" => Tuple(
+            "extra_i32" => Tuple(
                 Enum<1u8>(
                     Enum<5u8>(
-                        0i32
+                        32i32
                     )
                 ),
                 false
             ),
-            "extra_i32_1" => Tuple(
+            "extra_i64" => Tuple(
                 Enum<1u8>(
-                    Enum<5u8>(
-                        1i32
+                    Enum<6u8>(
+                        64i64
                     )
                 ),
                 false
             ),
-            "extra_i32_2" => Tuple(
+            "extra_u32" => Tuple(
                 Enum<1u8>(
-                    Enum<5u8>(
-                        2i32
+                    Enum<3u8>(
+                        32u32
                     )
                 ),
                 false
             ),
-            "extra_i32_3" => Tuple(
+            "extra_u64" => Tuple(
                 Enum<1u8>(
-                    Enum<5u8>(
-                        3i32
+                    Enum<4u8>(
+                        64u64
                     )
                 ),
                 false
             ),
-            "extra_i32_4" => Tuple(
+            "extra_u8" => Tuple(
                 Enum<1u8>(
-                    Enum<5u8>(
-                        4i32
-                    )
-                ),
-                false
-            ),
-            "extra_string_0" => Tuple(
-                Enum<1u8>(
-                    Enum<0u8>(
-                        "value_0"
-                    )
-                ),
-                false
-            ),
-            "extra_string_1" => Tuple(
-                Enum<1u8>(
-                    Enum<0u8>(
-                        "value_1"
-                    )
-                ),
-                false
-            ),
-            "extra_string_2" => Tuple(
-                Enum<1u8>(
-                    Enum<0u8>(
-                        "value_2"
-                    )
-                ),
-                false
-            ),
-            "extra_string_3" => Tuple(
-                Enum<1u8>(
-                    Enum<0u8>(
-                        "value_3"
-                    )
-                ),
-                false
-            ),
-            "extra_string_4" => Tuple(
-                Enum<1u8>(
-                    Enum<0u8>(
-                        "value_4"
+                    Enum<2u8>(
+                        8u8
                     )
                 ),
                 false

--- a/src/wrapped_radix_engine_toolkit/high_level/manifest_building/manifests_create_tokens.rs
+++ b/src/wrapped_radix_engine_toolkit/high_level/manifest_building/manifests_create_tokens.rs
@@ -373,6 +373,126 @@ mod tests {
                 ),
                 false
             ),
+            "extra_bool_0" => Tuple(
+                Enum<1u8>(
+                    Enum<1u8>(
+                        true
+                    )
+                ),
+                false
+            ),
+            "extra_bool_1" => Tuple(
+                Enum<1u8>(
+                    Enum<1u8>(
+                        false
+                    )
+                ),
+                false
+            ),
+            "extra_bool_2" => Tuple(
+                Enum<1u8>(
+                    Enum<1u8>(
+                        true
+                    )
+                ),
+                false
+            ),
+            "extra_bool_3" => Tuple(
+                Enum<1u8>(
+                    Enum<1u8>(
+                        false
+                    )
+                ),
+                false
+            ),
+            "extra_bool_4" => Tuple(
+                Enum<1u8>(
+                    Enum<1u8>(
+                        true
+                    )
+                ),
+                false
+            ),
+            "extra_i32_0" => Tuple(
+                Enum<1u8>(
+                    Enum<5u8>(
+                        0i32
+                    )
+                ),
+                false
+            ),
+            "extra_i32_1" => Tuple(
+                Enum<1u8>(
+                    Enum<5u8>(
+                        1i32
+                    )
+                ),
+                false
+            ),
+            "extra_i32_2" => Tuple(
+                Enum<1u8>(
+                    Enum<5u8>(
+                        2i32
+                    )
+                ),
+                false
+            ),
+            "extra_i32_3" => Tuple(
+                Enum<1u8>(
+                    Enum<5u8>(
+                        3i32
+                    )
+                ),
+                false
+            ),
+            "extra_i32_4" => Tuple(
+                Enum<1u8>(
+                    Enum<5u8>(
+                        4i32
+                    )
+                ),
+                false
+            ),
+            "extra_string_0" => Tuple(
+                Enum<1u8>(
+                    Enum<0u8>(
+                        "value_0"
+                    )
+                ),
+                false
+            ),
+            "extra_string_1" => Tuple(
+                Enum<1u8>(
+                    Enum<0u8>(
+                        "value_1"
+                    )
+                ),
+                false
+            ),
+            "extra_string_2" => Tuple(
+                Enum<1u8>(
+                    Enum<0u8>(
+                        "value_2"
+                    )
+                ),
+                false
+            ),
+            "extra_string_3" => Tuple(
+                Enum<1u8>(
+                    Enum<0u8>(
+                        "value_3"
+                    )
+                ),
+                false
+            ),
+            "extra_string_4" => Tuple(
+                Enum<1u8>(
+                    Enum<0u8>(
+                        "value_4"
+                    )
+                ),
+                false
+            ),
             "icon_url" => Tuple(
                 Enum<1u8>(
                     Enum<13u8>(

--- a/src/wrapped_radix_engine_toolkit/high_level/token_definition_metadata.rs
+++ b/src/wrapped_radix_engine_toolkit/high_level/token_definition_metadata.rs
@@ -1,4 +1,8 @@
 use crate::prelude::*;
+use radix_common::prelude::NodeId;
+use radix_common::time::Instant;
+use radix_common::types::GlobalAddress;
+use radix_engine_interface::prelude::UncheckedOrigin;
 
 #[derive(
     Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash, uniffi::Record,
@@ -15,7 +19,7 @@ impl From<TokenDefinitionMetadata>
     for ScryptoModuleConfig<ScryptoMetadataInit>
 {
     fn from(value: TokenDefinitionMetadata) -> Self {
-        let mut map = BTreeMap::<String, ScryptoMetadataValue>::from([
+        let map = BTreeMap::<String, ScryptoMetadataValue>::from([
             (
                 MetadataKey::Name.to_string(),
                 ScryptoMetadataValue::String(value.name),
@@ -36,22 +40,159 @@ impl From<TokenDefinitionMetadata>
                 MetadataKey::Tags.to_string(),
                 ScryptoMetadataValue::StringArray(value.tags),
             ),
+            (
+                "extra_String".to_string(),
+                ScryptoMetadataValue::String("foo bar".to_string()),
+            ),
+            ("extra_bool".to_string(), ScryptoMetadataValue::Bool(true)),
+            ("extra_u8".to_string(), ScryptoMetadataValue::U8(8)),
+            ("extra_u32".to_string(), ScryptoMetadataValue::U32(32)),
+            ("extra_u64".to_string(), ScryptoMetadataValue::U64(64)),
+            ("extra_i32".to_string(), ScryptoMetadataValue::I32(32)),
+            ("extra_i64".to_string(), ScryptoMetadataValue::I64(64)),
+            (
+                "extra_Decimal".to_string(),
+                ScryptoMetadataValue::Decimal(Decimal::eight().into()),
+            ),
+            (
+                "extra_GlobalAddress".to_string(),
+                ScryptoMetadataValue::GlobalAddress(GlobalAddress::from(
+                    AccountAddress::sample(),
+                )),
+            ),
+            (
+                "extra_PublicKey".to_string(),
+                ScryptoMetadataValue::PublicKey(PublicKey::sample().into()),
+            ),
+            (
+                "extra_NonFungibleGlobalId".to_string(),
+                ScryptoMetadataValue::NonFungibleGlobalId(
+                    NonFungibleGlobalId::sample().into(),
+                ),
+            ),
+            (
+                "extra_NonFungibleLocalId".to_string(),
+                ScryptoMetadataValue::NonFungibleLocalId(
+                    NonFungibleLocalId::sample().into(),
+                ),
+            ),
+            (
+                "extra_Instant".to_string(),
+                ScryptoMetadataValue::Instant(Instant::new(1891)),
+            ),
+            (
+                "extra_Url".to_string(),
+                ScryptoMetadataValue::Url(ScryptoUncheckedUrl::of(
+                    "https://radixdlt.com",
+                )),
+            ),
+            (
+                "extra_Origin".to_string(),
+                ScryptoMetadataValue::Origin(UncheckedOrigin::of(
+                    "https://radixdlt.com",
+                )),
+            ),
+            (
+                "extra_PublicKeyHash".to_string(),
+                ScryptoMetadataValue::PublicKeyHash(
+                    PublicKeyHash::sample().into(),
+                ),
+            ),
+            (
+                "extra_StringArray".to_string(),
+                ScryptoMetadataValue::StringArray(vec![
+                    "foo".to_string(),
+                    "bar".to_string(),
+                ]),
+            ),
+            (
+                "extra_BoolArray".to_string(),
+                ScryptoMetadataValue::BoolArray(vec![true, false]),
+            ),
+            (
+                "extra_U8Array".to_string(),
+                ScryptoMetadataValue::U8Array(vec![8, 9, 10, 11]),
+            ),
+            (
+                "extra_U32Array".to_string(),
+                ScryptoMetadataValue::U32Array(vec![32, 33, 34, 35]),
+            ),
+            (
+                "extra_U64Array".to_string(),
+                ScryptoMetadataValue::U64Array(vec![64, 65, 66, 67]),
+            ),
+            (
+                "extra_I32Array".to_string(),
+                ScryptoMetadataValue::I32Array(vec![32, 33, 34, 35]),
+            ),
+            (
+                "extra_I64Array".to_string(),
+                ScryptoMetadataValue::I64Array(vec![64, 65, 66, 67]),
+            ),
+            (
+                "extra_DecimalArray".to_string(),
+                ScryptoMetadataValue::DecimalArray(vec![
+                    Decimal::one().into(),
+                    Decimal::two().into(),
+                ]),
+            ),
+            (
+                "extra_GlobalAddressArray".to_string(),
+                ScryptoMetadataValue::GlobalAddressArray(vec![
+                    GlobalAddress::from(AccountAddress::sample()),
+                    GlobalAddress::from(AccountAddress::sample_other()),
+                ]),
+            ),
+            (
+                "extra_PublicKeyArray".to_string(),
+                ScryptoMetadataValue::PublicKeyArray(vec![
+                    PublicKey::sample().into(),
+                    PublicKey::sample_other().into(),
+                ]),
+            ),
+            (
+                "extra_NonFungibleGlobalIdArray".to_string(),
+                ScryptoMetadataValue::NonFungibleGlobalIdArray(vec![
+                    NonFungibleGlobalId::sample().into(),
+                    NonFungibleGlobalId::sample_other().into(),
+                ]),
+            ),
+            (
+                "extra_NonFungibleLocalIdArray".to_string(),
+                ScryptoMetadataValue::NonFungibleLocalIdArray(vec![
+                    NonFungibleLocalId::sample().into(),
+                    NonFungibleLocalId::sample_other().into(),
+                ]),
+            ),
+            (
+                "extra_InstantArray".to_string(),
+                ScryptoMetadataValue::InstantArray(vec![
+                    Instant::new(5),
+                    Instant::new(1891),
+                ]),
+            ),
+            (
+                "extra_UrlArray".to_string(),
+                ScryptoMetadataValue::UrlArray(vec![
+                    ScryptoUncheckedUrl::of("https://radixdlt.com"),
+                    ScryptoUncheckedUrl::of("https://ociswap.com"),
+                ]),
+            ),
+            (
+                "extra_OriginArray".to_string(),
+                ScryptoMetadataValue::OriginArray(vec![
+                    UncheckedOrigin::of("https://radixdlt.com"),
+                    UncheckedOrigin::of("https://ociswap.com"),
+                ]),
+            ),
+            (
+                "extra_PublicKeyHashArray".to_string(),
+                ScryptoMetadataValue::PublicKeyHashArray(vec![
+                    PublicKeyHash::sample().into(),
+                    PublicKeyHash::sample_other().into(),
+                ]),
+            ),
         ]);
-
-        for i in 0..5 {
-            map.insert(
-                format!("extra_string_{}", i),
-                ScryptoMetadataValue::String(format!("value_{}", i)),
-            );
-            map.insert(
-                format!("extra_bool_{}", i),
-                ScryptoMetadataValue::Bool(i % 2 == 0),
-            );
-            map.insert(
-                format!("extra_i32_{}", i),
-                ScryptoMetadataValue::I32(i),
-            );
-        }
         let init: ScryptoMetadataInit = map.into();
         ScryptoModuleConfig {
             init,

--- a/src/wrapped_radix_engine_toolkit/high_level/token_definition_metadata.rs
+++ b/src/wrapped_radix_engine_toolkit/high_level/token_definition_metadata.rs
@@ -15,7 +15,7 @@ impl From<TokenDefinitionMetadata>
     for ScryptoModuleConfig<ScryptoMetadataInit>
 {
     fn from(value: TokenDefinitionMetadata) -> Self {
-        let map = BTreeMap::<String, ScryptoMetadataValue>::from([
+        let mut map = BTreeMap::<String, ScryptoMetadataValue>::from([
             (
                 MetadataKey::Name.to_string(),
                 ScryptoMetadataValue::String(value.name),
@@ -37,6 +37,21 @@ impl From<TokenDefinitionMetadata>
                 ScryptoMetadataValue::StringArray(value.tags),
             ),
         ]);
+
+        for i in 0..5 {
+            map.insert(
+                format!("extra_string_{}", i),
+                ScryptoMetadataValue::String(format!("value_{}", i)),
+            );
+            map.insert(
+                format!("extra_bool_{}", i),
+                ScryptoMetadataValue::Bool(i % 2 == 0),
+            );
+            map.insert(
+                format!("extra_i32_{}", i),
+                ScryptoMetadataValue::I32(i),
+            );
+        }
         let init: ScryptoMetadataInit = map.into();
         ScryptoModuleConfig {
             init,


### PR DESCRIPTION
When creating a test token, the manifest will now include metadata values for every accepted type.