### PR TITLE
Profile safe concurrent access

### DIFF
--- a/crates/sargon/src/system/sargon_os/profile_state_holder.rs
+++ b/crates/sargon/src/system/sargon_os/profile_state_holder.rs
@@ -94,10 +94,9 @@ impl ProfileStateHolder {
     where
         F: Fn(&Profile) -> T,
     {
-        let guard = self
-            .profile_state
-            .read()
-            .unwrap_or_else(|poison| poison.into_inner());
+        let guard = self.profile_state.read().expect(
+            "Stop execution due to the profile state lock being poisoned",
+        );
 
         let state = &*guard;
         match state {
@@ -113,10 +112,9 @@ impl ProfileStateHolder {
     where
         F: Fn(&Profile) -> Result<T>,
     {
-        let guard = self
-            .profile_state
-            .read()
-            .unwrap_or_else(|poison| poison.into_inner());
+        let guard = self.profile_state.read().expect(
+            "Stop execution due to the profile state lock being poisoned",
+        );
 
         let state = &*guard;
         match state {
@@ -133,10 +131,9 @@ impl ProfileStateHolder {
         &self,
         profile_state: ProfileState,
     ) -> Result<()> {
-        let mut lock = self
-            .profile_state
-            .write()
-            .unwrap_or_else(|poison| poison.into_inner());
+        let mut lock = self.profile_state.write().expect(
+            "Stop execution due to the profile state lock being poisoned",
+        );
 
         *lock = profile_state;
         Ok(())
@@ -149,10 +146,9 @@ impl ProfileStateHolder {
     where
         F: Fn(&mut Profile) -> Result<R>,
     {
-        let mut guard = self
-            .profile_state
-            .write()
-            .unwrap_or_else(|poison| poison.into_inner());
+        let mut guard = self.profile_state.write().expect(
+            "Stop execution due to the profile state lock being poisoned",
+        );
 
         let state = &mut *guard;
 

--- a/crates/sargon/src/system/sargon_os/profile_state_holder.rs
+++ b/crates/sargon/src/system/sargon_os/profile_state_holder.rs
@@ -131,10 +131,9 @@ impl ProfileStateHolder {
         &self,
         profile_state: ProfileState,
     ) -> Result<()> {
-        let mut lock = self
-            .profile_state
-            .write()
-            .unwrap_or_else(|poison| poison.into_inner());
+        let mut lock = self.profile_state.write().expect(
+            "Stop execution due to the profile state lock being poisoned",
+        );
 
         *lock = profile_state;
         Ok(())

--- a/crates/sargon/src/system/sargon_os/profile_state_holder.rs
+++ b/crates/sargon/src/system/sargon_os/profile_state_holder.rs
@@ -247,7 +247,7 @@ mod tests {
     }
 
     #[test]
-    fn test_concurrent_access_writes() {
+    fn test_concurrent_access_writes_order_is_preserved() {
         let profile = Profile::sample();
         let state = ProfileState::Loaded(profile);
         let sut = ProfileStateHolder::new(state.clone());
@@ -325,7 +325,7 @@ mod tests {
 
     #[test]
     #[should_panic]
-    fn test_concurrent_access_poisoned_lock() {
+    fn test_concurrent_access_poisoned_lock_panics() {
         let state = ProfileState::Loaded(Profile::sample());
         let sut = ProfileStateHolder::new(state.clone());
         let state_holder = Arc::new(sut);

--- a/crates/sargon/src/system/sargon_os/profile_state_holder.rs
+++ b/crates/sargon/src/system/sargon_os/profile_state_holder.rs
@@ -215,7 +215,7 @@ mod tests {
     }
 
     #[test]
-    fn test_concurent_access_read_after_write() {
+    fn test_concurrent_access_read_after_write() {
         let state = ProfileState::Loaded(Profile::sample());
         let sut = ProfileStateHolder::new(state.clone());
         let state_holder = Arc::new(sut);
@@ -251,7 +251,7 @@ mod tests {
     }
 
     #[test]
-    fn test_concurent_access_writes() {
+    fn test_concurrent_access_writes() {
         let profile = Profile::sample();
         let state = ProfileState::Loaded(profile);
         let sut = ProfileStateHolder::new(state.clone());
@@ -328,7 +328,7 @@ mod tests {
     }
 
     #[test]
-    fn test_concurent_access_poisoned_lock() {
+    fn test_concurrent_access_poisoned_lock() {
         let state = ProfileState::Loaded(Profile::sample());
         let sut = ProfileStateHolder::new(state.clone());
         let state_holder = Arc::new(sut);


### PR DESCRIPTION
Make use of [read](https://doc.rust-lang.org/stable/std/sync/struct.RwLock.html#method.read) and [write](https://doc.rust-lang.org/stable/std/sync/struct.RwLock.html#method.write) on the RWLock instead of [try_read](https://doc.rust-lang.org/stable/std/sync/struct.RwLock.html#method.try_read) and [try_write](https://doc.rust-lang.org/stable/std/sync/struct.RwLock.html#method.try_write), which assure proper concurrent read/write access to the profile_state.