### PR TITLE
Fix third party deposit asset exceptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2593,7 +2593,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.0.27"
+version = "1.0.28"
 dependencies = [
  "actix-rt",
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "1.0.27"
+version = "1.0.28"
 edition = "2021"
 build = "build.rs"
 


### PR DESCRIPTION
Fixed the bug preventing from adding additional asset exception for the same rule.

Th old implementation was incorrectly checking only for the exception rule difference, ending in creating an empty manifest.

Original bug report: https://rdxworks.slack.com/archives/C03QFAWBRNX/p1721202200334219