### PR TITLE
New entities metadata present when no metadata exist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2617,7 +2617,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.1.24"
+version = "1.1.26"
 dependencies = [
  "actix-rt",
  "aes-gcm",

--- a/crates/sargon/Cargo.toml
+++ b/crates/sargon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "1.1.24"
+version = "1.1.26"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/sargon/src/wrapped_radix_engine_toolkit/low_level/execution_summary/new_entities.rs
+++ b/crates/sargon/src/wrapped_radix_engine_toolkit/low_level/execution_summary/new_entities.rs
@@ -23,21 +23,18 @@ impl From<(RetNewEntities, NetworkID)> for NewEntities {
     fn from(value: (RetNewEntities, NetworkID)) -> Self {
         let (ret, network_id) = value;
 
-        Self::new(
-            ret.resource_addresses.into_iter().map(|r| {
-                let resource_address = ResourceAddress::from((r, network_id));
-                let global_address =
-                    ScryptoGlobalAddress::from(resource_address);
+        Self::new(ret.resource_addresses.into_iter().map(|r| {
+            let resource_address = ResourceAddress::from((r, network_id));
+            let global_address = ScryptoGlobalAddress::from(resource_address);
 
-                let newly_created_resource = ret
-                    .metadata
-                    .get(&global_address)
-                    .map(|m| NewlyCreatedResource::from(m.clone()))
-                    .unwrap_or_default();
+            let newly_created_resource = ret
+                .metadata
+                .get(&global_address)
+                .map(|m| NewlyCreatedResource::from(m.clone()))
+                .unwrap_or_default();
 
-                (resource_address, newly_created_resource)
-            })
-        )
+            (resource_address, newly_created_resource)
+        }))
     }
 }
 

--- a/crates/sargon/src/wrapped_radix_engine_toolkit/low_level/execution_summary/new_entities.rs
+++ b/crates/sargon/src/wrapped_radix_engine_toolkit/low_level/execution_summary/new_entities.rs
@@ -24,25 +24,31 @@ impl From<(RetNewEntities, NetworkID)> for NewEntities {
         let (ret, network_id) = value;
 
         Self::new(
-            ret.resource_addresses
-                .into_iter()
-                .map(|r| {
-                    (ResourceAddress::from((r, network_id)), NewlyCreatedResource::empty())
-                })
+            ret.resource_addresses.into_iter().map(|r| {
+                let resource_address = ResourceAddress::from((r, network_id));
+                let global_address =
+                    ScryptoGlobalAddress::from(resource_address);
 
-            // We map from `IndexMap<GlobalAddress, IndexMap<String, Option<MetadataValue>>>`
-            // into: `HashMap<ResourceAddress, NewlyCreatedResource>`,
-            // and "filter out" (skip) any GlobalAddress that is not a ResourceAddress,
-            // why? Since Radix Wallets actually only use the ResourceAddress...
-            // ret.metadata
-            //     .into_iter()
-            //     .filter_map(|(k, v)| {
-            //         // We only care about `ResourceAddress`, and skip other address types.
-            //         TryInto::<ResourceAddress>::try_into((k, network_id))
-            //             .map(|a| (a, v))
-            //             .ok()
-            //     })
-            //     .map(|t| (t.0, NewlyCreatedResource::from(t.1))),
+                let newly_created_resource = ret
+                    .metadata
+                    .get(&global_address)
+                    .map(|m| NewlyCreatedResource::from(m.clone()))
+                    .unwrap_or_default();
+
+                (resource_address, newly_created_resource)
+            }), // We map from `IndexMap<GlobalAddress, IndexMap<String, Option<MetadataValue>>>`
+                // into: `HashMap<ResourceAddress, NewlyCreatedResource>`,
+                // and "filter out" (skip) any GlobalAddress that is not a ResourceAddress,
+                // why? Since Radix Wallets actually only use the ResourceAddress...
+                // ret.metadata
+                //     .into_iter()
+                //     .filter_map(|(k, v)| {
+                //         // We only care about `ResourceAddress`, and skip other address types.
+                //         TryInto::<ResourceAddress>::try_into((k, network_id))
+                //             .map(|a| (a, v))
+                //             .ok()
+                //     })
+                //     .map(|t| (t.0, NewlyCreatedResource::from(t.1))),
         )
     }
 }

