### PR TITLE
Git config author in release script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2617,7 +2617,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.1.26"
+version = "1.1.27"
 dependencies = [
  "actix-rt",
  "aes-gcm",

--- a/crates/sargon/Cargo.toml
+++ b/crates/sargon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "1.1.26"
+version = "1.1.27"
 edition = "2021"
 build = "build.rs"
 

--- a/scripts/ios/release.sh
+++ b/scripts/ios/release.sh
@@ -51,7 +51,7 @@ GIT_ADD_CMD="git add --force Package.swift apple/Sources/UniFFI/Sargon.swift"
 echo "🚢  Staging (potentially) changed files with: $GIT_ADD_CMD"
 eval $GIT_ADD_CMD
 
-GIT_COMMIT_CMD="git commit -m \"Release of '$NEXT_TAG' (updated Package.swift with new checksum and path to zip on Github, and maybe apple/Sources/UniFFI/Sargon.swift). This commit is not merged into main branch (and need not be).\" --no-verify"
+GIT_COMMIT_CMD="git commit --author=\"Sargon Script release.sh <sargon@github.runner>\" -m \"Release of '$NEXT_TAG' (updated Package.swift with new checksum and path to zip on Github, and maybe apple/Sources/UniFFI/Sargon.swift). This commit is not merged into main branch (and need not be).\" --no-verify"
 echo "🚢  Git commiting changes to Package.swift (and maybe Sargon.swift)"
 eval $GIT_COMMIT_CMD
 

--- a/scripts/ios/release.sh
+++ b/scripts/ios/release.sh
@@ -51,11 +51,13 @@ GIT_ADD_CMD="git add --force Package.swift apple/Sources/UniFFI/Sargon.swift"
 echo "🚢  Staging (potentially) changed files with: $GIT_ADD_CMD"
 eval $GIT_ADD_CMD
 
-GIT_COMMIT_CMD="git commit --author=\"Sargon Script release.sh <sargon@github.runner>\" -m \"Release of '$NEXT_TAG' (updated Package.swift with new checksum and path to zip on Github, and maybe apple/Sources/UniFFI/Sargon.swift). This commit is not merged into main branch (and need not be).\" --no-verify"
+GIT_AUTHOR="Sargon Script release.sh <sargon@github.runner>"
+
+GIT_COMMIT_CMD="git commit --author=$GIT_AUTHOR -m \"Release of '$NEXT_TAG' (updated Package.swift with new checksum and path to zip on Github, and maybe apple/Sources/UniFFI/Sargon.swift). This commit is not merged into main branch (and need not be).\" --no-verify"
 echo "🚢  Git commiting changes to Package.swift (and maybe Sargon.swift)"
 eval $GIT_COMMIT_CMD
 
-git tag $NEXT_TAG
+git tag --author=$GIT_AUTHOR $NEXT_TAG
 echo "🚢 🏷️ 📡 Pushing tag: $NEXT_TAG, but only tag, not commit."
 git push origin $NEXT_TAG
 


### PR DESCRIPTION
Trying to rid of the `Anka` author of our tags in our releases.

For more context see thread: https://rdxworks.slack.com/archives/C06EBEA0SGY/p1728481132742009?thread_ts=1728401660.134659&cid=C06EBEA0SGY