### PR TITLE
Bump to regenerate artefacts for iOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2585,7 +2585,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "actix-rt",
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 build = "build.rs"
 


### PR DESCRIPTION
Since I have had to set the tag 1.1.0 by hand the generated artefacts are not working. Re-trigger the whole deployment by bumping the version to 1.1.0