### PR TITLE
Add JNA dependency to sargon-desktop-bins

### DIFF
--- a/jvm/gradle/libs.versions.toml
+++ b/jvm/gradle/libs.versions.toml
@@ -22,6 +22,8 @@ okhttp = "5.0.0-alpha.14"
 turbine = "1.1.0"
 hilt = "2.51.1"
 ksp = "1.9.22-1.0.17"
+jna = "5.13.0"
+serialization-json = "1.6.3"
 viewmodel = "2.7.0"
 androidx-test = "1.5.0"
 androidx-test-junit = "1.1.5"
@@ -44,12 +46,14 @@ androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtim
 androidx-lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "viewmodel" }
 material = { module = "com.google.android.material:material", version.ref = "material" }
 timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization-json" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 okhttp-coroutines = { module = "com.squareup.okhttp3:okhttp-coroutines", version.ref = "okhttp" }
 okhttp-mock-web-server = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp" }
 okhttp-logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
 hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hilt" }
+jna = { module = "net.java.dev.jna:jna", version.ref = "jna" }
 junit = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
 junit-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit" }
 coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }

--- a/jvm/sargon-android/build.gradle.kts
+++ b/jvm/sargon-android/build.gradle.kts
@@ -124,9 +124,7 @@ koverReport {
 }
 
 dependencies {
-    // Cannot use version catalogues for aar. For some reason when published to Maven,
-    // the jna dependency cannot be resolved
-    implementation("net.java.dev.jna:jna:5.13.0@aar")
+    implementation("${libs.jna.get()}@aar")
 
     // For lifecycle callbacks
     implementation(libs.androidx.appcompat)
@@ -138,7 +136,7 @@ dependencies {
     implementation(libs.coroutines.android)
 
     // For Serialization extensions
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
+    implementation(libs.kotlinx.serialization.json)
 
     // For Network support
     implementation(libs.okhttp)
@@ -151,7 +149,7 @@ dependencies {
     implementation(libs.timber)
 
     // Unit tests
-    testImplementation("net.java.dev.jna:jna:5.13.0")
+    testImplementation(libs.jna)
     testImplementation(libs.junit)
     testImplementation(libs.junit.params)
     testImplementation(libs.mockk)
@@ -191,6 +189,18 @@ publishing {
 
             afterEvaluate {
                 artifact(tasks.getByName("desktopJar"))
+            }
+
+            pom {
+                withXml {
+                    val dependencies = asNode().appendNode("dependencies")
+
+                    val jni = dependencies.appendNode("dependency")
+                    jni.appendNode("groupId", "net.java.dev.jna")
+                    jni.appendNode("artifactId", "jna")
+                    jni.appendNode("version", libs.versions.jna.get())
+                    jni.appendNode("scope", "runtime")
+                }
             }
         }
     }


### PR DESCRIPTION
Since there is no `sargon-desktop` module, there is no information for its dependencies. A dependency that needs to ship with sargon is the jna runtime. 

This can only be mitigated with adding a custom pom dependency for runtime jna.