### PR TITLE
Skip duplicate Gateways without crashing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2593,7 +2593,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.0.22"
+version = "1.0.23"
 dependencies = [
  "actix-rt",
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "1.0.22"
+version = "1.0.23"
 edition = "2021"
 build = "build.rs"
 

--- a/apple/Sources/Sargon/Extensions/Swiftified/Profile/AppPreferences+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Profile/AppPreferences+Swiftified.swift
@@ -9,3 +9,9 @@ import Foundation
 import SargonUniFFI
 
 extension AppPreferences: SargonModel {}
+
+extension AppPreferences {
+	public func hasGateway(with url: URL) -> Bool {
+		appPreferencesHasGatewayWithUrl(appPreferences: self, url: url)
+	}
+}

--- a/apple/Tests/TestCases/Profile/AppPreferencesTests.swift
+++ b/apple/Tests/TestCases/Profile/AppPreferencesTests.swift
@@ -15,4 +15,10 @@ final class AppPreferencesTests: Test<AppPreferences> {
 	func test_default_guarantee_is_99() {
 		XCTAssertEqual(SUT.default.transaction.defaultDepositGuarantee, 0.99)
 	}
+	
+	func test_has_gateway() {
+		XCTAssertTrue(SUT.default.hasGateway(with: .init(string: "https://mainnet.radixdlt.com/")!))
+		XCTAssertTrue(SUT.default.hasGateway(with: .init(string: "https://mainnet.radixdlt.com")!))
+		XCTAssertFalse(SUT.default.hasGateway(with: .init(string: "https://radixdlt.com")!))
+	}
 }

--- a/src/profile/v100/app_preferences/app_preferences.rs
+++ b/src/profile/v100/app_preferences/app_preferences.rs
@@ -85,6 +85,12 @@ impl HasSampleValues for AppPreferences {
     }
 }
 
