### PR TITLE
Fix new sessions handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2593,7 +2593,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.0.19"
+version = "1.0.21"
 dependencies = [
  "actix-rt",
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "1.0.19"
+version = "1.0.21"
 edition = "2021"
 build = "build.rs"
 

--- a/src/radix_connect/wallet_interaction/dapp_wallet_interaction/wallet_to_dapp/failure_response/failure.rs
+++ b/src/radix_connect/wallet_interaction/dapp_wallet_interaction/wallet_to_dapp/failure_response/failure.rs
@@ -41,6 +41,16 @@ impl HasSampleValues for WalletToDappInteractionFailureResponse {
     }
 }
 
+impl WalletToDappInteractionFailureResponse {
+    pub fn sample_with_id(interaction_id: WalletInteractionId) -> Self {
+        Self::new(
+            interaction_id,
+            DappWalletInteractionErrorType::sample(),
+            "sample1".to_owned(),
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/radix_connect/wallet_interaction/dapp_wallet_interaction/wallet_to_dapp/response.rs
+++ b/src/radix_connect/wallet_interaction/dapp_wallet_interaction/wallet_to_dapp/response.rs
@@ -30,6 +30,17 @@ impl WalletToDappInteractionResponse {
             WalletToDappInteractionResponse::Failure(_) => false,
         }
     }
+
+    pub fn interaction_id(&self) -> WalletInteractionId {
+        match self {
+            WalletToDappInteractionResponse::Success(response) => {
+                response.interaction_id.clone()
+            }
+            WalletToDappInteractionResponse::Failure(response) => {
+                response.interaction_id.clone()
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/radix_connect/wallet_interaction/dapp_wallet_interaction/wallet_to_dapp/success_response/success.rs
+++ b/src/radix_connect/wallet_interaction/dapp_wallet_interaction/wallet_to_dapp/success_response/success.rs
@@ -35,6 +35,15 @@ impl HasSampleValues for WalletToDappInteractionSuccessResponse {
     }
 }
 
+impl WalletToDappInteractionSuccessResponse {
+    pub fn sample_with_id(interaction_id: WalletInteractionId) -> Self {
+        Self::new(
+            interaction_id,
+            WalletToDappInteractionResponseItems::sample(),
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
This is a fix for the following bug:
- User performs the first connect to a dApp.
- User is presented with Origin verification screen.
- User goes back to the dApp and sends a another request. RDT will attach the same session_id.
- User is redirected to the Wallet.
- User dismisses the first request.
- When user tries to complete the second request and error will be thrown telling them that the session for the given session id was not found.

The above did happen because the session was saved to the storage only on success interaction, and it was immediately removed after user completed the interaction.

The fix for this is to have the per wallet_interaction_id session, so until a session is verified for a given session_id we can have multiple sessions in memory for different interactions.