### PR TITLE
Clear home cards after restore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2593,7 +2593,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.0.28"
+version = "1.0.29"
 dependencies = [
  "actix-rt",
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "1.0.28"
+version = "1.0.29"
 edition = "2021"
 build = "build.rs"
 


### PR DESCRIPTION
Currently, whenever the wallet is restored there should be no home cards. 
The use case is as follows: 
The user clicks on a valid deep link -> installs the app -> the deep link is resolved -> home cards are saved to storage -> the user restores the wallet -> at this point we should ensure no home cards are stored.