### PR TITLE
Global id Default format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2593,7 +2593,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.0.19"
+version = "1.0.22"
 dependencies = [
  "actix-rt",
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "1.0.19"
+version = "1.0.22"
 edition = "2021"
 build = "build.rs"
 

--- a/apple/Tests/TestCases/Address/AccountAddressTests.swift
+++ b/apple/Tests/TestCases/Address/AccountAddressTests.swift
@@ -33,7 +33,6 @@ final class AccountAddressTests: AddressTest<AccountAddress> {
 	func test_formatted() {
 		XCTAssertEqual(SUT.sample.formatted(.full), "account_rdx128y6j78mt0aqv6372evz28hrxp8mn06ccddkr7xppc88hyvynvjdwr")
 		XCTAssertEqual(SUT.sample.formatted(.default), "acco...nvjdwr")
-		XCTAssertEqual(SUT.sample.formatted(.middle), "unt_rdx128y6j78mt0aqv6372evz28hrxp8mn06ccddkr7xppc88hyvy")
 	}
     
     func test_from_bech32_on_stokenet() throws {

--- a/apple/Tests/TestCases/Address/LegacyOlympiaAccountAddressTests.swift
+++ b/apple/Tests/TestCases/Address/LegacyOlympiaAccountAddressTests.swift
@@ -30,7 +30,6 @@ final class LegacyOlympiaAccountAddressTests: BaseAddressTest<LegacyOlympiaAccou
     func test_formatted() {
         XCTAssertNoDifference(SUT.sampleOther.formatted(.default), "rdx...0xqm2ylge")
         XCTAssertNoDifference(SUT.sampleOther.formatted(.raw), "rdx1qsp8n0nx0muaewav2ksx99wwsu9swq5mlndjmn3gm9vl9q2mzmup0xqm2ylge")
-		XCTAssertNoDifference(SUT.sampleOther.formatted(.middle), "1qsp8n0nx0muaewav2ksx99wwsu9swq5mlndjmn3gm9vl9q2mzmup")
     }
 }
 

--- a/apple/Tests/TestCases/Prelude/NonFungibleGlobalIDTests.swift
+++ b/apple/Tests/TestCases/Prelude/NonFungibleGlobalIDTests.swift
@@ -49,8 +49,7 @@ final class NonFungibleGlobalIDTests: IdentifiableByStringProtocolTest<NonFungib
             )
         )
         XCTAssertNoDifference(sut.formatted(.raw), "resource_rdx1nfyg2f68jw7hfdlg5hzvd8ylsa7e0kjl68t5t62v3ttamtejc9wlxa:{deadbeef12345678-babecafe87654321-fadedeaf01234567-ecadabba76543210}")
-		XCTAssertNoDifference(sut.formatted(.default), "reso...c9wlxa:dead...3210")
-		XCTAssertNoDifference(sut.formatted(.middle), "urce_rdx1nfyg2f68jw7hfdlg5hzvd8ylsa7e0kjl68t5t62v3ttamtej:beef12345678-babecafe87654321-fadedeaf01234567-ecadabba7654")
+		XCTAssertNoDifference(sut.formatted(.default), "reso...c9wlxa:{dead...3210}")
     }
 	
 	func test_formatted_string() throws {
@@ -59,7 +58,6 @@ final class NonFungibleGlobalIDTests: IdentifiableByStringProtocolTest<NonFungib
 			localID: .stringID("foobar")
 		)
 		XCTAssertNoDifference(sut.formatted(.raw), "resource_rdx1nfyg2f68jw7hfdlg5hzvd8ylsa7e0kjl68t5t62v3ttamtejc9wlxa:<foobar>")
