### PR TITLE
make unit test run un-slow again.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ build_rs_cov.profraw
 cobertura.xml
 .swiftpm/*
 default.profraw
+
+flamegraph.*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,8 @@ default-members = ["crates/sargon"]
 incremental = false
 panic = 'unwind'
 codegen-units = 1
+debug = true
+
+[profile.profiling]
+inherits = "release"
+debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ default-members = ["crates/sargon"]
 incremental = false
 panic = 'unwind'
 codegen-units = 1
-debug = true
 
 [profile.profiling]
 inherits = "release"

--- a/crates/sargon/src/types/samples/factor_source_ids_with_samples.rs
+++ b/crates/sargon/src/types/samples/factor_source_ids_with_samples.rs
@@ -18,40 +18,66 @@ pub(crate) static ALL_FACTOR_SOURCE_ID_SAMPLES: Lazy<
     ]
 });
 
+pub(crate) static MNEMONIC_BY_ID_MAP: Lazy<
+    IndexMap<FactorSourceIDFromHash, MnemonicWithPassphrase>,
+> = Lazy::new(|| {
+    IndexMap::from_iter([
+        (
+            FactorSourceIDFromHash::sample_device(),
+            MnemonicWithPassphrase::sample_device(),
+        ),
+        (
+            FactorSourceIDFromHash::sample_ledger(),
+            MnemonicWithPassphrase::sample_ledger(),
+        ),
+        (
+            FactorSourceIDFromHash::sample_ledger_other(),
+            MnemonicWithPassphrase::sample_ledger_other(),
+        ),
+        (
+            FactorSourceIDFromHash::sample_arculus(),
+            MnemonicWithPassphrase::sample_arculus(),
+        ),
+        (
+            FactorSourceIDFromHash::sample_arculus_other(),
+            MnemonicWithPassphrase::sample_arculus_other(),
+        ),
+        (
+            FactorSourceIDFromHash::sample_passphrase(),
+            MnemonicWithPassphrase::sample_passphrase(),
+        ),
+        (
+            FactorSourceIDFromHash::sample_passphrase_other(),
+            MnemonicWithPassphrase::sample_passphrase_other(),
+        ),
+        (
+            FactorSourceIDFromHash::sample_off_device(),
+            MnemonicWithPassphrase::sample_off_device(),
+        ),
+        (
+            FactorSourceIDFromHash::sample_off_device_other(),
+            MnemonicWithPassphrase::sample_off_device_other(),
+        ),
+        (
+            FactorSourceIDFromHash::sample_security_questions(),
+            MnemonicWithPassphrase::sample_security_questions(),
+        ),
+        (
+            FactorSourceIDFromHash::sample_device_other(),
+            MnemonicWithPassphrase::sample_device_other(),
+        ),
+    ])
+});
+
 impl FactorSourceIDFromHash {
     pub fn sample_at(index: usize) -> Self {
         ALL_FACTOR_SOURCE_ID_SAMPLES[index]
     }
 
     pub fn sample_associated_mnemonic(&self) -> MnemonicWithPassphrase {
-        let id = *self;
-        if id == FactorSourceIDFromHash::sample_device() {
-            MnemonicWithPassphrase::sample_device()
-        } else if id == FactorSourceIDFromHash::sample_ledger() {
-            MnemonicWithPassphrase::sample_ledger()
-        } else if id == FactorSourceIDFromHash::sample_ledger_other() {
-            MnemonicWithPassphrase::sample_ledger_other()
-        } else if id == FactorSourceIDFromHash::sample_arculus() {
-            MnemonicWithPassphrase::sample_arculus()
-        } else if id == FactorSourceIDFromHash::sample_arculus_other() {
-            MnemonicWithPassphrase::sample_arculus_other()
-        } else if id == FactorSourceIDFromHash::sample_passphrase() {
-            MnemonicWithPassphrase::sample_passphrase()
-        } else if id == FactorSourceIDFromHash::sample_passphrase_other() {
-            MnemonicWithPassphrase::sample_passphrase_other()
-        } else if id == FactorSourceIDFromHash::sample_off_device() {
-            MnemonicWithPassphrase::sample_off_device()
-        } else if id == FactorSourceIDFromHash::sample_off_device_other() {
-            MnemonicWithPassphrase::sample_off_device_other()
-        } else if id == FactorSourceIDFromHash::sample_security_questions() {
-            MnemonicWithPassphrase::sample_security_questions()
-        } else if id == FactorSourceIDFromHash::sample_device_other() {
-            MnemonicWithPassphrase::sample_device_other()
-        } else {
-            panic!(
-                "Sample mnemonic with passphrase for id {} not found",
-                id.body.to_hex()
-            )
-        }
+        MNEMONIC_BY_ID_MAP
+            .get(self)
+            .expect("Sample mnemonic with passphrase for id {} not found")
+            .clone()
     }
 }


### PR DESCRIPTION
> [!NOTE]
> Target branch is not main, rather Ghenadies UniFFI branch
> We really want this change on main too, but we expect to merge the UniFFI sep branch soon

Make unit test run in 80% faster (On my Mac Studio, now rung in 40s instead of 75 sec).

The slow test run in 1.3 sec instead of 5.3 sec.

The culprit was the manual look up in `sample_associated_mnemonic` using `if ==` comparision, instead of using a map structure.

I profiled using [`flamegraph` which is a great tool](https://github.com/flamegraph-rs/flamegraph). It is a bit hard at first to understand. It is the width of the rows which matter, **not the color** nor does any horizintal position matter. 
<img width="846" alt="Screenshot 2024-10-16 at 13 14 41" src="https://github.com/user-attachments/assets/23ea0c2b-a918-4919-82d2-ac2c3dddd4e6">

See flramegraph file - this is run before this optimization
![flamegraph](https://github.com/user-attachments/assets/f4a248fa-ee6f-4561-a051-15ba4293b6c6)

You need to boot your mac in Recovery Mode and disable SIP for `dtrace` to get flamegraph to work - follow this answer if you wanna try it yourself: https://stackoverflow.com/a/33584192