--- a/crates/sargon/src/wrapped_radix_engine_toolkit/low_level/execution_summary/new_entities.rs
+++ b/crates/sargon/src/wrapped_radix_engine_toolkit/low_level/execution_summary/new_entities.rs
@@ -36,19 +36,7 @@ impl From<(RetNewEntities, NetworkID)> for NewEntities {
                     .unwrap_or_default();
 
                 (resource_address, newly_created_resource)
-            }), // We map from `IndexMap<GlobalAddress, IndexMap<String, Option<MetadataValue>>>`
-                // into: `HashMap<ResourceAddress, NewlyCreatedResource>`,
-                // and "filter out" (skip) any GlobalAddress that is not a ResourceAddress,
-                // why? Since Radix Wallets actually only use the ResourceAddress...
-                // ret.metadata
-                //     .into_iter()
-                //     .filter_map(|(k, v)| {
-                //         // We only care about `ResourceAddress`, and skip other address types.
-                //         TryInto::<ResourceAddress>::try_into((k, network_id))
-                //             .map(|a| (a, v))
-                //             .ok()
-                //     })
-                //     .map(|t| (t.0, NewlyCreatedResource::from(t.1))),
+            })
         )
     }
 }

--- a/crates/sargon/src/wrapped_radix_engine_toolkit/low_level/execution_summary/new_entities.rs
+++ b/crates/sargon/src/wrapped_radix_engine_toolkit/low_level/execution_summary/new_entities.rs
@@ -24,19 +24,25 @@ impl From<(RetNewEntities, NetworkID)> for NewEntities {
         let (ret, network_id) = value;
 
         Self::new(
+            ret.resource_addresses
+                .into_iter()
+                .map(|r| {
+                    (ResourceAddress::from((r, network_id)), NewlyCreatedResource::empty())
+                })
+
             // We map from `IndexMap<GlobalAddress, IndexMap<String, Option<MetadataValue>>>`
             // into: `HashMap<ResourceAddress, NewlyCreatedResource>`,
             // and "filter out" (skip) any GlobalAddress that is not a ResourceAddress,
             // why? Since Radix Wallets actually only use the ResourceAddress...
-            ret.metadata
-                .into_iter()
-                .filter_map(|(k, v)| {
-                    // We only care about `ResourceAddress`, and skip other address types.
-                    TryInto::<ResourceAddress>::try_into((k, network_id))
-                        .map(|a| (a, v))
-                        .ok()
-                })
-                .map(|t| (t.0, NewlyCreatedResource::from(t.1))),
+            // ret.metadata
+            //     .into_iter()
+            //     .filter_map(|(k, v)| {
+            //         // We only care about `ResourceAddress`, and skip other address types.
+            //         TryInto::<ResourceAddress>::try_into((k, network_id))
+            //             .map(|a| (a, v))
+            //             .ok()
+            //     })
+            //     .map(|t| (t.0, NewlyCreatedResource::from(t.1))),
         )
     }
 }

--- a/crates/sargon/src/wrapped_radix_engine_toolkit/low_level/transaction_manifest/execution_summary/transaction_manifest_execution_summary.rs
+++ b/crates/sargon/src/wrapped_radix_engine_toolkit/low_level/transaction_manifest/execution_summary/transaction_manifest_execution_summary.rs
@@ -307,7 +307,10 @@ mod tests {
                 [DetailedManifestClass::General],
                 FeeLocks::default(),
                 FeeSummary::new("0.1585925", "0.1210119", "0.26540755769", 0,),
-                NewEntities::new([])
+                NewEntities::new([(
+                    token_address,
+                    NewlyCreatedResource::empty()
+                )])
             )
         );
     }
@@ -392,7 +395,9 @@ mod tests {
                         "0.96845625165",
                         0,
                     ),
-                    NewEntities::new([])
+                    NewEntities::new([
+                        (non_fungible_address, NewlyCreatedResource::default())
+                    ])
                 )
             );
     }
@@ -559,7 +564,9 @@ mod tests {
                 [DetailedManifestClass::General],
                 FeeLocks::default(),
                 FeeSummary::new("0.15184175", "0.1607719", "0.33388137243", 0,),
-                NewEntities::new([])
+                NewEntities::new([
+                    (ResourceAddress::try_from_bech32("resource_tdx_2_1tkrg7uwrc9sw3tkckuxwu65euwppxa00f7aqtx5ujd0aa22gej6nm7").unwrap(), NewlyCreatedResource::default())
+                ])
             )
         );
     }


### PR DESCRIPTION
`NewEntities` field will still include newly created resource addresses even if no metadata are present. 