### PR TITLE
Properly expose transaction proofs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2593,7 +2593,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.0.25"
+version = "1.0.26"
 dependencies = [
  "actix-rt",
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "1.0.25"
+version = "1.0.26"
 edition = "2021"
 build = "build.rs"
 

--- a/apple/Sources/Sargon/Extensions/Methods/RET/ResourceSpecifier+Warp+Functions.swift
+++ b/apple/Sources/Sargon/Extensions/Methods/RET/ResourceSpecifier+Warp+Functions.swift
@@ -1,0 +1,7 @@
+import SargonUniFFI
+
+extension ResourceSpecifier {
+    public var resourceAddress: ResourceAddress {
+        resourceSpecifierGetAddress(specifier: self)
+    }
+}

--- a/apple/Sources/Sargon/Extensions/SampleValues/RET/ResourceSpecifier+SampleValues.swift
+++ b/apple/Sources/Sargon/Extensions/SampleValues/RET/ResourceSpecifier+SampleValues.swift
@@ -1,0 +1,8 @@
+import SargonUniFFI
+
+#if DEBUG
+extension ResourceSpecifier {
+    public static let sample: Self = newResourceSpecifierSample()
+    public static let sampleOther: Self = newResourceSpecifierSampleOther()
+}
+#endif

--- a/apple/Sources/Sargon/Extensions/Swiftified/RET/ResourceSpecifier+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/RET/ResourceSpecifier+Swiftified.swift
@@ -1,0 +1,3 @@
+import SargonUniFFI
+
+extension ResourceSpecifier: SargonModel {}

--- a/apple/Tests/TestCases/RET/ResourceSpecifierTests.swift
+++ b/apple/Tests/TestCases/RET/ResourceSpecifierTests.swift
@@ -1,0 +1,16 @@
+import CustomDump
+import Foundation
+import Sargon
+import SargonUniFFI
+import XCTest
+
+final class ResourceSpecifierTests: Test<ResourceSpecifier> {
+    func test_resource_address() {
+        let sut = SUT.sample
+        switch sut {
+        case let .fungible(resourceAddress, _):
+            XCTAssertEqual(resourceAddress, sut.resourceAddress)
+        case .nonFungible: XCTFail("Expected fungible")
+        }
+    }
+}

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/ResourceSpecifier.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/ResourceSpecifier.kt
@@ -1,0 +1,9 @@
+
+package com.radixdlt.sargon.extensions
+
+import com.radixdlt.sargon.ResourceAddress
+import com.radixdlt.sargon.ResourceSpecifier
+import com.radixdlt.sargon.resourceSpecifierGetAddress
+
+val ResourceSpecifier.address: ResourceAddress
+    get() = resourceSpecifierGetAddress(specifier = this)

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/ResourceSpecifierSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/ResourceSpecifierSample.kt
@@ -1,0 +1,15 @@
+
+package com.radixdlt.sargon.samples
+
+import com.radixdlt.sargon.ResourceSpecifier
+import com.radixdlt.sargon.annotation.UsesSampleValues
+import com.radixdlt.sargon.newResourceSpecifierSample
+import com.radixdlt.sargon.newResourceSpecifierSampleOther
+
+@UsesSampleValues
+val ResourceSpecifier.Companion.sample: Sample<ResourceSpecifier>
+    get() = object: Sample<ResourceSpecifier> {
+        override fun invoke(): ResourceSpecifier = newResourceSpecifierSample()
+
+        override fun other(): ResourceSpecifier = newResourceSpecifierSampleOther()
+    }

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/ResourceSpecifierTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/ResourceSpecifierTest.kt
@@ -1,0 +1,23 @@
+package com.radixdlt.sargon
+
+import com.radixdlt.sargon.extensions.address
+import com.radixdlt.sargon.samples.Sample
+import com.radixdlt.sargon.samples.sample
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Test
+
+class ResourceSpecifierTest: SampleTestable<ResourceSpecifier> {
+    override val samples: List<Sample<ResourceSpecifier>>
+        get() = listOf(ResourceSpecifier.sample)
+
+    @Test
+    fun testIds() {
+        val sample = ResourceSpecifier.sample()
+        assertEquals(
+            (sample as ResourceSpecifier.Fungible).resourceAddress,
+            sample.address
+        )
+        assertInstanceOf(ResourceSpecifier.Fungible::class.java, sample)
+    }
+}

--- a/src/wrapped_radix_engine_toolkit/low_level/execution_summary/execution_summary.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/execution_summary/execution_summary.rs
@@ -39,7 +39,7 @@ pub struct ExecutionSummary {
     pub reserved_instructions: Vec<ReservedInstruction>,
 
     /// The list of the resources of proofs that were presented in the manifest.
-    pub presented_proofs: Vec<ResourceAddress>,
+    pub presented_proofs: Vec<ResourceSpecifier>,
 
     /// The set of all the encountered `ComponentAddress`es` in the manifest. This is
     /// to be primarily used for the "using dApps" section of the wallet's tx
@@ -70,7 +70,7 @@ impl ExecutionSummary {
         >,
         newly_created_non_fungibles: impl IntoIterator<Item = NonFungibleGlobalId>,
         reserved_instructions: impl IntoIterator<Item = ReservedInstruction>,
-        presented_proofs: impl IntoIterator<Item = ResourceAddress>,
+        presented_proofs: impl IntoIterator<Item = ResourceSpecifier>,
         encountered_component_addresses: impl IntoIterator<Item = ComponentAddress>,
         detailed_classification: impl IntoIterator<Item = DetailedManifestClass>,
         fee_locks: impl Into<FeeLocks>,
@@ -142,10 +142,7 @@ impl From<(RetExecutionSummary, NetworkID)> for ExecutionSummary {
             ret.reserved_instructions
                 .into_iter()
                 .map(ReservedInstruction::from),
-            ret
-                // iOS Wallet only use `Vec<ResourceAddress>` for `presented_proofs` today,
-                // have to assert Android does the same.
-                .presented_proofs
+            ret.presented_proofs
                 .values()
                 .cloned()
                 .flat_map(|vec| filter_try_to_vec_network_aware(vec, n)),

--- a/src/wrapped_radix_engine_toolkit/low_level/execution_summary/mod.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/execution_summary/mod.rs
@@ -5,6 +5,7 @@ mod new_entities;
 mod newly_created_resource;
 mod reserved_instruction;
 mod resource_indicator;
+mod resource_specifier;
 
 pub use execution_summary::*;
 pub use fee_locks::*;
@@ -13,3 +14,4 @@ pub use new_entities::*;
 pub use newly_created_resource::*;
 pub use reserved_instruction::*;
 pub use resource_indicator::*;
+pub use resource_specifier::*;

--- a/src/wrapped_radix_engine_toolkit/low_level/execution_summary/resource_specifier/mod.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/execution_summary/resource_specifier/mod.rs
@@ -1,3 +1,5 @@
 mod resource_specifier;
+mod resource_specifier_uniffi;
 
 pub use resource_specifier::*;
+pub use resource_specifier_uniffi::*;

--- a/src/wrapped_radix_engine_toolkit/low_level/execution_summary/resource_specifier/mod.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/execution_summary/resource_specifier/mod.rs
@@ -1,0 +1,3 @@
+mod resource_specifier;
+
+pub use resource_specifier::*;

--- a/src/wrapped_radix_engine_toolkit/low_level/execution_summary/resource_specifier/resource_specifier.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/execution_summary/resource_specifier/resource_specifier.rs
@@ -1,0 +1,80 @@
+use crate::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, Eq, uniffi::Enum)]
+pub enum ResourceSpecifier {
+    Fungible {
+        resource_address: ResourceAddress,
+        amount: Decimal,
+    },
+    NonFungible {
+        resource_address: ResourceAddress,
+        ids: Vec<NonFungibleLocalId>,
+    },
+}
+
+impl ResourceSpecifier {
+    pub fn get_address(&self) -> ResourceAddress {
+        match self {
+            ResourceSpecifier::Fungible {
+                resource_address,
+                amount: _,
+            } => *resource_address,
+            ResourceSpecifier::NonFungible {
+                resource_address,
+                ids: _,
+            } => *resource_address,
+        }
+    }
+}
+
+impl ResourceSpecifier {
+    pub fn fungible(
+        resource_address: impl Into<ResourceAddress>,
+        amount: impl Into<Decimal>,
+    ) -> Self {
+        Self::Fungible {
+            resource_address: resource_address.into(),
+            amount: amount.into(),
+        }
+    }
+
+    pub fn non_fungible(
+        resource_address: impl Into<ResourceAddress>,
+        ids: Vec<NonFungibleLocalId>,
+    ) -> Self {
+        Self::NonFungible {
+            resource_address: resource_address.into(),
+            ids,
+        }
+    }
+}
+
+impl From<(ScryptoResourceSpecifier, NetworkID)> for ResourceSpecifier {
+    fn from(value: (ScryptoResourceSpecifier, NetworkID)) -> Self {
+        let (scrypto_value, network_id) = value;
+        match scrypto_value {
+            ScryptoResourceSpecifier::Amount(resource_address, amount) => {
+                Self::fungible((resource_address, network_id), amount)
+            }
+            ScryptoResourceSpecifier::Ids(resource_address, ids) => {
+                Self::non_fungible(
+                    (resource_address, network_id),
+                    ids.into_iter().map(NonFungibleLocalId::from).collect(),
+                )
+            }
+        }
+    }
+}
+
+impl HasSampleValues for ResourceSpecifier {
+    fn sample() -> Self {
+        Self::fungible(ResourceAddress::sample(), 3)
+    }
+
+    fn sample_other() -> Self {
+        Self::non_fungible(
+            ResourceAddress::sample_other(),
+            vec![NonFungibleLocalId::sample_other()],
+        )
+    }
+}

--- a/src/wrapped_radix_engine_toolkit/low_level/execution_summary/resource_specifier/resource_specifier_uniffi.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/execution_summary/resource_specifier/resource_specifier_uniffi.rs
@@ -1,0 +1,40 @@
+use crate::prelude::*;
+
+#[uniffi::export]
+pub fn new_resource_specifier_sample() -> ResourceSpecifier {
+    ResourceSpecifier::sample()
+}
+
+#[uniffi::export]
+pub fn new_resource_specifier_sample_other() -> ResourceSpecifier {
+    ResourceSpecifier::sample_other()
+}
+
+#[uniffi::export]
+pub fn resource_specifier_get_address(
+    specifier: &ResourceSpecifier,
+) -> ResourceAddress {
+    specifier.get_address()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[allow(clippy::upper_case_acronyms)]
+    type SUT = ResourceSpecifier;
+
+    #[test]
+    fn inequality() {
+        assert_ne!(
+            new_resource_indicator_sample(),
+            new_resource_indicator_sample_other()
+        );
+    }
+
+    #[test]
+    fn get_address() {
+        let sut = SUT::sample();
+        assert_eq!(sut.get_address(), resource_specifier_get_address(&sut));
+    }
+}

--- a/src/wrapped_radix_engine_toolkit/low_level/transaction_manifest/execution_summary/transaction_manifest_execution_summary.rs
+++ b/src/wrapped_radix_engine_toolkit/low_level/transaction_manifest/execution_summary/transaction_manifest_execution_summary.rs
@@ -545,7 +545,7 @@ mod tests {
                     [], // addresses_of_identities_requiring_auth
                     [], // newly_created_non_fungibles
                     [], // reserved_instructions
-                    ["resource_tdx_2_1ng88qk08hrgmad30rzdxpyx779yuta4cwcjc3gstk60jhachsv94g9".parse::<ResourceAddress>().unwrap()], // presented_proofs
+                    [ResourceSpecifier::non_fungible("resource_tdx_2_1ng88qk08hrgmad30rzdxpyx779yuta4cwcjc3gstk60jhachsv94g9", vec!["<Member_44>".parse().unwrap()])], // presented_proofs
                     ["component_tdx_2_1crje3en7zsrna9t5vyywn3z3t9ht34l9udxjcpjvdhpcw9v6vlzru8".parse::<ComponentAddress>().unwrap()], // encountered_component_addresses
                     [
                         DetailedManifestClass::General


### PR DESCRIPTION
Expose the full resource specifier, not just the address.