### PR TITLE
Add wrapper FfiUrl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2585,7 +2585,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "actix-rt",
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2021"
 build = "build.rs"
 

--- a/apple/Sources/Sargon/Extensions/Methods/Prelude/FfiUrl+Wrap+Functions.swift
+++ b/apple/Sources/Sargon/Extensions/Methods/Prelude/FfiUrl+Wrap+Functions.swift
@@ -1,0 +1,12 @@
+import Foundation
+import SargonUniFFI
+
+#if DEBUG
+import XCTestDynamicOverlay
+#endif // DEBUG
+
+extension FfiUrl {
+	public var url: URL {
+		ffiUrlGetUrl(ffiUrl: self)
+	}
+}

--- a/apple/Sources/Sargon/Extensions/Swiftified/Prelude/FfiUrl+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Prelude/FfiUrl+Swiftified.swift
@@ -1,0 +1,3 @@
+import Foundation
+
+extension FfiUrl: @unchecked Sendable {}

--- a/apple/Sources/Sargon/Extensions/Swiftified/Profile/AppPreferences+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Profile/AppPreferences+Swiftified.swift
@@ -11,12 +11,8 @@ import SargonUniFFI
 extension AppPreferences: SargonModel {}
 
 extension AppPreferences {
-	public func hasGateway(with url: URL) -> Bool {
-		do {
-			let ffiUrl = try FfiUrl.parse(urlPath: url.absoluteString)
-			return appPreferencesHasGatewayWithUrl(appPreferences: self, url: ffiUrl)
-		} catch {
-			return false
-		}
+	public func hasGateway(with url: URL) throws -> Bool {
+		let ffiUrl = try FfiUrl(url: url)
+		return appPreferencesHasGatewayWithUrl(appPreferences: self, url: ffiUrl)
 	}
 }

--- a/apple/Sources/Sargon/Extensions/Swiftified/Profile/AppPreferences+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Profile/AppPreferences+Swiftified.swift
@@ -11,8 +11,7 @@ import SargonUniFFI
 extension AppPreferences: SargonModel {}
 
 extension AppPreferences {
-	public func hasGateway(with url: URL) throws -> Bool {
-		let ffiUrl = try FfiUrl(url: url)
-		return appPreferencesHasGatewayWithUrl(appPreferences: self, url: ffiUrl)
+	public func hasGateway(with url: FfiUrl) -> Bool {
+		appPreferencesHasGatewayWithUrl(appPreferences: self, url: url)
 	}
 }

--- a/apple/Sources/Sargon/Extensions/Swiftified/Profile/AppPreferences+Swiftified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Profile/AppPreferences+Swiftified.swift
@@ -12,6 +12,11 @@ extension AppPreferences: SargonModel {}
 
 extension AppPreferences {
 	public func hasGateway(with url: URL) -> Bool {
-		appPreferencesHasGatewayWithUrl(appPreferences: self, url: url)
+		do {
+			let ffiUrl = try FfiUrl.parse(urlPath: url.absoluteString)
+			return appPreferencesHasGatewayWithUrl(appPreferences: self, url: ffiUrl)
+		} catch {
+			return false
+		}
 	}
 }

--- a/apple/Tests/TestCases/Prelude/FfiUrlTests.swift
+++ b/apple/Tests/TestCases/Prelude/FfiUrlTests.swift
@@ -1,0 +1,13 @@
+import Foundation
+import Sargon
+import SargonUniFFI
+import XCTest
+
+final class FfiUrlTests: TestCase {
+	func test_url() throws {
+		let url = URL(string: "https://radixdlt.com")!
+		let sut = try FfiUrl(urlPath: url.absoluteString)
+		XCTAssertEqual(sut.url, url)
+	}
+	
+}

--- a/apple/Tests/TestCases/Prelude/FfiUrlTests.swift
+++ b/apple/Tests/TestCases/Prelude/FfiUrlTests.swift
@@ -5,9 +5,8 @@ import XCTest
 
 final class FfiUrlTests: TestCase {
 	func test_url() throws {
-		let url = URL(string: "https://radixdlt.com")!
+		let url = URL(string: "https://radixdlt.com/")!
 		let sut = try FfiUrl(urlPath: url.absoluteString)
 		XCTAssertEqual(sut.url, url)
 	}
-	
 }

--- a/apple/Tests/TestCases/Profile/AppPreferencesTests.swift
+++ b/apple/Tests/TestCases/Profile/AppPreferencesTests.swift
@@ -17,17 +17,18 @@ final class AppPreferencesTests: Test<AppPreferences> {
 	}
 	
 	func test_has_gateway_valid() throws {
-		XCTAssertTrue(try SUT.default.hasGateway(with: .init(string: "https://mainnet.radixdlt.com/")!))
-		XCTAssertTrue(try SUT.default.hasGateway(with: .init(string: "https://mainnet.radixdlt.com")!))
-		XCTAssertFalse(try SUT.default.hasGateway(with: .init(string: "https://radixdlt.com")!))
-		
+		XCTAssertTrue(SUT.default.hasGateway(with: try .init(urlPath: "https://mainnet.radixdlt.com/")))
+		XCTAssertTrue(SUT.default.hasGateway(with: try .init(urlPath: "https://mainnet.radixdlt.com")))
+		XCTAssertFalse(SUT.default.hasGateway(with: try .init(urlPath: "https://radixdlt.com/")))
 	}
 	
 	func test_has_gateway_invalid() {
-		let url = URL(string: "Rust considers this invalid")
-		XCTAssertNotNil(url)
-		XCTAssertThrowsError(try SUT.default.hasGateway(with: url!)) { error in
-			XCTAssertEqual(error.localizedDescription, "Failed to convert arg \'url\': relative URL without a base")
+		let urlPath = "invalid input"
+		XCTAssertThrowsError(SUT.default.hasGateway(with: try .init(urlPath: urlPath))) { error in
+			guard let commonError = error as? SargonUniFFI.CommonError else {
+				return XCTFail("Expected CommonError")
+			}
+			XCTAssertEqual(commonError, .InvalidUrl(badValue: urlPath))
 		}
 	}
 }

--- a/apple/Tests/TestCases/Profile/AppPreferencesTests.swift
+++ b/apple/Tests/TestCases/Profile/AppPreferencesTests.swift
@@ -17,8 +17,26 @@ final class AppPreferencesTests: Test<AppPreferences> {
 	}
 	
 	func test_has_gateway() {
-		XCTAssertTrue(SUT.default.hasGateway(with: .init(string: "https://mainnet.radixdlt.com/")!))
-		XCTAssertTrue(SUT.default.hasGateway(with: .init(string: "https://mainnet.radixdlt.com")!))
-		XCTAssertFalse(SUT.default.hasGateway(with: .init(string: "https://radixdlt.com")!))
+		// Valid URLs
+		do {
+			var result = try SUT.default.hasGateway(with: .init(string: "https://mainnet.radixdlt.com/")!)
+			XCTAssertTrue(result)
+			result = try SUT.default.hasGateway(with: .init(string: "https://mainnet.radixdlt.com")!)
+			XCTAssertTrue(result)
+			result = try SUT.default.hasGateway(with: .init(string: "https://radixdlt.com")!)
+			XCTAssertFalse(result)
+		} catch {
+			XCTFail("Unexpected failure")
+		}
+		
+		// Invalid URL
+		do {
+			let url = URL(string: "Rust considers this invalid")
+			XCTAssertNotNil(url)
+			let _ = try SUT.default.hasGateway(with: url!)
+			XCTFail("Should have thrown")
+		} catch let error {
+			XCTAssertEqual(error.localizedDescription, "Failed to convert arg \'url\': relative URL without a base")
+		}
 	}
 }

--- a/apple/Tests/TestCases/Profile/AppPreferencesTests.swift
+++ b/apple/Tests/TestCases/Profile/AppPreferencesTests.swift
@@ -16,26 +16,17 @@ final class AppPreferencesTests: Test<AppPreferences> {
 		XCTAssertEqual(SUT.default.transaction.defaultDepositGuarantee, 0.99)
 	}
 	
-	func test_has_gateway() {
-		// Valid URLs
-		do {
-			var result = try SUT.default.hasGateway(with: .init(string: "https://mainnet.radixdlt.com/")!)
-			XCTAssertTrue(result)
-			result = try SUT.default.hasGateway(with: .init(string: "https://mainnet.radixdlt.com")!)
-			XCTAssertTrue(result)
-			result = try SUT.default.hasGateway(with: .init(string: "https://radixdlt.com")!)
-			XCTAssertFalse(result)
-		} catch {
-			XCTFail("Unexpected failure")
-		}
+	func test_has_gateway_valid() throws {
+		XCTAssertTrue(try SUT.default.hasGateway(with: .init(string: "https://mainnet.radixdlt.com/")!))
+		XCTAssertTrue(try SUT.default.hasGateway(with: .init(string: "https://mainnet.radixdlt.com")!))
+		XCTAssertFalse(try SUT.default.hasGateway(with: .init(string: "https://radixdlt.com")!))
 		
-		// Invalid URL
-		do {
-			let url = URL(string: "Rust considers this invalid")
-			XCTAssertNotNil(url)
-			let _ = try SUT.default.hasGateway(with: url!)
-			XCTFail("Should have thrown")
-		} catch let error {
+	}
+	
+	func test_has_gateway_invalid() {
+		let url = URL(string: "Rust considers this invalid")
+		XCTAssertNotNil(url)
+		XCTAssertThrowsError(try SUT.default.hasGateway(with: url!)) { error in
 			XCTAssertEqual(error.localizedDescription, "Failed to convert arg \'url\': relative URL without a base")
 		}
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ mod home_cards;
 mod profile;
 mod radix_connect;
 mod system;
+mod types;
 mod wrapped_radix_engine_toolkit;
 
 pub mod prelude {

--- a/src/profile/v100/app_preferences/app_preferences_uniffi_fn.rs
+++ b/src/profile/v100/app_preferences/app_preferences_uniffi_fn.rs
@@ -1,4 +1,5 @@
 use crate::prelude::*;
+use crate::types::*;
 
 #[uniffi::export]
 pub fn new_app_preferences_sample() -> AppPreferences {
@@ -18,9 +19,9 @@ pub fn new_app_preferences_default() -> AppPreferences {
 #[uniffi::export]
 pub fn app_preferences_has_gateway_with_url(
     app_preferences: AppPreferences,
-    url: Url, // UniFFIUrl
+    url: FfiUrl,
 ) -> bool {
-    app_preferences.has_gateway_with_url(url) // (url.url)
+    app_preferences.has_gateway_with_url(url.url)
 }
 
 #[cfg(test)]
@@ -46,7 +47,7 @@ mod tests {
     fn test_app_preferences_has_gateway_with_url() {
         assert!(app_preferences_has_gateway_with_url(
             SUT::sample(),
-            Url::parse("https://mainnet.radixdlt.com").unwrap()
+            FfiUrl::parse("https://mainnet.radixdlt.com".to_string()).unwrap()
         ));
     }
 }

--- a/src/profile/v100/app_preferences/app_preferences_uniffi_fn.rs
+++ b/src/profile/v100/app_preferences/app_preferences_uniffi_fn.rs
@@ -18,9 +18,9 @@ pub fn new_app_preferences_default() -> AppPreferences {
 #[uniffi::export]
 pub fn app_preferences_has_gateway_with_url(
     app_preferences: AppPreferences,
-    url: Url,
+    url: Url, // UniFFIUrl
 ) -> bool {
-    app_preferences.has_gateway_with_url(url)
+    app_preferences.has_gateway_with_url(url) // (url.url)
 }
 
 #[cfg(test)]

--- a/src/profile/v100/app_preferences/app_preferences_uniffi_fn.rs
+++ b/src/profile/v100/app_preferences/app_preferences_uniffi_fn.rs
@@ -47,8 +47,7 @@ mod tests {
     fn test_app_preferences_has_gateway_with_url() {
         assert!(app_preferences_has_gateway_with_url(
             SUT::sample(),
-            &FfiUrl::new(Url::parse("https://mainnet.radixdlt.com").unwrap())
-                .unwrap()
+            &FfiUrl::from_str("https://mainnet.radixdlt.com").unwrap()
         ));
     }
 }

--- a/src/profile/v100/app_preferences/app_preferences_uniffi_fn.rs
+++ b/src/profile/v100/app_preferences/app_preferences_uniffi_fn.rs
@@ -19,9 +19,9 @@ pub fn new_app_preferences_default() -> AppPreferences {
 #[uniffi::export]
 pub fn app_preferences_has_gateway_with_url(
     app_preferences: AppPreferences,
-    url: FfiUrl,
+    url: &FfiUrl,
 ) -> bool {
-    app_preferences.has_gateway_with_url(url.url)
+    app_preferences.has_gateway_with_url(url.url.clone())
 }
 
 #[cfg(test)]
@@ -47,7 +47,8 @@ mod tests {
     fn test_app_preferences_has_gateway_with_url() {
         assert!(app_preferences_has_gateway_with_url(
             SUT::sample(),
-            FfiUrl::parse("https://mainnet.radixdlt.com".to_string()).unwrap()
+            &FfiUrl::new(Url::parse("https://mainnet.radixdlt.com").unwrap())
+                .unwrap()
         ));
     }
 }

--- a/src/types/ffi_url.rs
+++ b/src/types/ffi_url.rs
@@ -1,3 +1,4 @@
+use uniffi::deps::bytes::Buf;
 use uniffi::{Lift, RustBuffer};
 
 use crate::prelude::*;
@@ -26,6 +27,7 @@ unsafe impl Lift<UniFfiTag> for FfiUrl {
     }
 
     fn try_read(buf: &mut &[u8]) -> uniffi::Result<Self> {
+        buf.advance(4);
         let url = Url::try_read(buf)?;
         Ok(Self { url })
     }

--- a/src/types/ffi_url.rs
+++ b/src/types/ffi_url.rs
@@ -1,12 +1,16 @@
-use crate::prelude::*;
+use uniffi::Lift;
 
-#[derive(uniffi::Object)]
-pub struct UniFFIUrl {
+use crate::prelude::*;
+use crate::UniFfiTag;
+
+#[derive(Debug, PartialEq, Eq, Hash, uniffi::Object, derive_more::Display)]
+#[uniffi::export(Debug, Display, Eq, Hash)]
+pub struct FfiUrl {
     pub url: Url,
 }
 
 #[uniffi::export]
-impl UniFFIUrl {
+impl FfiUrl {
     #[uniffi::constructor]
     pub fn parse(url_path: String) -> Result<Self> {
         let url = parse_url(url_path)?;

--- a/src/types/ffi_url.rs
+++ b/src/types/ffi_url.rs
@@ -18,9 +18,14 @@ pub struct FfiUrl {
 #[uniffi::export]
 impl FfiUrl {
     #[uniffi::constructor]
-    pub fn new(url: Url) -> Result<Self> {
-        Ok(Self { url })
+    pub fn new(url_path: String) -> Result<Self> {
+        Self::from_str(&url_path)
     }
+}
+
+#[uniffi::export]
+pub fn ffi_url_get_url(ffi_url: &FfiUrl) -> Url {
+    ffi_url.url.clone()
 }
 
 impl FromStr for FfiUrl {
@@ -28,7 +33,7 @@ impl FromStr for FfiUrl {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let url = parse_url(s)?;
-        Self::new(url)
+        Ok(Self { url })
     }
 }
 
@@ -41,14 +46,21 @@ mod tests {
 
     #[test]
     fn test_new() {
-        let url = Url::parse("https://radixdlt.com").unwrap();
-        let result = SUT::new(url.clone());
-        assert_eq!(result.unwrap().url, url);
+        let url_path = "https://radixdlt.com";
+        let result = SUT::new(url_path.to_string());
+        assert_eq!(result.unwrap().url, Url::parse(url_path).unwrap());
     }
 
     #[test]
     fn test_from_str() {
         let result = SUT::from_str("https://radixdlt.com");
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_get_url() {
+        let url_path = "https://radixdlt.com";
+        let sut = SUT::new(url_path.to_string()).unwrap();
+        assert_eq!(ffi_url_get_url(&sut), Url::parse(url_path).unwrap());
     }
 }

--- a/src/types/ffi_url.rs
+++ b/src/types/ffi_url.rs
@@ -26,6 +26,15 @@ impl FfiUrl {
     }
 }
 
+impl FromStr for FfiUrl {
+    type Err = CommonError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let url = parse_url(s)?;
+        Self::new(url)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -38,5 +47,11 @@ mod tests {
         let url = Url::parse("https://radixdlt.com").unwrap();
         let result = SUT::new(url.clone());
         assert_eq!(result.unwrap().url, url);
+    }
+
+    #[test]
+    fn test_from_str() {
+        let result = SUT::from_str("https://radixdlt.com");
+        assert!(result.is_ok());
     }
 }

--- a/src/types/ffi_url.rs
+++ b/src/types/ffi_url.rs
@@ -1,4 +1,4 @@
-use uniffi::Lift;
+use uniffi::{Lift, RustBuffer};
 
 use crate::prelude::*;
 use crate::UniFfiTag;
@@ -14,6 +14,19 @@ impl FfiUrl {
     #[uniffi::constructor]
     pub fn parse(url_path: String) -> Result<Self> {
         let url = parse_url(url_path)?;
+        Ok(Self { url })
+    }
+}
+
+unsafe impl Lift<UniFfiTag> for FfiUrl {
+    type FfiType = RustBuffer;
+
+    fn try_lift(buf: RustBuffer) -> uniffi::Result<Self> {
+        Self::try_lift_from_rust_buffer(buf)
+    }
+
+    fn try_read(buf: &mut &[u8]) -> uniffi::Result<Self> {
+        let url = Url::try_read(buf)?;
         Ok(Self { url })
     }
 }

--- a/src/types/ffi_url.rs
+++ b/src/types/ffi_url.rs
@@ -1,7 +1,4 @@
-use uniffi::deps::bytes::Buf;
-
 use crate::prelude::*;
-use crate::UniFfiTag;
 
 /// A wrapper around `Url` that allows us to safely deal with Urls generated on hosts.
 ///

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,0 +1,3 @@
+mod uniffi_url;
+
+pub use uniffi_url::*;

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,3 +1,3 @@
-mod uniffi_url;
+mod ffi_url;
 
-pub use uniffi_url::*;
+pub use ffi_url::*;

--- a/src/types/uniffi_url.rs
+++ b/src/types/uniffi_url.rs
@@ -1,0 +1,15 @@
+use crate::prelude::*;
+
+#[derive(uniffi::Object)]
+pub struct UniFFIUrl {
+    pub url: Url,
+}
+
+#[uniffi::export]
+impl UniFFIUrl {
+    #[uniffi::constructor]
+    pub fn parse(url_path: String) -> Result<Self> {
+        let url = parse_url(url_path)?;
+        Ok(Self { url })
+    }
+}


### PR DESCRIPTION
## Description
Adds a wrapper around Rust `Url`, which has to be created on host sides. This way, if the conversion fails, the error is downcasted to host which will handle it appropiately (rather than having Rust code panic).