### PR TITLE
Bump AsyncExtensions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2602,7 +2602,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.1.13"
+version = "1.1.14"
 dependencies = [
  "actix-rt",
  "aes-gcm",

--- a/Package.swift
+++ b/Package.swift
@@ -55,7 +55,7 @@ let package = Package(
 		.package(url: "https://github.com/SwiftyJSON/SwiftyJSON", from: "5.0.2"),
 		
 		// Multicast / Share of notifications in EventBus
-		.package(url: "https://github.com/sideeffect-io/AsyncExtensions", exact: "0.5.2"),
+		.package(url: "https://github.com/sideeffect-io/AsyncExtensions", exact: "0.5.3"),
 	],
 	targets: [
 		binaryTarget,

--- a/crates/sargon/Cargo.toml
+++ b/crates/sargon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "1.1.13"
+version = "1.1.14"
 edition = "2021"
 build = "build.rs"
 


### PR DESCRIPTION
Update `AsyncExtensions` to version 0.5.3 to support Xcode 16.