### PR TITLE
Set custom name to builds that come from workflow dispatch

### DIFF
--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -2,6 +2,11 @@ name: CD Android
 
 on:
   workflow_dispatch:
+    inputs:
+      build_name:
+        description: "A custom version name. The resulting name will have the format <cargo.version.patch>-<custom-name>-<rev> (E.g. 1.0.23-custom-name-2eb68d8c)."
+        required: true
+        type: string
   push:
     tags:
       - "**"
@@ -21,6 +26,7 @@ jobs:
     env:
       RUST_TOOLCHAIN: nightly-2024-01-11
       RUST_COMPONENTS: "rust-std"
+      CUSTOM_BUILD_NAME: ${{ inputs.build_name }}
     steps:
       - uses: RDXWorks-actions/checkout@main
 

--- a/.github/workflows/release-desktop-bins.yml
+++ b/.github/workflows/release-desktop-bins.yml
@@ -2,6 +2,11 @@ name: CD Desktop Binaries
 
 on:
   workflow_dispatch:
+    inputs:
+      build_name:
+        description: "A custom version name. The resulting name will have the format <cargo.version.patch>-<custom-name>-<rev> (E.g. 1.0.23-custom-name-2eb68d8c)."
+        required: true
+        type: string
   push:
     tags:
       - "**"
@@ -21,6 +26,7 @@ jobs:
     env:
       RUST_TOOLCHAIN: nightly-2024-01-11
       RUST_COMPONENTS: "rust-std"
+      CUSTOM_BUILD_NAME: ${{ inputs.build_name }}
     steps:
       - uses: RDXWorks-actions/checkout@main
 

--- a/jvm/buildSrc/src/main/java/com/radixdlt/cargo/toml/SargonVersion.kt
+++ b/jvm/buildSrc/src/main/java/com/radixdlt/cargo/toml/SargonVersion.kt
@@ -21,4 +21,12 @@ private fun Project.parseGitHash(): String {
     return String(out.toByteArray(), Charsets.UTF_8).trim()
 }
 
-fun Project.sargonVersion(): String = "${parseTomlVersion()}-${parseGitHash()}"
+fun Project.sargonVersion(): String {
+    val customBuildName = System.getenv("CUSTOM_BUILD_NAME")?.takeIf {
+        it.isNotBlank()
+    }?.replace("\\s+".toRegex(), "-")?.let {
+        "-${it}"
+    }.orEmpty()
+
+    return "${parseTomlVersion()}${customBuildName}-${parseGitHash()}"
+}


### PR DESCRIPTION
Maven libraries that are built from `workflow_dispatch` action will require a custom name. This is to differentiate them from the rest of the builds that come from CD. The reason is that when we build custom binaries for testing a branch rather than main the output used to be something like `1.0.23-2eb68d8c` which may be confused with a revision from main.

Resulting build names from workflow dispatch will look like this instead `1.0.23-custom-name-2eb68d8c` were the custom name will be required in the workflow dispatch context menu.