### PR TITLE
Add function to clear home cards

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2593,7 +2593,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.0.26"
+version = "1.0.27"
 dependencies = [
  "actix-rt",
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "1.0.26"
+version = "1.0.27"
 edition = "2021"
 build = "build.rs"
 


### PR DESCRIPTION
This PR adds a `uniffi` exported function to notify the `HomeCardsManager` to clear the home cards both in-memory and from storage. This is required when factory resetting the wallet and ensures that all the control over the home cards is inside Sargon. Thanks, @matiasbzurovski for the suggestion.