### PR TITLE
Fix Transaction Manifest builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2586,7 +2586,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.0.17"
+version = "1.0.18"
 dependencies = [
  "actix-rt",
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "1.0.17"
+version = "1.0.18"
 edition = "2021"
 build = "build.rs"
 

--- a/apple/Tests/TestCases/RET/ManifestBuilding/ManifestBuildingTests.swift
+++ b/apple/Tests/TestCases/RET/ManifestBuilding/ManifestBuildingTests.swift
@@ -86,11 +86,10 @@ final class ManifestBuildingTests: Test<TransactionManifest> {
             oneIn(metadata: \.description)
             oneIn(metadata: \.symbol)
             oneOf(initialSupply.formattedPlain(locale: .test))
-            oneOf(accountAddress.address)
         }
 		// We are not testing with AccountAddress.sampleValues since sampleMainnet & sampleMainnetOther are used
 		// to build the prefilled the dummy metadata extra fields (so they will appear more than once in the manifest).
-		[AccountAddress.sampleStokenet, .sampleStokenetOther].forEach(doTest)
+		AccountAddress.sampleValues.forEach(doTest)
     }
 	
 	func test_create_single_fungible_token() {

--- a/fixtures/transaction/create_3_nft_collections.rtm
+++ b/fixtures/transaction/create_3_nft_collections.rtm
@@ -136,7 +136,15 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_BoolArray" => Tuple(
+            "extra_bool" => Tuple(
+                Enum<1u8>(
+                    Enum<1u8>(
+                        true
+                    )
+                ),
+                false
+            ),
+            "extra_bool_array" => Tuple(
                 Enum<1u8>(
                     Enum<129u8>(
                         Array<Bool>(
@@ -147,7 +155,7 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_Decimal" => Tuple(
+            "extra_decimal" => Tuple(
                 Enum<1u8>(
                     Enum<7u8>(
                         Decimal("8")
@@ -155,7 +163,7 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_DecimalArray" => Tuple(
+            "extra_decimal_array" => Tuple(
                 Enum<1u8>(
                     Enum<135u8>(
                         Array<Decimal>(
@@ -166,7 +174,7 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_GlobalAddress" => Tuple(
+            "extra_global_address" => Tuple(
                 Enum<1u8>(
                     Enum<8u8>(
                         Address("account_tdx_2_128y6j78mt0aqv6372evz28hrxp8mn06ccddkr7xppc88hyvyqrllae")
@@ -174,18 +182,26 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_GlobalAddressArray" => Tuple(
+            "extra_global_address_array" => Tuple(
                 Enum<1u8>(
                     Enum<136u8>(
                         Array<Address>(
-                            Address("account_tdx_2_128y6j78mt0aqv6372evz28hrxp8mn06ccddkr7xppc88hyvyqrllae"),
-                            Address("account_tdx_2_12xkzynhzgtpnnd02tudw2els2g9xl73yk54ppw8xekt2sdrlwkwcf0")
+                            Address("account_tdx_2_1289zm062j788dwrjefqkfgfeea5tkkdnh8htqhdrzdvjkql4kxceql"),
+                            Address("account_tdx_2_129663ef7fj8azge3y6sl73lf9vyqt53ewzlf7ul2l76mg5wyqlqlpr")
                         )
                     )
                 ),
                 false
             ),
-            "extra_I32Array" => Tuple(
+            "extra_i32" => Tuple(
+                Enum<1u8>(
+                    Enum<5u8>(
+                        32i32
+                    )
+                ),
+                false
+            ),
+            "extra_i32_array" => Tuple(
                 Enum<1u8>(
                     Enum<133u8>(
                         Array<I32>(
@@ -198,7 +214,15 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_I64Array" => Tuple(
+            "extra_i64" => Tuple(
+                Enum<1u8>(
+                    Enum<6u8>(
+                        64i64
+                    )
+                ),
+                false
+            ),
+            "extra_i64_array" => Tuple(
                 Enum<1u8>(
                     Enum<134u8>(
                         Array<I64>(
@@ -211,7 +235,7 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_Instant" => Tuple(
+            "extra_instant" => Tuple(
                 Enum<1u8>(
                     Enum<12u8>(
                         1891i64
@@ -219,7 +243,7 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_InstantArray" => Tuple(
+            "extra_instant_array" => Tuple(
                 Enum<1u8>(
                     Enum<140u8>(
                         Array<I64>(
@@ -230,45 +254,45 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_NonFungibleGlobalId" => Tuple(
+            "extra_non_fungible_global_id" => Tuple(
                 Enum<1u8>(
                     Enum<10u8>(
-                        NonFungibleGlobalId("resource_tdx_2_1nfyg2f68jw7hfdlg5hzvd8ylsa7e0kjl68t5t62v3ttamtejs3wnhg:<Member_237>")
+                        NonFungibleGlobalId("resource_tdx_2_1ng6aanl0nw98dgqxtja3mx4kpa8rzwhyt4q22sy9uul0vf9frs528x:#1#")
                     )
                 ),
                 false
             ),
-            "extra_NonFungibleGlobalIdArray" => Tuple(
+            "extra_non_fungible_global_id_array" => Tuple(
                 Enum<1u8>(
                     Enum<138u8>(
                         Array<Tuple>(
-                            NonFungibleGlobalId("resource_tdx_2_1nfyg2f68jw7hfdlg5hzvd8ylsa7e0kjl68t5t62v3ttamtejs3wnhg:<Member_237>"),
-                            NonFungibleGlobalId("resource_tdx_2_1n2ekdd2m0jsxjt9wasmu3p49twy2yfalpaa6wf08md46sk8dp0lpzc:<foobar>")
+                            NonFungibleGlobalId("resource_tdx_2_1ng6aanl0nw98dgqxtja3mx4kpa8rzwhyt4q22sy9uul0vf9frs528x:#1#"),
+                            NonFungibleGlobalId("resource_tdx_2_1ng6aanl0nw98dgqxtja3mx4kpa8rzwhyt4q22sy9uul0vf9frs528x:#2#")
                         )
                     )
                 ),
                 false
             ),
-            "extra_NonFungibleLocalId" => Tuple(
+            "extra_non_fungible_local_id" => Tuple(
                 Enum<1u8>(
                     Enum<11u8>(
-                        NonFungibleLocalId("{deaddeaddeaddead-deaddeaddeaddead-deaddeaddeaddead-deaddeaddeaddead}")
+                        NonFungibleLocalId("#1#")
                     )
                 ),
                 false
             ),
-            "extra_NonFungibleLocalIdArray" => Tuple(
+            "extra_non_fungible_local_id_array" => Tuple(
                 Enum<1u8>(
                     Enum<139u8>(
                         Array<NonFungibleLocalId>(
-                            NonFungibleLocalId("{deaddeaddeaddead-deaddeaddeaddead-deaddeaddeaddead-deaddeaddeaddead}"),
-                            NonFungibleLocalId("<foobar>")
+                            NonFungibleLocalId("#1#"),
+                            NonFungibleLocalId("#2#")
                         )
                     )
                 ),
                 false
             ),
-            "extra_Origin" => Tuple(
+            "extra_origin" => Tuple(
                 Enum<1u8>(
                     Enum<14u8>(
                         "https://radixdlt.com"
@@ -276,7 +300,7 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_OriginArray" => Tuple(
+            "extra_origin_array" => Tuple(
                 Enum<1u8>(
                     Enum<142u8>(
                         Array<String>(
@@ -287,7 +311,7 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_PublicKey" => Tuple(
+            "extra_public_key" => Tuple(
                 Enum<1u8>(
                     Enum<9u8>(
                         Enum<1u8>(
@@ -297,7 +321,7 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_PublicKeyArray" => Tuple(
+            "extra_public_key_array" => Tuple(
                 Enum<1u8>(
                     Enum<137u8>(
                         Array<Enum>(
@@ -312,7 +336,7 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_PublicKeyHash" => Tuple(
+            "extra_public_key_hash" => Tuple(
                 Enum<1u8>(
                     Enum<15u8>(
                         Enum<1u8>(
@@ -322,7 +346,7 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_PublicKeyHashArray" => Tuple(
+            "extra_public_key_hash_array" => Tuple(
                 Enum<1u8>(
                     Enum<143u8>(
                         Array<Enum>(
@@ -337,7 +361,7 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_String" => Tuple(
+            "extra_string" => Tuple(
                 Enum<1u8>(
                     Enum<0u8>(
                         "foo bar"
@@ -345,90 +369,13 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_StringArray" => Tuple(
+            "extra_string_array" => Tuple(
                 Enum<1u8>(
                     Enum<128u8>(
                         Array<String>(
                             "foo",
                             "bar"
                         )
-                    )
-                ),
-                false
-            ),
-            "extra_U32Array" => Tuple(
-                Enum<1u8>(
-                    Enum<131u8>(
-                        Array<U32>(
-                            32u32,
-                            33u32,
-                            34u32,
-                            35u32
-                        )
-                    )
-                ),
-                false
-            ),
-            "extra_U64Array" => Tuple(
-                Enum<1u8>(
-                    Enum<132u8>(
-                        Array<U64>(
-                            64u64,
-                            65u64,
-                            66u64,
-                            67u64
-                        )
-                    )
-                ),
-                false
-            ),
-            "extra_U8Array" => Tuple(
-                Enum<1u8>(
-                    Enum<130u8>(
-                        Bytes("08090a0b")
-                    )
-                ),
-                false
-            ),
-            "extra_Url" => Tuple(
-                Enum<1u8>(
-                    Enum<13u8>(
-                        "https://radixdlt.com"
-                    )
-                ),
-                false
-            ),
-            "extra_UrlArray" => Tuple(
-                Enum<1u8>(
-                    Enum<141u8>(
-                        Array<String>(
-                            "https://radixdlt.com",
-                            "https://ociswap.com"
-                        )
-                    )
-                ),
-                false
-            ),
-            "extra_bool" => Tuple(
-                Enum<1u8>(
-                    Enum<1u8>(
-                        true
-                    )
-                ),
-                false
-            ),
-            "extra_i32" => Tuple(
-                Enum<1u8>(
-                    Enum<5u8>(
-                        32i32
-                    )
-                ),
-                false
-            ),
-            "extra_i64" => Tuple(
-                Enum<1u8>(
-                    Enum<6u8>(
-                        64i64
                     )
                 ),
                 false
@@ -441,6 +388,19 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
+            "extra_u32_array" => Tuple(
+                Enum<1u8>(
+                    Enum<131u8>(
+                        Array<U32>(
+                            32u32,
+                            33u32,
+                            34u32,
+                            35u32
+                        )
+                    )
+                ),
+                false
+            ),
             "extra_u64" => Tuple(
                 Enum<1u8>(
                     Enum<4u8>(
@@ -449,10 +409,50 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
+            "extra_u64_array" => Tuple(
+                Enum<1u8>(
+                    Enum<132u8>(
+                        Array<U64>(
+                            64u64,
+                            65u64,
+                            66u64,
+                            67u64
+                        )
+                    )
+                ),
+                false
+            ),
             "extra_u8" => Tuple(
                 Enum<1u8>(
                     Enum<2u8>(
                         8u8
+                    )
+                ),
+                false
+            ),
+            "extra_u8_array" => Tuple(
+                Enum<1u8>(
+                    Enum<130u8>(
+                        Bytes("08090a0b")
+                    )
+                ),
+                false
+            ),
+            "extra_url" => Tuple(
+                Enum<1u8>(
+                    Enum<13u8>(
+                        "https://radixdlt.com"
+                    )
+                ),
+                false
+            ),
+            "extra_url_array" => Tuple(
+                Enum<1u8>(
+                    Enum<141u8>(
+                        Array<String>(
+                            "https://radixdlt.com",
+                            "https://ociswap.com"
+                        )
                     )
                 ),
                 false
@@ -636,7 +636,15 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_BoolArray" => Tuple(
+            "extra_bool" => Tuple(
+                Enum<1u8>(
+                    Enum<1u8>(
+                        true
+                    )
+                ),
+                false
+            ),
+            "extra_bool_array" => Tuple(
                 Enum<1u8>(
                     Enum<129u8>(
                         Array<Bool>(
@@ -647,7 +655,7 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_Decimal" => Tuple(
+            "extra_decimal" => Tuple(
                 Enum<1u8>(
                     Enum<7u8>(
                         Decimal("8")
@@ -655,7 +663,7 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_DecimalArray" => Tuple(
+            "extra_decimal_array" => Tuple(
                 Enum<1u8>(
                     Enum<135u8>(
                         Array<Decimal>(
@@ -666,7 +674,7 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_GlobalAddress" => Tuple(
+            "extra_global_address" => Tuple(
                 Enum<1u8>(
                     Enum<8u8>(
                         Address("account_tdx_2_128y6j78mt0aqv6372evz28hrxp8mn06ccddkr7xppc88hyvyqrllae")
@@ -674,18 +682,26 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_GlobalAddressArray" => Tuple(
+            "extra_global_address_array" => Tuple(
                 Enum<1u8>(
                     Enum<136u8>(
                         Array<Address>(
-                            Address("account_tdx_2_128y6j78mt0aqv6372evz28hrxp8mn06ccddkr7xppc88hyvyqrllae"),
-                            Address("account_tdx_2_12xkzynhzgtpnnd02tudw2els2g9xl73yk54ppw8xekt2sdrlwkwcf0")
+                            Address("account_tdx_2_1289zm062j788dwrjefqkfgfeea5tkkdnh8htqhdrzdvjkql4kxceql"),
+                            Address("account_tdx_2_129663ef7fj8azge3y6sl73lf9vyqt53ewzlf7ul2l76mg5wyqlqlpr")
                         )
                     )
                 ),
                 false
             ),
-            "extra_I32Array" => Tuple(
+            "extra_i32" => Tuple(
+                Enum<1u8>(
+                    Enum<5u8>(
+                        32i32
+                    )
+                ),
+                false
+            ),
+            "extra_i32_array" => Tuple(
                 Enum<1u8>(
                     Enum<133u8>(
                         Array<I32>(
@@ -698,7 +714,15 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_I64Array" => Tuple(
+            "extra_i64" => Tuple(
+                Enum<1u8>(
+                    Enum<6u8>(
+                        64i64
+                    )
+                ),
+                false
+            ),
+            "extra_i64_array" => Tuple(
                 Enum<1u8>(
                     Enum<134u8>(
                         Array<I64>(
@@ -711,7 +735,7 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_Instant" => Tuple(
+            "extra_instant" => Tuple(
                 Enum<1u8>(
                     Enum<12u8>(
                         1891i64
@@ -719,7 +743,7 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_InstantArray" => Tuple(
+            "extra_instant_array" => Tuple(
                 Enum<1u8>(
                     Enum<140u8>(
                         Array<I64>(
@@ -730,45 +754,45 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_NonFungibleGlobalId" => Tuple(
+            "extra_non_fungible_global_id" => Tuple(
                 Enum<1u8>(
                     Enum<10u8>(
-                        NonFungibleGlobalId("resource_tdx_2_1nfyg2f68jw7hfdlg5hzvd8ylsa7e0kjl68t5t62v3ttamtejs3wnhg:<Member_237>")
+                        NonFungibleGlobalId("resource_tdx_2_1ng6aanl0nw98dgqxtja3mx4kpa8rzwhyt4q22sy9uul0vf9frs528x:#1#")
                     )
                 ),
                 false
             ),
-            "extra_NonFungibleGlobalIdArray" => Tuple(
+            "extra_non_fungible_global_id_array" => Tuple(
                 Enum<1u8>(
                     Enum<138u8>(
                         Array<Tuple>(
-                            NonFungibleGlobalId("resource_tdx_2_1nfyg2f68jw7hfdlg5hzvd8ylsa7e0kjl68t5t62v3ttamtejs3wnhg:<Member_237>"),
-                            NonFungibleGlobalId("resource_tdx_2_1n2ekdd2m0jsxjt9wasmu3p49twy2yfalpaa6wf08md46sk8dp0lpzc:<foobar>")
+                            NonFungibleGlobalId("resource_tdx_2_1ng6aanl0nw98dgqxtja3mx4kpa8rzwhyt4q22sy9uul0vf9frs528x:#1#"),
+                            NonFungibleGlobalId("resource_tdx_2_1ng6aanl0nw98dgqxtja3mx4kpa8rzwhyt4q22sy9uul0vf9frs528x:#2#")
                         )
                     )
                 ),
                 false
             ),
-            "extra_NonFungibleLocalId" => Tuple(
+            "extra_non_fungible_local_id" => Tuple(
                 Enum<1u8>(
                     Enum<11u8>(
-                        NonFungibleLocalId("{deaddeaddeaddead-deaddeaddeaddead-deaddeaddeaddead-deaddeaddeaddead}")
+                        NonFungibleLocalId("#1#")
                     )
                 ),
                 false
             ),
-            "extra_NonFungibleLocalIdArray" => Tuple(
+            "extra_non_fungible_local_id_array" => Tuple(
                 Enum<1u8>(
                     Enum<139u8>(
                         Array<NonFungibleLocalId>(
-                            NonFungibleLocalId("{deaddeaddeaddead-deaddeaddeaddead-deaddeaddeaddead-deaddeaddeaddead}"),
-                            NonFungibleLocalId("<foobar>")
+                            NonFungibleLocalId("#1#"),
+                            NonFungibleLocalId("#2#")
                         )
                     )
                 ),
                 false
             ),
-            "extra_Origin" => Tuple(
+            "extra_origin" => Tuple(
                 Enum<1u8>(
                     Enum<14u8>(
                         "https://radixdlt.com"
@@ -776,7 +800,7 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_OriginArray" => Tuple(
+            "extra_origin_array" => Tuple(
                 Enum<1u8>(
                     Enum<142u8>(
                         Array<String>(
@@ -787,7 +811,7 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_PublicKey" => Tuple(
+            "extra_public_key" => Tuple(
                 Enum<1u8>(
                     Enum<9u8>(
                         Enum<1u8>(
@@ -797,7 +821,7 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_PublicKeyArray" => Tuple(
+            "extra_public_key_array" => Tuple(
                 Enum<1u8>(
                     Enum<137u8>(
                         Array<Enum>(
@@ -812,7 +836,7 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_PublicKeyHash" => Tuple(
+            "extra_public_key_hash" => Tuple(
                 Enum<1u8>(
                     Enum<15u8>(
                         Enum<1u8>(
@@ -822,7 +846,7 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_PublicKeyHashArray" => Tuple(
+            "extra_public_key_hash_array" => Tuple(
                 Enum<1u8>(
                     Enum<143u8>(
                         Array<Enum>(
@@ -837,7 +861,7 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_String" => Tuple(
+            "extra_string" => Tuple(
                 Enum<1u8>(
                     Enum<0u8>(
                         "foo bar"
@@ -845,90 +869,13 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_StringArray" => Tuple(
+            "extra_string_array" => Tuple(
                 Enum<1u8>(
                     Enum<128u8>(
                         Array<String>(
                             "foo",
                             "bar"
                         )
-                    )
-                ),
-                false
-            ),
-            "extra_U32Array" => Tuple(
-                Enum<1u8>(
-                    Enum<131u8>(
-                        Array<U32>(
-                            32u32,
-                            33u32,
-                            34u32,
-                            35u32
-                        )
-                    )
-                ),
-                false
-            ),
-            "extra_U64Array" => Tuple(
-                Enum<1u8>(
-                    Enum<132u8>(
-                        Array<U64>(
-                            64u64,
-                            65u64,
-                            66u64,
-                            67u64
-                        )
-                    )
-                ),
-                false
-            ),
-            "extra_U8Array" => Tuple(
-                Enum<1u8>(
-                    Enum<130u8>(
-                        Bytes("08090a0b")
-                    )
-                ),
-                false
-            ),
-            "extra_Url" => Tuple(
-                Enum<1u8>(
-                    Enum<13u8>(
-                        "https://radixdlt.com"
-                    )
-                ),
-                false
-            ),
-            "extra_UrlArray" => Tuple(
-                Enum<1u8>(
-                    Enum<141u8>(
-                        Array<String>(
-                            "https://radixdlt.com",
-                            "https://ociswap.com"
-                        )
-                    )
-                ),
-                false
-            ),
-            "extra_bool" => Tuple(
-                Enum<1u8>(
-                    Enum<1u8>(
-                        true
-                    )
-                ),
-                false
-            ),
-            "extra_i32" => Tuple(
-                Enum<1u8>(
-                    Enum<5u8>(
-                        32i32
-                    )
-                ),
-                false
-            ),
-            "extra_i64" => Tuple(
-                Enum<1u8>(
-                    Enum<6u8>(
-                        64i64
                     )
                 ),
                 false
@@ -941,6 +888,19 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
+            "extra_u32_array" => Tuple(
+                Enum<1u8>(
+                    Enum<131u8>(
+                        Array<U32>(
+                            32u32,
+                            33u32,
+                            34u32,
+                            35u32
+                        )
+                    )
+                ),
+                false
+            ),
             "extra_u64" => Tuple(
                 Enum<1u8>(
                     Enum<4u8>(
@@ -949,10 +909,50 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
+            "extra_u64_array" => Tuple(
+                Enum<1u8>(
+                    Enum<132u8>(
+                        Array<U64>(
+                            64u64,
+                            65u64,
+                            66u64,
+                            67u64
+                        )
+                    )
+                ),
+                false
+            ),
             "extra_u8" => Tuple(
                 Enum<1u8>(
                     Enum<2u8>(
                         8u8
+                    )
+                ),
+                false
+            ),
+            "extra_u8_array" => Tuple(
+                Enum<1u8>(
+                    Enum<130u8>(
+                        Bytes("08090a0b")
+                    )
+                ),
+                false
+            ),
+            "extra_url" => Tuple(
+                Enum<1u8>(
+                    Enum<13u8>(
+                        "https://radixdlt.com"
+                    )
+                ),
+                false
+            ),
+            "extra_url_array" => Tuple(
+                Enum<1u8>(
+                    Enum<141u8>(
+                        Array<String>(
+                            "https://radixdlt.com",
+                            "https://ociswap.com"
+                        )
                     )
                 ),
                 false
@@ -1136,7 +1136,15 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_BoolArray" => Tuple(
+            "extra_bool" => Tuple(
+                Enum<1u8>(
+                    Enum<1u8>(
+                        true
+                    )
+                ),
+                false
+            ),
+            "extra_bool_array" => Tuple(
                 Enum<1u8>(
                     Enum<129u8>(
                         Array<Bool>(
@@ -1147,7 +1155,7 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_Decimal" => Tuple(
+            "extra_decimal" => Tuple(
                 Enum<1u8>(
                     Enum<7u8>(
                         Decimal("8")
@@ -1155,7 +1163,7 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_DecimalArray" => Tuple(
+            "extra_decimal_array" => Tuple(
                 Enum<1u8>(
                     Enum<135u8>(
                         Array<Decimal>(
@@ -1166,7 +1174,7 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_GlobalAddress" => Tuple(
+            "extra_global_address" => Tuple(
                 Enum<1u8>(
                     Enum<8u8>(
                         Address("account_tdx_2_128y6j78mt0aqv6372evz28hrxp8mn06ccddkr7xppc88hyvyqrllae")
@@ -1174,18 +1182,26 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_GlobalAddressArray" => Tuple(
+            "extra_global_address_array" => Tuple(
                 Enum<1u8>(
                     Enum<136u8>(
                         Array<Address>(
-                            Address("account_tdx_2_128y6j78mt0aqv6372evz28hrxp8mn06ccddkr7xppc88hyvyqrllae"),
-                            Address("account_tdx_2_12xkzynhzgtpnnd02tudw2els2g9xl73yk54ppw8xekt2sdrlwkwcf0")
+                            Address("account_tdx_2_1289zm062j788dwrjefqkfgfeea5tkkdnh8htqhdrzdvjkql4kxceql"),
+                            Address("account_tdx_2_129663ef7fj8azge3y6sl73lf9vyqt53ewzlf7ul2l76mg5wyqlqlpr")
                         )
                     )
                 ),
                 false
             ),
-            "extra_I32Array" => Tuple(
+            "extra_i32" => Tuple(
+                Enum<1u8>(
+                    Enum<5u8>(
+                        32i32
+                    )
+                ),
+                false
+            ),
+            "extra_i32_array" => Tuple(
                 Enum<1u8>(
                     Enum<133u8>(
                         Array<I32>(
@@ -1198,7 +1214,15 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_I64Array" => Tuple(
+            "extra_i64" => Tuple(
+                Enum<1u8>(
+                    Enum<6u8>(
+                        64i64
+                    )
+                ),
+                false
+            ),
+            "extra_i64_array" => Tuple(
                 Enum<1u8>(
                     Enum<134u8>(
                         Array<I64>(
@@ -1211,7 +1235,7 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_Instant" => Tuple(
+            "extra_instant" => Tuple(
                 Enum<1u8>(
                     Enum<12u8>(
                         1891i64
@@ -1219,7 +1243,7 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_InstantArray" => Tuple(
+            "extra_instant_array" => Tuple(
                 Enum<1u8>(
                     Enum<140u8>(
                         Array<I64>(
@@ -1230,45 +1254,45 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_NonFungibleGlobalId" => Tuple(
+            "extra_non_fungible_global_id" => Tuple(
                 Enum<1u8>(
                     Enum<10u8>(
-                        NonFungibleGlobalId("resource_tdx_2_1nfyg2f68jw7hfdlg5hzvd8ylsa7e0kjl68t5t62v3ttamtejs3wnhg:<Member_237>")
+                        NonFungibleGlobalId("resource_tdx_2_1ng6aanl0nw98dgqxtja3mx4kpa8rzwhyt4q22sy9uul0vf9frs528x:#1#")
                     )
                 ),
                 false
             ),
-            "extra_NonFungibleGlobalIdArray" => Tuple(
+            "extra_non_fungible_global_id_array" => Tuple(
                 Enum<1u8>(
                     Enum<138u8>(
                         Array<Tuple>(
-                            NonFungibleGlobalId("resource_tdx_2_1nfyg2f68jw7hfdlg5hzvd8ylsa7e0kjl68t5t62v3ttamtejs3wnhg:<Member_237>"),
-                            NonFungibleGlobalId("resource_tdx_2_1n2ekdd2m0jsxjt9wasmu3p49twy2yfalpaa6wf08md46sk8dp0lpzc:<foobar>")
+                            NonFungibleGlobalId("resource_tdx_2_1ng6aanl0nw98dgqxtja3mx4kpa8rzwhyt4q22sy9uul0vf9frs528x:#1#"),
+                            NonFungibleGlobalId("resource_tdx_2_1ng6aanl0nw98dgqxtja3mx4kpa8rzwhyt4q22sy9uul0vf9frs528x:#2#")
                         )
                     )
                 ),
                 false
             ),
-            "extra_NonFungibleLocalId" => Tuple(
+            "extra_non_fungible_local_id" => Tuple(
                 Enum<1u8>(
                     Enum<11u8>(
-                        NonFungibleLocalId("{deaddeaddeaddead-deaddeaddeaddead-deaddeaddeaddead-deaddeaddeaddead}")
+                        NonFungibleLocalId("#1#")
                     )
                 ),
                 false
             ),
-            "extra_NonFungibleLocalIdArray" => Tuple(
+            "extra_non_fungible_local_id_array" => Tuple(
                 Enum<1u8>(
                     Enum<139u8>(
                         Array<NonFungibleLocalId>(
-                            NonFungibleLocalId("{deaddeaddeaddead-deaddeaddeaddead-deaddeaddeaddead-deaddeaddeaddead}"),
-                            NonFungibleLocalId("<foobar>")
+                            NonFungibleLocalId("#1#"),
+                            NonFungibleLocalId("#2#")
                         )
                     )
                 ),
                 false
             ),
-            "extra_Origin" => Tuple(
+            "extra_origin" => Tuple(
                 Enum<1u8>(
                     Enum<14u8>(
                         "https://radixdlt.com"
@@ -1276,7 +1300,7 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_OriginArray" => Tuple(
+            "extra_origin_array" => Tuple(
                 Enum<1u8>(
                     Enum<142u8>(
                         Array<String>(
@@ -1287,7 +1311,7 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_PublicKey" => Tuple(
+            "extra_public_key" => Tuple(
                 Enum<1u8>(
                     Enum<9u8>(
                         Enum<1u8>(
@@ -1297,7 +1321,7 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_PublicKeyArray" => Tuple(
+            "extra_public_key_array" => Tuple(
                 Enum<1u8>(
                     Enum<137u8>(
                         Array<Enum>(
@@ -1312,7 +1336,7 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_PublicKeyHash" => Tuple(
+            "extra_public_key_hash" => Tuple(
                 Enum<1u8>(
                     Enum<15u8>(
                         Enum<1u8>(
@@ -1322,7 +1346,7 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_PublicKeyHashArray" => Tuple(
+            "extra_public_key_hash_array" => Tuple(
                 Enum<1u8>(
                     Enum<143u8>(
                         Array<Enum>(
@@ -1337,7 +1361,7 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_String" => Tuple(
+            "extra_string" => Tuple(
                 Enum<1u8>(
                     Enum<0u8>(
                         "foo bar"
@@ -1345,90 +1369,13 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
-            "extra_StringArray" => Tuple(
+            "extra_string_array" => Tuple(
                 Enum<1u8>(
                     Enum<128u8>(
                         Array<String>(
                             "foo",
                             "bar"
                         )
-                    )
-                ),
-                false
-            ),
-            "extra_U32Array" => Tuple(
-                Enum<1u8>(
-                    Enum<131u8>(
-                        Array<U32>(
-                            32u32,
-                            33u32,
-                            34u32,
-                            35u32
-                        )
-                    )
-                ),
-                false
-            ),
-            "extra_U64Array" => Tuple(
-                Enum<1u8>(
-                    Enum<132u8>(
-                        Array<U64>(
-                            64u64,
-                            65u64,
-                            66u64,
-                            67u64
-                        )
-                    )
-                ),
-                false
-            ),
-            "extra_U8Array" => Tuple(
-                Enum<1u8>(
-                    Enum<130u8>(
-                        Bytes("08090a0b")
-                    )
-                ),
-                false
-            ),
-            "extra_Url" => Tuple(
-                Enum<1u8>(
-                    Enum<13u8>(
-                        "https://radixdlt.com"
-                    )
-                ),
-                false
-            ),
-            "extra_UrlArray" => Tuple(
-                Enum<1u8>(
-                    Enum<141u8>(
-                        Array<String>(
-                            "https://radixdlt.com",
-                            "https://ociswap.com"
-                        )
-                    )
-                ),
-                false
-            ),
-            "extra_bool" => Tuple(
-                Enum<1u8>(
-                    Enum<1u8>(
-                        true
-                    )
-                ),
-                false
-            ),
-            "extra_i32" => Tuple(
-                Enum<1u8>(
-                    Enum<5u8>(
-                        32i32
-                    )
-                ),
-                false
-            ),
-            "extra_i64" => Tuple(
-                Enum<1u8>(
-                    Enum<6u8>(
-                        64i64
                     )
                 ),
                 false
@@ -1441,6 +1388,19 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
+            "extra_u32_array" => Tuple(
+                Enum<1u8>(
+                    Enum<131u8>(
+                        Array<U32>(
+                            32u32,
+                            33u32,
+                            34u32,
+                            35u32
+                        )
+                    )
+                ),
+                false
+            ),
             "extra_u64" => Tuple(
                 Enum<1u8>(
                     Enum<4u8>(
@@ -1449,10 +1409,50 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 ),
                 false
             ),
+            "extra_u64_array" => Tuple(
+                Enum<1u8>(
+                    Enum<132u8>(
+                        Array<U64>(
+                            64u64,
+                            65u64,
+                            66u64,
+                            67u64
+                        )
+                    )
+                ),
+                false
+            ),
             "extra_u8" => Tuple(
                 Enum<1u8>(
                     Enum<2u8>(
                         8u8
+                    )
+                ),
+                false
+            ),
+            "extra_u8_array" => Tuple(
+                Enum<1u8>(
+                    Enum<130u8>(
+                        Bytes("08090a0b")
+                    )
+                ),
+                false
+            ),
+            "extra_url" => Tuple(
+                Enum<1u8>(
+                    Enum<13u8>(
+                        "https://radixdlt.com"
+                    )
+                ),
+                false
+            ),
+            "extra_url_array" => Tuple(
+                Enum<1u8>(
+                    Enum<141u8>(
+                        Array<String>(
+                            "https://radixdlt.com",
+                            "https://ociswap.com"
+                        )
                     )
                 ),
                 false

--- a/src/profile/v100/address/resource_address.rs
+++ b/src/profile/v100/address/resource_address.rs
@@ -123,6 +123,12 @@ impl ResourceAddress {
             .expect("GC membership")
     }
 
+    pub(crate) fn sample_stokenet_nft_abandon() -> Self {
+        "resource_tdx_2_1ng6aanl0nw98dgqxtja3mx4kpa8rzwhyt4q22sy9uul0vf9frs528x"
+            .parse()
+            .expect("Abandon")
+    }
+
     pub(crate) fn sample_stokenet_nft_other() -> Self {
         "resource_tdx_2_1ngw6cufaxs5p82kw49juy2yfkt53se76vr0xfsu3tvyduuw6s0y6lc"
             .parse()

--- a/src/wrapped_radix_engine_toolkit/high_level/manifest_building/manifests_create_tokens.rs
+++ b/src/wrapped_radix_engine_toolkit/high_level/manifest_building/manifests_create_tokens.rs
@@ -294,7 +294,7 @@ mod tests {
         assert_eq!(
             SUT::create_fungible_token(&AccountAddress::sample_mainnet(),)
                 .to_string(),
-            r#"CREATE_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
+            r##"CREATE_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
     Enum<2u8>(
         Enum<0u8>()
     )
@@ -373,7 +373,15 @@ mod tests {
                 ),
                 false
             ),
-            "extra_BoolArray" => Tuple(
+            "extra_bool" => Tuple(
+                Enum<1u8>(
+                    Enum<1u8>(
+                        true
+                    )
+                ),
+                false
+            ),
+            "extra_bool_array" => Tuple(
                 Enum<1u8>(
                     Enum<129u8>(
                         Array<Bool>(
@@ -384,7 +392,7 @@ mod tests {
                 ),
                 false
             ),
-            "extra_Decimal" => Tuple(
+            "extra_decimal" => Tuple(
                 Enum<1u8>(
                     Enum<7u8>(
                         Decimal("8")
@@ -392,7 +400,7 @@ mod tests {
                 ),
                 false
             ),
-            "extra_DecimalArray" => Tuple(
+            "extra_decimal_array" => Tuple(
                 Enum<1u8>(
                     Enum<135u8>(
                         Array<Decimal>(
@@ -403,7 +411,7 @@ mod tests {
                 ),
                 false
             ),
-            "extra_GlobalAddress" => Tuple(
+            "extra_global_address" => Tuple(
                 Enum<1u8>(
                     Enum<8u8>(
                         Address("account_rdx128y6j78mt0aqv6372evz28hrxp8mn06ccddkr7xppc88hyvynvjdwr")
@@ -411,18 +419,26 @@ mod tests {
                 ),
                 false
             ),
-            "extra_GlobalAddressArray" => Tuple(
+            "extra_global_address_array" => Tuple(
                 Enum<1u8>(
                     Enum<136u8>(
                         Array<Address>(
-                            Address("account_rdx128y6j78mt0aqv6372evz28hrxp8mn06ccddkr7xppc88hyvynvjdwr"),
-                            Address("account_rdx12xkzynhzgtpnnd02tudw2els2g9xl73yk54ppw8xekt2sdrlaer264")
+                            Address("account_rdx1289zm062j788dwrjefqkfgfeea5tkkdnh8htqhdrzdvjkql49f4tn9"),
+                            Address("account_rdx129663ef7fj8azge3y6sl73lf9vyqt53ewzlf7ul2l76mg5wynsddje")
                         )
                     )
                 ),
                 false
             ),
-            "extra_I32Array" => Tuple(
+            "extra_i32" => Tuple(
+                Enum<1u8>(
+                    Enum<5u8>(
+                        32i32
+                    )
+                ),
+                false
+            ),
+            "extra_i32_array" => Tuple(
                 Enum<1u8>(
                     Enum<133u8>(
                         Array<I32>(
@@ -435,7 +451,15 @@ mod tests {
                 ),
                 false
             ),
-            "extra_I64Array" => Tuple(
+            "extra_i64" => Tuple(
+                Enum<1u8>(
+                    Enum<6u8>(
+                        64i64
+                    )
+                ),
+                false
+            ),
+            "extra_i64_array" => Tuple(
                 Enum<1u8>(
                     Enum<134u8>(
                         Array<I64>(
@@ -448,7 +472,7 @@ mod tests {
                 ),
                 false
             ),
-            "extra_Instant" => Tuple(
+            "extra_instant" => Tuple(
                 Enum<1u8>(
                     Enum<12u8>(
                         1891i64
@@ -456,7 +480,7 @@ mod tests {
                 ),
                 false
             ),
-            "extra_InstantArray" => Tuple(
+            "extra_instant_array" => Tuple(
                 Enum<1u8>(
                     Enum<140u8>(
                         Array<I64>(
@@ -467,45 +491,45 @@ mod tests {
                 ),
                 false
             ),
-            "extra_NonFungibleGlobalId" => Tuple(
+            "extra_non_fungible_global_id" => Tuple(
                 Enum<1u8>(
                     Enum<10u8>(
-                        NonFungibleGlobalId("resource_rdx1nfyg2f68jw7hfdlg5hzvd8ylsa7e0kjl68t5t62v3ttamtejc9wlxa:<Member_237>")
+                        NonFungibleGlobalId("resource_rdx1ng6aanl0nw98dgqxtja3mx4kpa8rzwhyt4q22sy9uul0vf9fty5xkn:#1#")
                     )
                 ),
                 false
             ),
-            "extra_NonFungibleGlobalIdArray" => Tuple(
+            "extra_non_fungible_global_id_array" => Tuple(
                 Enum<1u8>(
                     Enum<138u8>(
                         Array<Tuple>(
-                            NonFungibleGlobalId("resource_rdx1nfyg2f68jw7hfdlg5hzvd8ylsa7e0kjl68t5t62v3ttamtejc9wlxa:<Member_237>"),
-                            NonFungibleGlobalId("resource_rdx1n2ekdd2m0jsxjt9wasmu3p49twy2yfalpaa6wf08md46sk8dfmldnd:<foobar>")
+                            NonFungibleGlobalId("resource_rdx1ng6aanl0nw98dgqxtja3mx4kpa8rzwhyt4q22sy9uul0vf9fty5xkn:#1#"),
+                            NonFungibleGlobalId("resource_rdx1ng6aanl0nw98dgqxtja3mx4kpa8rzwhyt4q22sy9uul0vf9fty5xkn:#2#")
                         )
                     )
                 ),
                 false
             ),
-            "extra_NonFungibleLocalId" => Tuple(
+            "extra_non_fungible_local_id" => Tuple(
                 Enum<1u8>(
                     Enum<11u8>(
-                        NonFungibleLocalId("{deaddeaddeaddead-deaddeaddeaddead-deaddeaddeaddead-deaddeaddeaddead}")
+                        NonFungibleLocalId("#1#")
                     )
                 ),
                 false
             ),
-            "extra_NonFungibleLocalIdArray" => Tuple(
+            "extra_non_fungible_local_id_array" => Tuple(
                 Enum<1u8>(
                     Enum<139u8>(
                         Array<NonFungibleLocalId>(
-                            NonFungibleLocalId("{deaddeaddeaddead-deaddeaddeaddead-deaddeaddeaddead-deaddeaddeaddead}"),
-                            NonFungibleLocalId("<foobar>")
+                            NonFungibleLocalId("#1#"),
+                            NonFungibleLocalId("#2#")
                         )
                     )
                 ),
                 false
             ),
-            "extra_Origin" => Tuple(
+            "extra_origin" => Tuple(
                 Enum<1u8>(
                     Enum<14u8>(
                         "https://radixdlt.com"
@@ -513,7 +537,7 @@ mod tests {
                 ),
                 false
             ),
-            "extra_OriginArray" => Tuple(
+            "extra_origin_array" => Tuple(
                 Enum<1u8>(
                     Enum<142u8>(
                         Array<String>(
@@ -524,7 +548,7 @@ mod tests {
                 ),
                 false
             ),
-            "extra_PublicKey" => Tuple(
+            "extra_public_key" => Tuple(
                 Enum<1u8>(
                     Enum<9u8>(
                         Enum<1u8>(
@@ -534,7 +558,7 @@ mod tests {
                 ),
                 false
             ),
-            "extra_PublicKeyArray" => Tuple(
+            "extra_public_key_array" => Tuple(
                 Enum<1u8>(
                     Enum<137u8>(
                         Array<Enum>(
@@ -549,7 +573,7 @@ mod tests {
                 ),
                 false
             ),
-            "extra_PublicKeyHash" => Tuple(
+            "extra_public_key_hash" => Tuple(
                 Enum<1u8>(
                     Enum<15u8>(
                         Enum<1u8>(
@@ -559,7 +583,7 @@ mod tests {
                 ),
                 false
             ),
-            "extra_PublicKeyHashArray" => Tuple(
+            "extra_public_key_hash_array" => Tuple(
                 Enum<1u8>(
                     Enum<143u8>(
                         Array<Enum>(
@@ -574,7 +598,7 @@ mod tests {
                 ),
                 false
             ),
-            "extra_String" => Tuple(
+            "extra_string" => Tuple(
                 Enum<1u8>(
                     Enum<0u8>(
                         "foo bar"
@@ -582,90 +606,13 @@ mod tests {
                 ),
                 false
             ),
-            "extra_StringArray" => Tuple(
+            "extra_string_array" => Tuple(
                 Enum<1u8>(
                     Enum<128u8>(
                         Array<String>(
                             "foo",
                             "bar"
                         )
-                    )
-                ),
-                false
-            ),
-            "extra_U32Array" => Tuple(
-                Enum<1u8>(
-                    Enum<131u8>(
-                        Array<U32>(
-                            32u32,
-                            33u32,
-                            34u32,
-                            35u32
-                        )
-                    )
-                ),
-                false
-            ),
-            "extra_U64Array" => Tuple(
-                Enum<1u8>(
-                    Enum<132u8>(
-                        Array<U64>(
-                            64u64,
-                            65u64,
-                            66u64,
-                            67u64
-                        )
-                    )
-                ),
-                false
-            ),
-            "extra_U8Array" => Tuple(
-                Enum<1u8>(
-                    Enum<130u8>(
-                        Bytes("08090a0b")
-                    )
-                ),
-                false
-            ),
-            "extra_Url" => Tuple(
-                Enum<1u8>(
-                    Enum<13u8>(
-                        "https://radixdlt.com"
-                    )
-                ),
-                false
-            ),
-            "extra_UrlArray" => Tuple(
-                Enum<1u8>(
-                    Enum<141u8>(
-                        Array<String>(
-                            "https://radixdlt.com",
-                            "https://ociswap.com"
-                        )
-                    )
-                ),
-                false
-            ),
-            "extra_bool" => Tuple(
-                Enum<1u8>(
-                    Enum<1u8>(
-                        true
-                    )
-                ),
-                false
-            ),
-            "extra_i32" => Tuple(
-                Enum<1u8>(
-                    Enum<5u8>(
-                        32i32
-                    )
-                ),
-                false
-            ),
-            "extra_i64" => Tuple(
-                Enum<1u8>(
-                    Enum<6u8>(
-                        64i64
                     )
                 ),
                 false
@@ -678,6 +625,19 @@ mod tests {
                 ),
                 false
             ),
+            "extra_u32_array" => Tuple(
+                Enum<1u8>(
+                    Enum<131u8>(
+                        Array<U32>(
+                            32u32,
+                            33u32,
+                            34u32,
+                            35u32
+                        )
+                    )
+                ),
+                false
+            ),
             "extra_u64" => Tuple(
                 Enum<1u8>(
                     Enum<4u8>(
@@ -686,10 +646,50 @@ mod tests {
                 ),
                 false
             ),
+            "extra_u64_array" => Tuple(
+                Enum<1u8>(
+                    Enum<132u8>(
+                        Array<U64>(
+                            64u64,
+                            65u64,
+                            66u64,
+                            67u64
+                        )
+                    )
+                ),
+                false
+            ),
             "extra_u8" => Tuple(
                 Enum<1u8>(
                     Enum<2u8>(
                         8u8
+                    )
+                ),
+                false
+            ),
+            "extra_u8_array" => Tuple(
+                Enum<1u8>(
+                    Enum<130u8>(
+                        Bytes("08090a0b")
+                    )
+                ),
+                false
+            ),
+            "extra_url" => Tuple(
+                Enum<1u8>(
+                    Enum<13u8>(
+                        "https://radixdlt.com"
+                    )
+                ),
+                false
+            ),
+            "extra_url_array" => Tuple(
+                Enum<1u8>(
+                    Enum<141u8>(
+                        Array<String>(
+                            "https://radixdlt.com",
+                            "https://ociswap.com"
+                        )
                     )
                 ),
                 false
@@ -739,7 +739,7 @@ CALL_METHOD
     Expression("ENTIRE_WORKTOP")
     Enum<0u8>()
 ;
-"#
+"##
         );
     }
 

--- a/src/wrapped_radix_engine_toolkit/high_level/token_definition_metadata.rs
+++ b/src/wrapped_radix_engine_toolkit/high_level/token_definition_metadata.rs
@@ -19,6 +19,21 @@ impl From<TokenDefinitionMetadata>
     for ScryptoModuleConfig<ScryptoMetadataInit>
 {
     fn from(value: TokenDefinitionMetadata) -> Self {
+        let resource_address = ResourceAddress::sample_stokenet_nft_abandon();
+        let non_fungible_local_id = NonFungibleLocalId::Integer { value: 1 };
+        let non_fungible_local_id_other =
+            NonFungibleLocalId::Integer { value: 2 };
+        let non_fungible_resource_address =
+            NonFungibleResourceAddress::new(resource_address).unwrap();
+        let non_fungible_global_id = NonFungibleGlobalId::new(
+            non_fungible_resource_address,
+            non_fungible_local_id.clone(),
+        );
+        let non_fungible_global_id_other = NonFungibleGlobalId::new(
+            non_fungible_resource_address,
+            non_fungible_local_id_other.clone(),
+        );
+
         let map = BTreeMap::<String, ScryptoMetadataValue>::from([
             (
                 MetadataKey::Name.to_string(),
@@ -41,7 +56,7 @@ impl From<TokenDefinitionMetadata>
                 ScryptoMetadataValue::StringArray(value.tags),
             ),
             (
-                "extra_String".to_string(),
+                "extra_string".to_string(),
                 ScryptoMetadataValue::String("foo bar".to_string()),
             ),
             ("extra_bool".to_string(), ScryptoMetadataValue::Bool(true)),
@@ -51,142 +66,142 @@ impl From<TokenDefinitionMetadata>
             ("extra_i32".to_string(), ScryptoMetadataValue::I32(32)),
             ("extra_i64".to_string(), ScryptoMetadataValue::I64(64)),
             (
-                "extra_Decimal".to_string(),
+                "extra_decimal".to_string(),
                 ScryptoMetadataValue::Decimal(Decimal::eight().into()),
             ),
             (
-                "extra_GlobalAddress".to_string(),
+                "extra_global_address".to_string(),
                 ScryptoMetadataValue::GlobalAddress(GlobalAddress::from(
                     AccountAddress::sample(),
                 )),
             ),
             (
-                "extra_PublicKey".to_string(),
+                "extra_public_key".to_string(),
                 ScryptoMetadataValue::PublicKey(PublicKey::sample().into()),
             ),
             (
-                "extra_NonFungibleGlobalId".to_string(),
+                "extra_non_fungible_global_id".to_string(),
                 ScryptoMetadataValue::NonFungibleGlobalId(
-                    NonFungibleGlobalId::sample().into(),
+                    non_fungible_global_id.clone().into(),
                 ),
             ),
             (
-                "extra_NonFungibleLocalId".to_string(),
+                "extra_non_fungible_local_id".to_string(),
                 ScryptoMetadataValue::NonFungibleLocalId(
-                    NonFungibleLocalId::sample().into(),
+                    non_fungible_local_id.clone().into(),
                 ),
             ),
             (
-                "extra_Instant".to_string(),
+                "extra_instant".to_string(),
                 ScryptoMetadataValue::Instant(Instant::new(1891)),
             ),
             (
-                "extra_Url".to_string(),
+                "extra_url".to_string(),
                 ScryptoMetadataValue::Url(ScryptoUncheckedUrl::of(
                     "https://radixdlt.com",
                 )),
             ),
             (
-                "extra_Origin".to_string(),
+                "extra_origin".to_string(),
                 ScryptoMetadataValue::Origin(UncheckedOrigin::of(
                     "https://radixdlt.com",
                 )),
             ),
             (
-                "extra_PublicKeyHash".to_string(),
+                "extra_public_key_hash".to_string(),
                 ScryptoMetadataValue::PublicKeyHash(
                     PublicKeyHash::sample().into(),
                 ),
             ),
             (
-                "extra_StringArray".to_string(),
+                "extra_string_array".to_string(),
                 ScryptoMetadataValue::StringArray(vec![
                     "foo".to_string(),
                     "bar".to_string(),
                 ]),
             ),
             (
-                "extra_BoolArray".to_string(),
+                "extra_bool_array".to_string(),
                 ScryptoMetadataValue::BoolArray(vec![true, false]),
             ),
             (
-                "extra_U8Array".to_string(),
+                "extra_u8_array".to_string(),
                 ScryptoMetadataValue::U8Array(vec![8, 9, 10, 11]),
             ),
             (
-                "extra_U32Array".to_string(),
+                "extra_u32_array".to_string(),
                 ScryptoMetadataValue::U32Array(vec![32, 33, 34, 35]),
             ),
             (
-                "extra_U64Array".to_string(),
+                "extra_u64_array".to_string(),
                 ScryptoMetadataValue::U64Array(vec![64, 65, 66, 67]),
             ),
             (
-                "extra_I32Array".to_string(),
+                "extra_i32_array".to_string(),
                 ScryptoMetadataValue::I32Array(vec![32, 33, 34, 35]),
             ),
             (
-                "extra_I64Array".to_string(),
+                "extra_i64_array".to_string(),
                 ScryptoMetadataValue::I64Array(vec![64, 65, 66, 67]),
             ),
             (
-                "extra_DecimalArray".to_string(),
+                "extra_decimal_array".to_string(),
                 ScryptoMetadataValue::DecimalArray(vec![
                     Decimal::one().into(),
                     Decimal::two().into(),
                 ]),
             ),
             (
-                "extra_GlobalAddressArray".to_string(),
+                "extra_global_address_array".to_string(),
                 ScryptoMetadataValue::GlobalAddressArray(vec![
-                    GlobalAddress::from(AccountAddress::sample()),
-                    GlobalAddress::from(AccountAddress::sample_other()),
+                    GlobalAddress::from(AccountAddress::sample_stokenet()),
+                    GlobalAddress::from(AccountAddress::sample_stokenet_other()),
                 ]),
             ),
             (
-                "extra_PublicKeyArray".to_string(),
+                "extra_public_key_array".to_string(),
                 ScryptoMetadataValue::PublicKeyArray(vec![
                     PublicKey::sample().into(),
                     PublicKey::sample_other().into(),
                 ]),
             ),
             (
-                "extra_NonFungibleGlobalIdArray".to_string(),
+                "extra_non_fungible_global_id_array".to_string(),
                 ScryptoMetadataValue::NonFungibleGlobalIdArray(vec![
-                    NonFungibleGlobalId::sample().into(),
-                    NonFungibleGlobalId::sample_other().into(),
+                    non_fungible_global_id.clone().into(),
+                    non_fungible_global_id_other.clone().into(),
                 ]),
             ),
             (
-                "extra_NonFungibleLocalIdArray".to_string(),
+                "extra_non_fungible_local_id_array".to_string(),
                 ScryptoMetadataValue::NonFungibleLocalIdArray(vec![
-                    NonFungibleLocalId::sample().into(),
-                    NonFungibleLocalId::sample_other().into(),
+                    non_fungible_local_id.clone().into(),
+                    non_fungible_local_id_other.clone().into(),
                 ]),
             ),
             (
-                "extra_InstantArray".to_string(),
+                "extra_instant_array".to_string(),
                 ScryptoMetadataValue::InstantArray(vec![
                     Instant::new(5),
                     Instant::new(1891),
                 ]),
             ),
             (
-                "extra_UrlArray".to_string(),
+                "extra_url_array".to_string(),
                 ScryptoMetadataValue::UrlArray(vec![
                     ScryptoUncheckedUrl::of("https://radixdlt.com"),
                     ScryptoUncheckedUrl::of("https://ociswap.com"),
                 ]),
             ),
             (
-                "extra_OriginArray".to_string(),
+                "extra_origin_array".to_string(),
                 ScryptoMetadataValue::OriginArray(vec![
                     UncheckedOrigin::of("https://radixdlt.com"),
                     UncheckedOrigin::of("https://ociswap.com"),
                 ]),
             ),
             (
-                "extra_PublicKeyHashArray".to_string(),
+                "extra_public_key_hash_array".to_string(),
                 ScryptoMetadataValue::PublicKeyHashArray(vec![
                     PublicKeyHash::sample().into(),
                     PublicKeyHash::sample_other().into(),


### PR DESCRIPTION
## Changelog
Fixes some issues introduced on https://github.com/radixdlt/sargon/pull/173, where the Transaction Manifest generated would be invalid due since some of the referred ids included in metadata weren't present on Stokenet.

[Here](https://stokenet-dashboard.radixdlt.com/resource/resource_tdx_2_1t4h3u5knhu308hfp5h6lwf7cq6pjl4wu0cvmjwjfy32hjfnzd745dj/metadata) is an example token built using these changes.