-		XCTAssertNoDifference(sut.formatted(.default), "reso...c9wlxa:foobar")
-		XCTAssertNoDifference(sut.formatted(.middle), "urce_rdx1nfyg2f68jw7hfdlg5hzvd8ylsa7e0kjl68t5t62v3ttamtej")
+		XCTAssertNoDifference(sut.formatted(.default), "reso...c9wlxa:<foobar>")
 	}
 }

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/NonFungibleGlobalIdTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/NonFungibleGlobalIdTest.kt
@@ -44,7 +44,7 @@ class NonFungibleGlobalIdTest {
             nonFungibleLocalId = NonFungibleLocalId.init("#1#")
         )
 
-        assertEquals("reso...c9wlxa:1", address.formatted())
+        assertEquals("reso...c9wlxa:#1#", address.formatted())
         assertEquals(
             "resource_rdx1nfyg2f68jw7hfdlg5hzvd8ylsa7e0kjl68t5t62v3ttamtejc9wlxa:1",
             address.formatted(format = AddressFormat.FULL)

--- a/src/profile/v100/address/account_address.rs
+++ b/src/profile/v100/address/account_address.rs
@@ -277,14 +277,6 @@ mod tests {
     }
 
     #[test]
-    fn formatted_middle() {
-        assert_eq!(
-            SUT::sample().formatted(AddressFormat::Middle),
-            "unt_rdx128y6j78mt0aqv6372evz28hrxp8mn06ccddkr7xppc88hyvy"
-        );
-    }
-
-    #[test]
     fn invalid() {
         assert_eq!(
             SUT::try_from_bech32("x"),

--- a/src/profile/v100/address/address_format.rs
+++ b/src/profile/v100/address/address_format.rs
@@ -14,5 +14,4 @@ pub enum AddressFormat {
     Full,
     Raw,
     Default,
-    Middle,
 }

--- a/src/profile/v100/address/legacy_olympia_account_address.rs
+++ b/src/profile/v100/address/legacy_olympia_account_address.rs
@@ -118,7 +118,6 @@ impl LegacyOlympiaAccountAddress {
         match format {
             AddressFormat::Default => format_string(self.to_string(), 3, 9),
             AddressFormat::Full | AddressFormat::Raw => self.to_string(),
-            AddressFormat::Middle => trim_string(self.to_string(), 3, 9),
         }
     }
 }
@@ -228,14 +227,6 @@ mod tests {
         assert_eq!(
             SUT::sample_other().formatted(AddressFormat::Raw),
             "rdx1qsp8n0nx0muaewav2ksx99wwsu9swq5mlndjmn3gm9vl9q2mzmup0xqm2ylge"
-        );
-    }
-
-    #[test]
-    fn formatted_middle() {
-        assert_eq!(
-            SUT::sample_other().formatted(AddressFormat::Middle),
-            "1qsp8n0nx0muaewav2ksx99wwsu9swq5mlndjmn3gm9vl9q2mzmup"
         );
     }
 

--- a/src/profile/v100/address/non_fungible_global_id.rs
+++ b/src/profile/v100/address/non_fungible_global_id.rs
@@ -349,7 +349,7 @@ mod tests {
         // local_id: ruid
         local_id = NonFungibleLocalId::ruid(hex_decode("deadbeef12345678babecafe87654321fadedeaf01234567ecadabba76543210").unwrap()).unwrap();
         item = SUT::new(resource_address, local_id);
-        // TODO
+        println!("{}", item.formatted(AddressFormat::Raw));
         assert_eq!(
             item.formatted(AddressFormat::Default),
             "reso...c9wlxa:{dead...3210}"

--- a/src/profile/v100/address/non_fungible_global_id.rs
+++ b/src/profile/v100/address/non_fungible_global_id.rs
@@ -182,16 +182,6 @@ impl NonFungibleGlobalId {
                 self.non_fungible_local_id.formatted(format)
             ),
             AddressFormat::Raw => self.to_canonical_string(),
-            AddressFormat::Middle => match self.non_fungible_local_id {
-                NonFungibleLocalId::Ruid { value: _ } => {
-                    format!(
-                        "{}:{}",
-                        self.resource_address.formatted(format),
-                        self.non_fungible_local_id.formatted(format)
-                    )
-                }
-                _ => self.resource_address.formatted(format),
-            },
         }
     }
 }
@@ -339,10 +329,6 @@ mod tests {
             item.formatted(AddressFormat::Default),
             "reso...c9wlxa:#12345678#"
         );
-        assert_eq!(
-            item.formatted(AddressFormat::Middle),
-            "urce_rdx1nfyg2f68jw7hfdlg5hzvd8ylsa7e0kjl68t5t62v3ttamtej"
-        );
 
         // local_id: string
         local_id = NonFungibleLocalId::string("foobar").unwrap();
@@ -351,10 +337,6 @@ mod tests {
             item.formatted(AddressFormat::Default),
             "reso...c9wlxa:<foobar>"
         );
-        assert_eq!(
-            item.formatted(AddressFormat::Middle),
-            "urce_rdx1nfyg2f68jw7hfdlg5hzvd8ylsa7e0kjl68t5t62v3ttamtej"
-        );
 
         // local_id: bytes
         local_id = NonFungibleLocalId::bytes([0xde, 0xad]).unwrap();
@@ -362,10 +344,6 @@ mod tests {
         assert_eq!(
             item.formatted(AddressFormat::Default),
             "reso...c9wlxa:[dead]"
-        );
-        assert_eq!(
-            item.formatted(AddressFormat::Middle),
-            "urce_rdx1nfyg2f68jw7hfdlg5hzvd8ylsa7e0kjl68t5t62v3ttamtej"
         );
 
         // local_id: ruid
@@ -376,7 +354,6 @@ mod tests {
             item.formatted(AddressFormat::Default),
             "reso...c9wlxa:{dead...3210}"
         );
-        assert_eq!(item.formatted(AddressFormat::Middle), "urce_rdx1nfyg2f68jw7hfdlg5hzvd8ylsa7e0kjl68t5t62v3ttamtej:beef12345678-babecafe87654321-fadedeaf01234567-ecadabba7654");
     }
 
     #[test]

--- a/src/profile/v100/address/non_fungible_global_id.rs
+++ b/src/profile/v100/address/non_fungible_global_id.rs
@@ -160,7 +160,23 @@ impl NonFungibleGlobalId {
 
     pub fn formatted(&self, format: AddressFormat) -> String {
         match format {
-            AddressFormat::Default | AddressFormat::Full => format!(
+            AddressFormat::Default => {
+                let local_id_formatted = match self.non_fungible_local_id {
+                    NonFungibleLocalId::Ruid { value: _ } => format_string(
+                        self.non_fungible_local_id.to_string(),
+                        5,
+                        5,
+                    ),
+                    _ => self.non_fungible_local_id.to_string(),
+                };
+
+                format!(
+                    "{}:{}",
+                    self.resource_address.formatted(format),
+                    local_id_formatted
+                )
+            }
+            AddressFormat::Full => format!(
                 "{}:{}",
                 self.resource_address.formatted(format),
                 self.non_fungible_local_id.formatted(format)
@@ -300,7 +316,7 @@ mod tests {
     fn formatted_default() {
         assert_eq!(
             SUT::sample_ruid().formatted(AddressFormat::Default),
-            "reso...c9wlxa:dead...3210"
+            "reso...c9wlxa:{dead...3210}"
         );
     }
 
@@ -321,7 +337,7 @@ mod tests {
         let mut item = SUT::new(resource_address, local_id);
         assert_eq!(
             item.formatted(AddressFormat::Default),
-            "reso...c9wlxa:12345678"
+            "reso...c9wlxa:#12345678#"
         );
         assert_eq!(
             item.formatted(AddressFormat::Middle),
@@ -333,7 +349,7 @@ mod tests {
         item = SUT::new(resource_address, local_id);
         assert_eq!(
             item.formatted(AddressFormat::Default),
-            "reso...c9wlxa:foobar"
+            "reso...c9wlxa:<foobar>"
         );
         assert_eq!(
             item.formatted(AddressFormat::Middle),
@@ -345,7 +361,7 @@ mod tests {
         item = SUT::new(resource_address, local_id);
         assert_eq!(
             item.formatted(AddressFormat::Default),
-            "reso...c9wlxa:dead"
+            "reso...c9wlxa:[dead]"
         );
         assert_eq!(
             item.formatted(AddressFormat::Middle),
@@ -355,9 +371,10 @@ mod tests {
         // local_id: ruid
         local_id = NonFungibleLocalId::ruid(hex_decode("deadbeef12345678babecafe87654321fadedeaf01234567ecadabba76543210").unwrap()).unwrap();
         item = SUT::new(resource_address, local_id);
+        // TODO
         assert_eq!(
             item.formatted(AddressFormat::Default),
-            "reso...c9wlxa:dead...3210"
+            "reso...c9wlxa:{dead...3210}"
         );
         assert_eq!(item.formatted(AddressFormat::Middle), "urce_rdx1nfyg2f68jw7hfdlg5hzvd8ylsa7e0kjl68t5t62v3ttamtej:beef12345678-babecafe87654321-fadedeaf01234567-ecadabba7654");
     }

--- a/src/profile/v100/address/non_fungible_local_id.rs
+++ b/src/profile/v100/address/non_fungible_local_id.rs
@@ -64,12 +64,6 @@ impl NonFungibleLocalId {
             },
             AddressFormat::Full => self.to_user_facing_string(),
             AddressFormat::Raw => self.to_string(),
-            AddressFormat::Middle => match self {
-                NonFungibleLocalId::Ruid { value: _ } => {
-                    trim_string(self.to_user_facing_string(), 4, 4)
-                }
-                _ => self.to_user_facing_string(),
-            },
         }
     }
     pub fn to_user_facing_string(&self) -> String {
@@ -341,36 +335,6 @@ mod tests {
         assert_eq!( SUT::ruid(
             hex_decode("deadbeef12345678babecafe87654321fadedeaf01234567ecadabba76543210").unwrap()
         ).unwrap().formatted(AddressFormat::Full), "deadbeef12345678-babecafe87654321-fadedeaf01234567-ecadabba76543210");
-    }
-
-    #[test]
-    fn formatted_middle_variant_string() {
-        assert_eq!(
-            SUT::string("foo").unwrap().formatted(AddressFormat::Middle),
-            "foo"
-        );
-    }
-
-    #[test]
-    fn formatted_middle_variant_integer() {
-        assert_eq!(SUT::integer(1234).formatted(AddressFormat::Middle), "1234");
-    }
-
-    #[test]
-    fn formatted_middle_variant_bytes() {
-        assert_eq!(
-            SUT::bytes([0xde, 0xad])
-                .unwrap()
-                .formatted(AddressFormat::Middle),
-            "dead"
-        );
-    }
-
-    #[test]
-    fn formatted_middle_variant_ruid() {
-        assert_eq!( SUT::ruid(
-            hex_decode("deadbeef12345678babecafe87654321fadedeaf01234567ecadabba76543210").unwrap()
-        ).unwrap().formatted(AddressFormat::Middle), "beef12345678-babecafe87654321-fadedeaf01234567-ecadabba7654");
     }
 
     #[test]

--- a/src/profile/v100/address/resource_address.rs
+++ b/src/profile/v100/address/resource_address.rs
@@ -308,14 +308,6 @@ mod tests {
     }
 
     #[test]
-    fn formatted_middle() {
-        assert_eq!(
-            SUT::sample().formatted(AddressFormat::Middle),
-            "urce_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxx"
-        );
-    }
-
-    #[test]
     fn display() {
         let s = "resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd";
         let a = SUT::try_from_bech32(s).unwrap();

--- a/src/profile/v100/address/wrap_ret_address.rs
+++ b/src/profile/v100/address/wrap_ret_address.rs
@@ -51,17 +51,6 @@ pub(crate) fn format_string(
     format!("{}...{}", prefix, suffix)
 }
 
-pub(crate) fn trim_string(
-    s: impl AsRef<str>,
-    prefix: usize,
-    suffix: usize,
-) -> String {
-    let s = s.as_ref();
-    let start = prefix;
-    let end = s.len() - suffix;
-    s[start..end].to_string()
-}
-
 pub trait IntoScryptoAddress: IsNetworkAware {
     fn scrypto(&self) -> ScryptoGlobalAddress;
 }
@@ -218,7 +207,6 @@ macro_rules! decl_ret_wrapped_address {
                     match format {
                         AddressFormat::Default => format_string(self.address(), 4, 6),
                         AddressFormat::Full | AddressFormat::Raw => self.address(),
-                        AddressFormat::Middle => trim_string(self.address(), 4, 6),
                     }
                 }
 

--- a/src/wrapped_radix_engine_toolkit/low_level/transaction_hashes/transaction_hashes.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/transaction_hashes/transaction_hashes.rs
@@ -62,7 +62,6 @@ macro_rules! decl_tx_hash {
                     assert_eq!(sut.formatted(AddressFormat::Default), [< $struct_name:snake _formatted>](&sut, AddressFormat::Default));
                     assert_eq!(sut.formatted(AddressFormat::Raw), [< $struct_name:snake _formatted>](&sut, AddressFormat::Raw));
                     assert_eq!(sut.formatted(AddressFormat::Full), [< $struct_name:snake _formatted>](&sut, AddressFormat::Full));
-                    assert_eq!(sut.formatted(AddressFormat::Middle), [< $struct_name:snake _formatted>](&sut, AddressFormat::Middle));
                 }
             }
         }
@@ -101,7 +100,6 @@ macro_rules! decl_tx_hash {
                 match format {
                     AddressFormat::Default => format_string(self.bech32_encoded_tx_id.to_string(), 4, 6),
                     AddressFormat::Full | AddressFormat::Raw => self.bech32_encoded_tx_id.to_string(),
-                    AddressFormat::Middle => trim_string(self.bech32_encoded_tx_id.to_string(), 4, 6),
                 }
             }
         }


### PR DESCRIPTION
The `AddressFormat::Default` of the global id has changed according to the [Non-Fungible Display standard](https://docs.radixdlt.com/v1/docs/non-fungible-display#nonfungible-global-id-address-display).

In essence the default format for a global id will be as follows:
1. String: 
    * RAW: `resource_sim1ngktvyeenvvqetnqwysevcx5fyvl6hqe36y3rkhdfdn6uzvt5366ha:<foobar>`
    * DEFAULT:  `reso...5366ha:<foobar>`
2. Integer:
    * RAW: `resource_sim1ngktvyeenvvqetnqwysevcx5fyvl6hqe36y3rkhdfdn6uzvt5366ha:#1#`
    * DEFAULT:  `reso...5366ha:#1#`
3. Bytes:
    * RAW: `resource_sim1ngktvyeenvvqetnqwysevcx5fyvl6hqe36y3rkhdfdn6uzvt5366ha:[dead]`
    * DEFAULT:  `reso...5366ha:[dead]`
4. Ruid:
    * RAW: `resource_sim1ngktvyeenvvqetnqwysevcx5fyvl6hqe36y3rkhdfdn6uzvt5366ha:{deadbeef12345678-babecafe87654321-fadedeaf01234567-ecadabba76543210}`
    * DEFAULT:  `reso...5366ha:{dead...3210}`

Also `Middle` was removed since it will be unused from both hosts.

> [!Note]
> `Full` format was not changed for global ids. I am not sure what should be the output, or the purpose of it.