+impl AppPreferences {
+    pub fn has_gateway_with_url(&self, url: Url) -> bool {
+        self.gateways.all().into_iter().any(|g| g.id() == url)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -121,6 +127,22 @@ mod tests {
     #[test]
     fn get_transaction() {
         assert_eq!(SUT::sample().transaction, TransactionPreferences::sample())
+    }
+
+    #[test]
+    fn test_has_gateway_with_url() {
+        let sut = SUT::sample();
+        // Test without the "/" at the end
+        let mut url = Url::parse("https://mainnet.radixdlt.com").unwrap();
+        assert!(sut.has_gateway_with_url(url));
+
+        // Test with the "/" at the end
+        url = Url::parse("https://mainnet.radixdlt.com/").unwrap();
+        assert!(sut.has_gateway_with_url(url));
+
+        // Test with a Url that isn't present
+        url = Url::parse("https://radixdlt.com/").unwrap();
+        assert!(!sut.has_gateway_with_url(url));
     }
 
     #[test]

--- a/src/profile/v100/app_preferences/app_preferences_uniffi_fn.rs
+++ b/src/profile/v100/app_preferences/app_preferences_uniffi_fn.rs
@@ -41,4 +41,12 @@ mod tests {
     fn test_default() {
         assert_eq!(new_app_preferences_default(), AppPreferences::default());
     }
+
+    #[test]
+    fn test_app_preferences_has_gateway_with_url() {
+        assert!(app_preferences_has_gateway_with_url(
+            SUT::sample(),
+            Url::parse("https://mainnet.radixdlt.com").unwrap()
+        ));
+    }
 }

--- a/src/profile/v100/app_preferences/app_preferences_uniffi_fn.rs
+++ b/src/profile/v100/app_preferences/app_preferences_uniffi_fn.rs
@@ -15,6 +15,14 @@ pub fn new_app_preferences_default() -> AppPreferences {
     AppPreferences::default()
 }
 
+#[uniffi::export]
+pub fn app_preferences_has_gateway_with_url(
+    app_preferences: AppPreferences,
+    url: Url,
+) -> bool {
+    app_preferences.has_gateway_with_url(url)
+}
+
 #[cfg(test)]
 mod tests {
 

--- a/src/profile/v100/app_preferences/gateways/saved_gateways.rs
+++ b/src/profile/v100/app_preferences/gateways/saved_gateways.rs
@@ -66,24 +66,34 @@ impl<'de> Deserialize<'de> for SavedGateways {
         struct Wrapper {
             #[serde(rename = "current")]
             url: Url,
-            saved: IdentifiedVecOf<Gateway>,
+            saved: Vec<Gateway>,
         }
         let wrapped = Wrapper::deserialize(deserializer)?;
         let current = wrapped
             .saved
             .iter()
             .find(|g| g.id() == wrapped.url)
-            .clone()
             .ok_or({
                 CommonError::InvalidGatewaysJSONCurrentNotFoundAmongstSaved
             })
             .map_err(de::Error::custom)?;
 
-        let mut other = wrapped.saved.clone();
+        let saved = wrapped.saved.clone();
+        let mut other = IdentifiedVecOf::<Gateway>::new();
+        for item in saved {
+            let _ = other.try_insert_unique(item.clone()).map_err(|e| {
+                error!(
+                    "Failed to insert unique Gateway {}, error: {:?}",
+                    item,
+                    e.clone()
+                );
+                e
+            });
+        }
 
         other.remove_id(&current.id());
 
-        SavedGateways::new_with_other(current, other.items())
+        SavedGateways::new_with_other(current.clone(), other.items())
             .map_err(de::Error::custom)
     }
 }
@@ -297,6 +307,56 @@ mod tests {
             }
             "#,
         )
+    }
+
+    #[test]
+    fn deserialize_from_json_ignore_repetitions() {
+        let json = r#"
+        {
+                "current": "https://rcnet-v3.radixdlt.com/",
+                "saved": [
+                    {
+                        "network":
+                        {
+                            "name": "zabanet",
+                            "id": 14,
+                            "displayDescription": "RCnet-V3 (Test Network)"
+                        },
+                        "url": "https://rcnet-v3.radixdlt.com/"
+                    },
+                    {
+                        "network":
+                        {
+                            "name": "mainnet",
+                            "id": 1,
+                            "displayDescription": "Mainnet"
+                        },
+                        "url": "https://mainnet.radixdlt.com/"
+                    },
+                    {
+                        "network":
+                        {
+                            "name": "stokenet",
+                            "id": 2,
+                            "displayDescription": "Stokenet"
+                        },
+                        "url": "https://babylon-stokenet-gateway.radixdlt.com/"
+                    },
+                    {
+                        "network":
+                        {
+                            "name": "different",
+                            "id": 11,
+                            "displayDescription": "All differs but Url is the same than stokenet"
+                        },
+                        "url": "https://babylon-stokenet-gateway.radixdlt.com/"
+                    }
+                ]
+            }
+        "#;
+
+        let sut = serde_json::from_str::<SUT>(json).unwrap();
+        assert_eq!(sut, SUT::sample());
     }
 
     #[test]

--- a/src/profile/v100/app_preferences/gateways/saved_gateways.rs
+++ b/src/profile/v100/app_preferences/gateways/saved_gateways.rs
@@ -81,14 +81,13 @@ impl<'de> Deserialize<'de> for SavedGateways {
         let saved = wrapped.saved.clone();
         let mut other = IdentifiedVecOf::<Gateway>::new();
         for item in saved {
-            let _ = other.try_insert_unique(item.clone()).map_err(|e| {
+            if let Err(e) = other.try_insert_unique(item.clone()) {
                 error!(
                     "Failed to insert unique Gateway {}, error: {:?}",
                     item,
                     e.clone()
-                );
-                e
-            });
+                )
+            };
         }
 
         other.remove_id(&current.id());


### PR DESCRIPTION
## Changelog
- When deserializing `SavedGateways`, if JSON has elements with same Url we will just skip those that are repeated.
- Add function to check if `AppPreferences` have a `Gateway` with the given `Url`.

Both changes should unlock this user and prevent having issues like this in the future. [JIRA](https://radixdlt.atlassian.net/browse/ABW-3500)
