### PR TITLE
Tombstone accounts functionality and sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3560,9 +3560,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.41.1"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
+checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1270,12 +1270,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1283,6 +1299,17 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -1304,6 +1331,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.85",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
 name = "futures-task"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1315,10 +1359,16 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -2753,6 +2803,7 @@ dependencies = [
  "derive_more 1.0.0",
  "enum-as-inner",
  "enum-iterator",
+ "futures",
  "hex 0.4.3 (git+https://github.com/KokaKiwi/rust-hex/?rev=b2b4370b5bf021b98ee7adc92233e8de3f2de792)",
  "hkdf",
  "iota-crypto",
@@ -3509,9 +3560,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.41.0"
+version = "1.41.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
+checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
 dependencies = [
  "backtrace",
  "bytes",

--- a/crates/sargon-uniffi/src/profile/v100/entity/entity_flag.rs
+++ b/crates/sargon-uniffi/src/profile/v100/entity/entity_flag.rs
@@ -10,6 +10,10 @@ pub enum EntityFlag {
     /// The entity is marked as deleted by user. Entity should still be kept in Profile
     DeletedByUser,
 
+    /// The entity is marked as tombstoned by the user. Entity should still be kept in Profile
+    /// Such an entity cannot be involved in any transaction anymore.
+    TombstonedByUser,
+
     /// Just a temporary placeholder value used by Sample Values.
     PlaceholderSampleValueFlag,
 }

--- a/crates/sargon-uniffi/src/system/drivers/event_bus_driver/support/event_profile_modified.rs
+++ b/crates/sargon-uniffi/src/system/drivers/event_bus_driver/support/event_profile_modified.rs
@@ -13,6 +13,9 @@ pub enum EventProfileModified {
     /// An existing account has been updated
     AccountUpdated { address: AccountAddress },
 
+    /// Existing accounts have been updated
+    AccountsUpdated { addresses: Vec<AccountAddress> },
+
     /// Profile updated with a new factor source.
     FactorSourceAdded { id: FactorSourceID },
 

--- a/crates/sargon-uniffi/src/system/sargon_os/mod.rs
+++ b/crates/sargon-uniffi/src/system/sargon_os/mod.rs
@@ -7,6 +7,7 @@ mod sargon_os_factors;
 mod sargon_os_gateway;
 mod sargon_os_profile;
 mod sargon_os_security_structures;
+mod sargon_os_sync_accounts;
 mod transactions;
 
 pub use profile_state_holder::*;
@@ -16,4 +17,5 @@ pub use sargon_os_factors::*;
 pub use sargon_os_gateway::*;
 pub use sargon_os_profile::*;
 pub use sargon_os_security_structures::*;
+pub use sargon_os_sync_accounts::*;
 pub use transactions::*;

--- a/crates/sargon-uniffi/src/system/sargon_os/sargon_os_accounts.rs
+++ b/crates/sargon-uniffi/src/system/sargon_os/sargon_os_accounts.rs
@@ -236,4 +236,22 @@ impl SargonOS {
             .await
             .into_result()
     }
+
+    /// Updates the profile by marking the account with `account_address` as hidden.
+    pub async fn mark_account_as_hidden(&self, account_address: AccountAddress) -> Result<()> {
+        self
+            .wrapped
+            .mark_account_as_hidden(account_address.into_internal())
+            .await
+            .into_result()
+    }
+
+    /// Updates the profile by marking the account with `account_address` as tombstoned.
+    pub async fn mark_account_as_tombstoned(&self, account_address: AccountAddress) -> Result<()> {
+        self
+            .wrapped
+            .mark_account_as_tombstoned(account_address.into_internal())
+            .await
+            .into_result()
+    }
 }

--- a/crates/sargon-uniffi/src/system/sargon_os/sargon_os_accounts.rs
+++ b/crates/sargon-uniffi/src/system/sargon_os/sargon_os_accounts.rs
@@ -238,18 +238,22 @@ impl SargonOS {
     }
 
     /// Updates the profile by marking the account with `account_address` as hidden.
-    pub async fn mark_account_as_hidden(&self, account_address: AccountAddress) -> Result<()> {
-        self
-            .wrapped
+    pub async fn mark_account_as_hidden(
+        &self,
+        account_address: AccountAddress,
+    ) -> Result<()> {
+        self.wrapped
             .mark_account_as_hidden(account_address.into_internal())
             .await
             .into_result()
     }
 
     /// Updates the profile by marking the account with `account_address` as tombstoned.
-    pub async fn mark_account_as_tombstoned(&self, account_address: AccountAddress) -> Result<()> {
-        self
-            .wrapped
+    pub async fn mark_account_as_tombstoned(
+        &self,
+        account_address: AccountAddress,
+    ) -> Result<()> {
+        self.wrapped
             .mark_account_as_tombstoned(account_address.into_internal())
             .await
             .into_result()

--- a/crates/sargon-uniffi/src/system/sargon_os/sargon_os_sync_accounts.rs
+++ b/crates/sargon-uniffi/src/system/sargon_os/sargon_os_sync_accounts.rs
@@ -1,0 +1,17 @@
+use crate::prelude::*;
+
+// ==================
+// Sync Profile Accounts with status on ledger
+// ==================
+impl SargonOS {
+    /// Checks all active accounts in current network on ledger, if any of them are deleted.
+    /// Any deleted account is marked as tombstoned in profile.
+    ///
+    /// Returns true if any account became tombstoned.
+    pub async fn sync_accounts_deleted_on_ledger(&self) -> Result<bool> {
+        self.wrapped
+            .sync_accounts_deleted_on_ledger()
+            .await
+            .into_result()
+    }
+}

--- a/crates/sargon/Cargo.toml
+++ b/crates/sargon/Cargo.toml
@@ -177,6 +177,7 @@ reqwest = { git = "https://github.com/seanmonstar/reqwest", rev = "0720159f6369f
 
 # async-std = "1.13.0"
 async-std = "1.13.0"
+futures = "0.3.31"
 
 # Fixes nasty iOS bug "_kSecMatchSubjectWholeString", see https://github.com/kornelski/rust-security-framework/issues/203
 # This is a workaround to fix a bug with version 2.11.0 that added some symbols that are not available on iOS

--- a/crates/sargon/src/gateway_api/endpoints/state_endpoints.rs
+++ b/crates/sargon/src/gateway_api/endpoints/state_endpoints.rs
@@ -48,6 +48,27 @@ impl GatewayClient {
         self.post("state/entity/page/non-fungibles/", request, res_id)
             .await
     }
+
+    pub(crate) async fn state_entity_page_non_fungible_vaults(
+        &self,
+        request: StateEntityNonFungibleResourceVaultsPageRequest,
+    ) -> Result<
+        PageResponse<
+            NonFungibleResourcesCollectionItemVaultAggregatedVaultItem,
+        >,
+    > {
+        //Result<StateEntityNonFungibleResourceVaultsPageResponse> { TODO ask
+        self.post("state/entity/page/non-fungible-vaults/", request, res_id)
+            .await
+    }
+
+    pub(crate) async fn state_entity_page_non_fungible_vaults_ids(
+        &self,
+        request: StateEntityNonFungibleIdsPageRequest,
+    ) -> Result<PageResponse<NonFungibleLocalId>> {
+        self.post("state/entity/page/non-fungible-vault/ids", request, res_id)
+            .await
+    }
 }
 
 impl GatewayClient {

--- a/crates/sargon/src/gateway_api/methods/page_methods.rs
+++ b/crates/sargon/src/gateway_api/methods/page_methods.rs
@@ -27,7 +27,8 @@ impl GatewayClient {
                 api_call(cursor.clone(), ledger_state_selector.clone()).await?;
             items.extend(response.items);
             cursor = response.next_cursor;
-            ledger_state_selector = response.ledger_state.map(Into::into);
+            ledger_state_selector =
+                Some(LedgerStateSelector::from(response.ledger_state));
             more_to_load = cursor.is_some();
         }
 

--- a/crates/sargon/src/gateway_api/models/types/request/state/entity/page/mod.rs
+++ b/crates/sargon/src/gateway_api/models/types/request/state/entity/page/mod.rs
@@ -1,5 +1,9 @@
 mod fungibles;
+mod non_fungible_vault_ids;
+mod non_fungible_vaults;
 mod non_fungibles;
 
 pub use fungibles::*;
+pub use non_fungible_vault_ids::*;
+pub use non_fungible_vaults::*;
 pub use non_fungibles::*;

--- a/crates/sargon/src/gateway_api/models/types/request/state/entity/page/non_fungible_vault_ids.rs
+++ b/crates/sargon/src/gateway_api/models/types/request/state/entity/page/non_fungible_vault_ids.rs
@@ -1,0 +1,47 @@
+use crate::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StateEntityNonFungibleIdsPageRequest {
+    /// Bech32m-encoded human readable version of the address.
+    pub(crate) address: Address,
+
+    /// Bech32m-encoded human readable version of the address.
+    pub(crate) vault_address: VaultAddress,
+
+    /// Bech32m-encoded human readable version of the address.
+    pub(crate) resource_address: ResourceAddress,
+
+    /// This allows for a request to be made against a historic state. If a constraint is specified,
+    /// the Gateway will resolve the request against the ledger state at that time.
+    /// If not specified, requests will be made with respect to the top of the committed ledger.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) at_ledger_state: Option<LedgerStateSelector>,
+
+    /// This cursor allows forward pagination, by providing the cursor from the previous request.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) cursor: Option<String>,
+
+    /// The page size requested.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) limit_per_page: Option<u64>,
+}
+
+impl StateEntityNonFungibleIdsPageRequest {
+    pub fn new(
+        address: Address,
+        vault_address: VaultAddress,
+        resource_address: ResourceAddress,
+        at_ledger_state: impl Into<Option<LedgerStateSelector>>,
+        cursor: impl Into<Option<String>>,
+        limit_per_page: impl Into<Option<u64>>,
+    ) -> StateEntityNonFungibleIdsPageRequest {
+        StateEntityNonFungibleIdsPageRequest {
+            address,
+            vault_address,
+            resource_address,
+            at_ledger_state: at_ledger_state.into(),
+            cursor: cursor.into(),
+            limit_per_page: limit_per_page.into(),
+        }
+    }
+}

--- a/crates/sargon/src/gateway_api/models/types/request/state/entity/page/non_fungible_vaults.rs
+++ b/crates/sargon/src/gateway_api/models/types/request/state/entity/page/non_fungible_vaults.rs
@@ -1,0 +1,63 @@
+use crate::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StateEntityNonFungibleResourceVaultsPageRequest {
+    /// Bech32m-encoded human readable version of the address.
+    pub(crate) address: Address,
+
+    /// Bech32m-encoded human readable version of the address.
+    pub(crate) resource_address: ResourceAddress,
+
+    /// This allows for a request to be made against a historic state. If a constraint is specified,
+    /// the Gateway will resolve the request against the ledger state at that time.
+    /// If not specified, requests will be made with respect to the top of the committed ledger.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) at_ledger_state: Option<LedgerStateSelector>,
+
+    /// This cursor allows forward pagination, by providing the cursor from the previous request.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) cursor: Option<String>,
+
+    /// The page size requested.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) limit_per_page: Option<u64>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) opt_ins: Option<StateEntityNonFungibleResourceVaultsPageOptIns>,
+}
+
+impl StateEntityNonFungibleResourceVaultsPageRequest {
+    pub fn new(
+        address: Address,
+        resource_address: ResourceAddress,
+        at_ledger_state: impl Into<Option<LedgerStateSelector>>,
+        cursor: impl Into<Option<String>>,
+        limit_per_page: impl Into<Option<u64>>,
+        opt_ins: impl Into<Option<StateEntityNonFungibleResourceVaultsPageOptIns>>,
+    ) -> StateEntityNonFungibleResourceVaultsPageRequest {
+        StateEntityNonFungibleResourceVaultsPageRequest {
+            address,
+            resource_address,
+            at_ledger_state: at_ledger_state.into(),
+            cursor: cursor.into(),
+            limit_per_page: limit_per_page.into(),
+            opt_ins: opt_ins.into(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StateEntityNonFungibleResourceVaultsPageOptIns {
+    /// if set to `true`, first page of non fungible ids are returned for each
+    /// non fungible resource, with cursor which can be later used at
+    /// `/state/entity/page/non-fungible-vault/ids` endpoint.
+    pub(crate) non_fungible_include_nfids: Option<bool>,
+}
+
+impl StateEntityNonFungibleResourceVaultsPageOptIns {
+    pub fn include() -> StateEntityNonFungibleResourceVaultsPageOptIns {
+        StateEntityNonFungibleResourceVaultsPageOptIns {
+            non_fungible_include_nfids: Some(true),
+        }
+    }
+}

--- a/crates/sargon/src/gateway_api/models/types/response/page_response.rs
+++ b/crates/sargon/src/gateway_api/models/types/response/page_response.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 
 #[derive(Deserialize, Serialize, Clone, PartialEq, Eq, Debug)]
 pub struct PageResponse<T> {
-    pub ledger_state: Option<LedgerState>,
+    pub ledger_state: LedgerState,
     pub total_count: Option<u64>,
     pub next_cursor: Option<String>,
     pub items: Vec<T>,
@@ -10,7 +10,7 @@ pub struct PageResponse<T> {
 
 impl<T> PageResponse<T> {
     pub fn new(
-        ledger_state: impl Into<Option<LedgerState>>,
+        ledger_state: impl Into<LedgerState>,
         total_count: impl Into<Option<u64>>,
         next_cursor: impl Into<Option<String>>,
         items: Vec<T>,

--- a/crates/sargon/src/gateway_api/models/types/response/state/entity/mod.rs
+++ b/crates/sargon/src/gateway_api/models/types/response/state/entity/mod.rs
@@ -1,3 +1,5 @@
 mod details;
+mod page;
 
 pub use details::*;
+pub use page::*;

--- a/crates/sargon/src/gateway_api/models/types/response/state/entity/page/mod.rs
+++ b/crates/sargon/src/gateway_api/models/types/response/state/entity/page/mod.rs
@@ -1,0 +1,5 @@
+mod non_fungible_vault_item;
+mod non_fungible_vaults;
+
+pub use non_fungible_vault_item::*;
+pub use non_fungible_vaults::*;

--- a/crates/sargon/src/gateway_api/models/types/response/state/entity/page/non_fungible_vault_item.rs
+++ b/crates/sargon/src/gateway_api/models/types/response/state/entity/page/non_fungible_vault_item.rs
@@ -1,0 +1,18 @@
+use crate::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NonFungibleResourcesCollectionItemVaultAggregatedVaultItem {
+    pub total_count: Option<u64>,
+
+    /// Bech32m-encoded human readable version of the address.
+    pub vault_address: VaultAddress,
+
+    /// The most recent state version underlying object was modified at.
+    pub last_updated_at_state_version: u64,
+
+    /// If specified, contains a cursor to query next page of the `items` collection
+    pub next_cursor: Option<String>,
+
+    /// The page of local ids in this vault.
+    pub items: Option<Vec<NonFungibleLocalId>>,
+}

--- a/crates/sargon/src/gateway_api/models/types/response/state/entity/page/non_fungible_vaults.rs
+++ b/crates/sargon/src/gateway_api/models/types/response/state/entity/page/non_fungible_vaults.rs
@@ -1,0 +1,21 @@
+use crate::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StateEntityNonFungibleResourceVaultsPageResponse {
+    pub ledger_state: Option<LedgerState>,
+
+    /// Total number of items in underlying collection, fragment of which is available in `items` collection.
+    pub total_count: Option<u64>,
+
+    /// If specified, contains a cursor to query next page of the `items` collection.
+    pub next_cursor: Option<String>,
+
+    /// Collection of fungible resources.
+    pub items: Vec<NonFungibleResourcesCollectionItemVaultAggregatedVaultItem>,
+
+    /// Bech32m-encoded human readable version of the address.
+    pub address: Address,
+
+    /// Bech32m-encoded human readable version of the address.
+    pub resource_address: ResourceAddress,
+}

--- a/crates/sargon/src/lib.rs
+++ b/crates/sargon/src/lib.rs
@@ -4,6 +4,7 @@
 #![allow(unused_imports)]
 #![allow(internal_features)]
 #![feature(iter_repeat_n)]
+#![feature(future_join)]
 
 mod core;
 mod gateway_api;
@@ -51,6 +52,7 @@ pub mod prelude {
     pub(crate) use derive_more::derive::{
         AsRef, Debug as MoreDebug, Deref, Display,
     };
+    pub(crate) use futures::future::{join_all, try_join_all};
     pub use radix_common::math::traits::CheckedMul as ScryptoCheckedMul;
     pub(crate) use std::cell::RefCell;
     pub(crate) use std::cmp::Ordering;

--- a/crates/sargon/src/profile/logic/account/account_visibility.rs
+++ b/crates/sargon/src/profile/logic/account/account_visibility.rs
@@ -1,7 +1,6 @@
 use crate::prelude::*;
 
 impl Account {
-
     /// Marks the account as hidden
     pub fn mark_as_hidden(&mut self) {
         self.flags.insert_flag(EntityFlag::DeletedByUser);

--- a/crates/sargon/src/profile/logic/account/account_visibility.rs
+++ b/crates/sargon/src/profile/logic/account/account_visibility.rs
@@ -1,0 +1,50 @@
+use crate::prelude::*;
+
+impl Account {
+
+    /// Marks the account as hidden
+    pub fn mark_as_hidden(&mut self) {
+        self.flags.insert_flag(EntityFlag::DeletedByUser);
+    }
+
+    /// Marks the account as tombstoned
+    pub fn mark_as_tombstoned(&mut self) {
+        self.flags.insert_flag(EntityFlag::TombstonedByUser);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[allow(clippy::upper_case_acronyms)]
+    type SUT = Account;
+
+    #[test]
+    fn test_mark_as_hidden_is_hidden() {
+        let mut sut = SUT::sample();
+        sut.mark_as_hidden();
+        assert!(sut.is_hidden())
+    }
+
+    #[test]
+    fn test_currently_hidden_remains_hidden() {
+        let mut sut = SUT::sample_mainnet_diana();
+        sut.mark_as_hidden();
+        assert!(sut.is_hidden())
+    }
+
+    #[test]
+    fn test_mark_as_tombstoned_is_tombstoned() {
+        let mut sut = SUT::sample();
+        sut.mark_as_tombstoned();
+        assert!(sut.is_tombstoned())
+    }
+
+    #[test]
+    fn test_currently_tombstoned_remains_tombstoned() {
+        let mut sut = SUT::sample_mainnet_sean();
+        sut.mark_as_tombstoned();
+        assert!(sut.is_tombstoned())
+    }
+}

--- a/crates/sargon/src/profile/logic/account/accounts_visibility.rs
+++ b/crates/sargon/src/profile/logic/account/accounts_visibility.rs
@@ -1,10 +1,10 @@
 use crate::prelude::*;
 
 impl Accounts {
-    pub fn non_hidden(&self) -> Self {
+    pub fn visible(&self) -> Self {
         self.clone()
             .into_iter()
-            .filter(|p| !p.is_hidden())
+            .filter(|p| !p.is_hidden() && !p.is_tombstoned())
             .collect()
     }
 }
@@ -19,17 +19,18 @@ mod tests {
     #[test]
     fn test_get_non_hidden_none_hidden() {
         let sut = SUT::sample();
-        assert_eq!(&sut.non_hidden(), &sut)
+        assert_eq!(&sut.visible(), &sut)
     }
 
     #[test]
-    fn test_get_non_hidden_one_hidden() {
+    fn test_get_visible_one_visible() {
         let values = &[
             Account::sample_mainnet_bob(),
-            Account::sample_mainnet_diana(),
+            Account::sample_mainnet_diana(), // This account is hidden
+            Account::sample_mainnet_sean(), // This account is tombstoned
         ];
         let sut = SUT::from_iter(values.clone());
 
-        assert_eq!(sut.non_hidden(), SUT::just(Account::sample_mainnet_bob()))
+        assert_eq!(sut.visible(), SUT::just(Account::sample_mainnet_bob()))
     }
 }

--- a/crates/sargon/src/profile/logic/account/accounts_visibility.rs
+++ b/crates/sargon/src/profile/logic/account/accounts_visibility.rs
@@ -27,7 +27,7 @@ mod tests {
         let values = &[
             Account::sample_mainnet_bob(),
             Account::sample_mainnet_diana(), // This account is hidden
-            Account::sample_mainnet_sean(), // This account is tombstoned
+            Account::sample_mainnet_sean(),  // This account is tombstoned
         ];
         let sut = SUT::from_iter(values.clone());
 

--- a/crates/sargon/src/profile/logic/account/mod.rs
+++ b/crates/sargon/src/profile/logic/account/mod.rs
@@ -1,12 +1,12 @@
-mod accounts_visibility;
 mod account_visibility;
+mod accounts_visibility;
 mod create_account;
 mod query_accounts;
 mod query_personas;
 mod query_security_structures;
 
-pub use accounts_visibility::*;
 pub use account_visibility::*;
+pub use accounts_visibility::*;
 pub use create_account::*;
 pub use query_accounts::*;
 pub use query_personas::*;

--- a/crates/sargon/src/profile/logic/account/mod.rs
+++ b/crates/sargon/src/profile/logic/account/mod.rs
@@ -1,10 +1,12 @@
 mod accounts_visibility;
+mod account_visibility;
 mod create_account;
 mod query_accounts;
 mod query_personas;
 mod query_security_structures;
 
 pub use accounts_visibility::*;
+pub use account_visibility::*;
 pub use create_account::*;
 pub use query_accounts::*;
 pub use query_personas::*;

--- a/crates/sargon/src/profile/logic/account/query_accounts.rs
+++ b/crates/sargon/src/profile/logic/account/query_accounts.rs
@@ -4,7 +4,7 @@ impl Profile {
     /// Returns the non-hidden accounts on the current network, empty if no accounts
     /// on the network
     pub fn accounts_on_current_network(&self) -> Result<Accounts> {
-        self.current_network().map(|n| n.accounts.non_hidden())
+        self.current_network().map(|n| n.accounts.visible())
     }
 
     /// Returns the non-hidden accounts on the current network as `AccountForDisplay`
@@ -20,7 +20,7 @@ impl Profile {
     }
 
     /// Looks up the account by account address, returns Err if the account is
-    /// unknown, will return a hidden account if queried for.
+    /// unknown, will return a hidden, or tombstoned account if queried for.
     pub fn account_by_address(
         &self,
         address: AccountAddress,

--- a/crates/sargon/src/profile/logic/profile_network/profile_network_get_entities.rs
+++ b/crates/sargon/src/profile/logic/profile_network/profile_network_get_entities.rs
@@ -6,7 +6,7 @@ impl ProfileNetwork {
     }
 
     pub fn accounts_non_hidden(&self) -> Accounts {
-        self.accounts.non_hidden()
+        self.accounts.visible()
     }
 }
 

--- a/crates/sargon/src/profile/v100/address/non_fungible_local_id.rs
+++ b/crates/sargon/src/profile/v100/address/non_fungible_local_id.rs
@@ -476,10 +476,12 @@ mod tests {
     #[test]
     fn test_derives_account_address() {
         let local_id = SUT::try_from(
-            "[51f3033e8c2b32e398fecd57bbc8ea470bd575ae3a772e42e0a90e675b47]",
+            "[511dc6eee81feec3439609a650807168995ff4bc0c04986e0f089f0bc7fc]",
         )
         .unwrap();
-        let account_address = AccountAddress::try_from_bech32("account_rdx128esx05v9view8x87e4tmhj82gu9a2adw8fmjushq4y8xwk68vgsuw0").unwrap();
+        let account_address = AccountAddress::try_from_bech32(
+            "account_tdx_2_12ywudmhgrlhvxsukpxn9pqr3dzv4la9upszfsms0pz0sh3lu6erxux"
+        ).unwrap();
 
         assert!(local_id.derives_account_address(account_address));
     }

--- a/crates/sargon/src/profile/v100/entity/account/account.rs
+++ b/crates/sargon/src/profile/v100/entity/account/account.rs
@@ -153,6 +153,7 @@ impl Account {
         index: u32,
         name: &str,
         is_hidden: bool,
+        is_tombstoned: bool,
     ) -> Self {
         let private_hd_factor_source =
             PrivateHierarchicalDeterministicFactorSource::sample();
@@ -172,40 +173,49 @@ impl Account {
         if is_hidden {
             account.flags.insert(EntityFlag::DeletedByUser);
         }
+        if is_tombstoned {
+            account.flags.insert(EntityFlag::TombstonedByUser);
+        }
         account
     }
 
-    fn sample_at_index_name(index: u32, name: &str, is_hidden: bool) -> Self {
+    fn sample_at_index_name(index: u32, name: &str, is_hidden: bool, is_tombstoned: bool) -> Self {
         Self::sample_at_index_name_network(
             NetworkID::Mainnet,
             index,
             name,
             is_hidden,
+            is_tombstoned,
         )
     }
 
     /// A `Mainnet` account named "Alice", a sample used to facilitate unit tests, with
     /// derivation index 0,
     pub fn sample_mainnet_alice() -> Self {
-        Self::sample_at_index_name(0, "Alice", false)
+        Self::sample_at_index_name(0, "Alice", false, false)
     }
 
     /// A `Mainnet` account named "Bob", a sample used to facilitate unit tests, with
     /// derivation index 1.
     pub fn sample_mainnet_bob() -> Self {
-        Self::sample_at_index_name(1, "Bob", false)
+        Self::sample_at_index_name(1, "Bob", false, false)
     }
 
     /// A `Mainnet` account named "Carol", a sample used to facilitate unit tests, with
     /// derivation index 2.
     pub fn sample_mainnet_carol() -> Self {
-        Self::sample_at_index_name(2, "Carol", false)
+        Self::sample_at_index_name(2, "Carol", false, false)
     }
 
     /// A HIDDEN `Mainnet` account named "Diana", a sample used to facilitate unit tests, with
     /// derivation index 3.
     pub fn sample_mainnet_diana() -> Self {
-        Self::sample_at_index_name(3, "Diana", true)
+        Self::sample_at_index_name(3, "Diana", true, false)
+    }
+
+    /// A tombestoned account named Sean, with derivation index 4.
+    pub fn sample_mainnet_sean() -> Self {
+        Self::sample_at_index_name(4, "Sean", false, true)
     }
 
     /// A `Mainnet` account named "Alice", a sample used to facilitate unit tests, with
@@ -241,6 +251,7 @@ impl Account {
             0,
             "Nadia",
             false,
+            false,
         )
     }
 
@@ -251,6 +262,7 @@ impl Account {
             1,
             "Olivia",
             true,
+            false,
         )
     }
 
@@ -260,6 +272,7 @@ impl Account {
             NetworkID::Stokenet,
             2,
             "Paige",
+            false,
             false,
         )
     }

--- a/crates/sargon/src/profile/v100/entity/account/account.rs
+++ b/crates/sargon/src/profile/v100/entity/account/account.rs
@@ -179,7 +179,12 @@ impl Account {
         account
     }
 
-    fn sample_at_index_name(index: u32, name: &str, is_hidden: bool, is_tombstoned: bool) -> Self {
+    fn sample_at_index_name(
+        index: u32,
+        name: &str,
+        is_hidden: bool,
+        is_tombstoned: bool,
+    ) -> Self {
         Self::sample_at_index_name_network(
             NetworkID::Mainnet,
             index,

--- a/crates/sargon/src/profile/v100/entity/entity_flag.rs
+++ b/crates/sargon/src/profile/v100/entity/entity_flag.rs
@@ -19,9 +19,13 @@ use crate::prelude::*;
 )]
 #[serde(rename_all = "camelCase")]
 pub enum EntityFlag {
-    /// The entity is marked as deleted by user. Entity should still be kept in Profile
+    /// The entity is marked as hidden by user. Entity should still be kept in Profile
+    /// The user can "unhide" the entity and continue involving it in transactions on ledger.
     DeletedByUser,
 
+    /// The entity is marked as tombstoned by the user. Entity should still be kept in Profile
+    /// Such an entity cannot be involved in any transaction anymore.
+    TombstonedByUser,
     /// Just a temporary placeholder value used by Sample Values.
     PlaceholderSampleValueFlag,
 }
@@ -55,7 +59,7 @@ mod tests {
     }
 
     #[test]
-    fn json_roundtrip() {
+    fn json_roundtrip_deleted() {
         assert_json_value_eq_after_roundtrip(
             &SUT::DeletedByUser,
             json!("deletedByUser"),
@@ -64,12 +68,23 @@ mod tests {
     }
 
     #[test]
+    fn json_roundtrip_tombstoned() {
+        assert_json_value_eq_after_roundtrip(
+            &SUT::TombstonedByUser,
+            json!("tombstonedByUser"),
+        );
+        assert_json_roundtrip(&SUT::TombstonedByUser);
+    }
+
+    #[test]
     fn display() {
         assert_eq!(format!("{}", SUT::DeletedByUser), "DeletedByUser");
+        assert_eq!(format!("{}", SUT::TombstonedByUser), "TombstonedByUser");
     }
 
     #[test]
     fn debug() {
         assert_eq!(format!("{:?}", SUT::DeletedByUser), "DeletedByUser");
+        assert_eq!(format!("{:?}", SUT::TombstonedByUser), "TombstonedByUser");
     }
 }

--- a/crates/sargon/src/profile/v100/entity/is_entity.rs
+++ b/crates/sargon/src/profile/v100/entity/is_entity.rs
@@ -11,4 +11,10 @@ pub trait IsEntity {
             .into_iter()
             .contains(&EntityFlag::DeletedByUser)
     }
+
+    fn is_tombstoned(&self) -> bool {
+        self.flags()
+            .into_iter()
+            .contains(&EntityFlag::TombstonedByUser)
+    }
 }

--- a/crates/sargon/src/system/clients/client/http_client/http_client.rs
+++ b/crates/sargon/src/system/clients/client/http_client/http_client.rs
@@ -56,9 +56,6 @@ impl HttpClient {
         U: for<'a> Deserialize<'a>,
     {
         let response = self.execute_network_request(request).await?;
-        let decoded = String::from_utf8(response.clone().bytes).unwrap();
-        println!("{}", decoded);
-
         self.model_from_response(response)
     }
 

--- a/crates/sargon/src/system/clients/client/http_client/http_client.rs
+++ b/crates/sargon/src/system/clients/client/http_client/http_client.rs
@@ -56,6 +56,9 @@ impl HttpClient {
         U: for<'a> Deserialize<'a>,
     {
         let response = self.execute_network_request(request).await?;
+        let decoded = String::from_utf8(response.clone().bytes).unwrap();
+        println!("{}", decoded);
+
         self.model_from_response(response)
     }
 

--- a/crates/sargon/src/system/drivers/event_bus_driver/support/event_profile_modified.rs
+++ b/crates/sargon/src/system/drivers/event_bus_driver/support/event_profile_modified.rs
@@ -4,43 +4,28 @@ use crate::prelude::*;
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum EventProfileModified {
     /// A new account with `address` was inserted into the active profile
-    AccountAdded {
-        address: AccountAddress,
-    },
+    AccountAdded { address: AccountAddress },
 
     /// New accounts with `addresses` were inserted into the active profile
-    AccountsAdded {
-        addresses: Vec<AccountAddress>,
-    },
+    AccountsAdded { addresses: Vec<AccountAddress> },
 
     /// An existing account has been updated
-    AccountUpdated {
-        address: AccountAddress,
-    },
+    AccountUpdated { address: AccountAddress },
 
-    AccountsUpdated {
-        addresses: Vec<AccountAddress>,
-    },
+    /// Existing accounts have been updated
+    AccountsUpdated { addresses: Vec<AccountAddress> },
 
     /// Profile updated with a new factor source.
-    FactorSourceAdded {
-        id: FactorSourceID,
-    },
+    FactorSourceAdded { id: FactorSourceID },
 
     /// Profile updated with many new factor sources.
-    FactorSourcesAdded {
-        ids: Vec<FactorSourceID>,
-    },
+    FactorSourcesAdded { ids: Vec<FactorSourceID> },
 
     /// An existing factor source has been updated
-    FactorSourceUpdated {
-        id: FactorSourceID,
-    },
+    FactorSourceUpdated { id: FactorSourceID },
 
     /// Profile updated with a new Security Structure.
-    SecurityStructureAdded {
-        id: SecurityStructureID,
-    },
+    SecurityStructureAdded { id: SecurityStructureID },
 }
 
 impl HasEventKind for EventProfileModified {

--- a/crates/sargon/src/system/drivers/event_bus_driver/support/event_profile_modified.rs
+++ b/crates/sargon/src/system/drivers/event_bus_driver/support/event_profile_modified.rs
@@ -4,27 +4,43 @@ use crate::prelude::*;
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum EventProfileModified {
     /// A new account with `address` was inserted into the active profile
-    AccountAdded { address: AccountAddress },
+    AccountAdded {
+        address: AccountAddress,
+    },
 
     /// New accounts with `addresses` were inserted into the active profile
-    AccountsAdded { addresses: Vec<AccountAddress> },
+    AccountsAdded {
+        addresses: Vec<AccountAddress>,
+    },
 
     /// An existing account has been updated
-    AccountUpdated { address: AccountAddress },
+    AccountUpdated {
+        address: AccountAddress,
+    },
 
-    AccountsUpdated { addresses: Vec<AccountAddress> },
+    AccountsUpdated {
+        addresses: Vec<AccountAddress>,
+    },
 
     /// Profile updated with a new factor source.
-    FactorSourceAdded { id: FactorSourceID },
+    FactorSourceAdded {
+        id: FactorSourceID,
+    },
 
     /// Profile updated with many new factor sources.
-    FactorSourcesAdded { ids: Vec<FactorSourceID> },
+    FactorSourcesAdded {
+        ids: Vec<FactorSourceID>,
+    },
 
     /// An existing factor source has been updated
-    FactorSourceUpdated { id: FactorSourceID },
+    FactorSourceUpdated {
+        id: FactorSourceID,
+    },
 
     /// Profile updated with a new Security Structure.
-    SecurityStructureAdded { id: SecurityStructureID },
+    SecurityStructureAdded {
+        id: SecurityStructureID,
+    },
 }
 
 impl HasEventKind for EventProfileModified {
@@ -43,6 +59,7 @@ impl HasEventKind for EventProfileModified {
             Self::SecurityStructureAdded { id: _ } => {
                 EventKind::SecurityStructureAdded
             }
+            Self::AccountsUpdated { addresses: _ } => EventKind::AccountUpdated,
         }
     }
 }

--- a/crates/sargon/src/system/drivers/event_bus_driver/support/event_profile_modified.rs
+++ b/crates/sargon/src/system/drivers/event_bus_driver/support/event_profile_modified.rs
@@ -12,6 +12,8 @@ pub enum EventProfileModified {
     /// An existing account has been updated
     AccountUpdated { address: AccountAddress },
 
+    AccountsUpdated { addresses: Vec<AccountAddress> },
+
     /// Profile updated with a new factor source.
     FactorSourceAdded { id: FactorSourceID },
 

--- a/crates/sargon/src/system/sargon_os/mod.rs
+++ b/crates/sargon/src/system/sargon_os/mod.rs
@@ -7,6 +7,7 @@ mod sargon_os_factors;
 mod sargon_os_gateway;
 mod sargon_os_profile;
 mod sargon_os_security_structures;
+mod sargon_os_sync_accounts;
 mod transactions;
 
 pub use pre_authorization::*;
@@ -17,4 +18,5 @@ pub use sargon_os_factors::*;
 pub use sargon_os_gateway::*;
 pub use sargon_os_profile::*;
 pub use sargon_os_security_structures::*;
+pub use sargon_os_sync_accounts::*;
 pub use transactions::*;

--- a/crates/sargon/src/system/sargon_os/sargon_os_sync_accounts.rs
+++ b/crates/sargon/src/system/sargon_os/sargon_os_sync_accounts.rs
@@ -1,0 +1,50 @@
+use crate::prelude::*;
+
+// ==================
+// Sync Profile Accounts with status on ledger
+// ==================
+impl SargonOS {
+    /// Checks all active accounts in current network on ledger, if any of them are deleted.
+    /// Any deleted account is marked as tombstoned in profile.
+    ///
+    /// Returns true if any account became tombstoned.
+    pub async fn sync_accounts_deleted_on_ledger(&self) -> Result<bool> {
+        let accounts = self.accounts_on_current_network()?;
+
+        let network_id = self.profile_state_holder.current_network_id()?;
+        let gateway_client = GatewayClient::new(
+            self.clients.http_client.driver.clone(),
+            network_id,
+        );
+
+        let active_account_addresses =
+            accounts.iter().map(|a| a.address).collect::<Vec<_>>();
+        let on_ledger_checks = active_account_addresses
+            .iter()
+            .map(|address| {
+                gateway_client.check_account_is_deleted(address.clone())
+            })
+            .collect_vec();
+        let account_addresses_with_deleted_status =
+            try_join_all(on_ledger_checks).await?;
+
+        let account_addresses_to_tombstone =
+            account_addresses_with_deleted_status
+                .iter()
+                .filter_map(|(account_address, is_deleted)| {
+                    if is_deleted {
+                        Some(account_address.clone())
+                    } else {
+                        None
+                    }
+                })
+                .collect_vec();
+
+        if (!account_addresses_to_tombstone.is_empty()) {
+            self.mark_accounts_as_tombstoned(account_addresses_to_tombstone)
+                .await?;
+        }
+
+        Ok(!account_addresses_to_tombstone.is_empty())
+    }
+}

--- a/crates/sargon/src/system/sargon_os/sargon_os_sync_accounts.rs
+++ b/crates/sargon/src/system/sargon_os/sargon_os_sync_accounts.rs
@@ -32,7 +32,7 @@ impl SargonOS {
             account_addresses_with_deleted_status
                 .iter()
                 .filter_map(|(account_address, is_deleted)| {
-                    if is_deleted {
+                    if *is_deleted {
                         Some(account_address.clone())
                     } else {
                         None
@@ -40,11 +40,13 @@ impl SargonOS {
                 })
                 .collect_vec();
 
-        if (!account_addresses_to_tombstone.is_empty()) {
+        let any_account_tombstoned = !account_addresses_to_tombstone.is_empty();
+
+        if any_account_tombstoned {
             self.mark_accounts_as_tombstoned(account_addresses_to_tombstone)
                 .await?;
         }
 
-        Ok(!account_addresses_to_tombstone.is_empty())
+        Ok(any_account_tombstoned)
     }
 }

--- a/crates/sargon/tests/integration/main.rs
+++ b/crates/sargon/tests/integration/main.rs
@@ -25,6 +25,22 @@ mod integration_tests {
     }
 
     #[actix_rt::test]
+    async fn test_account_deleted() {
+        let gateway_client = new_gateway_client(NetworkID::Stokenet);
+        let account_address = AccountAddress::try_from_bech32(
+            "account_tdx_2_12ywudmhgrlhvxsukpxn9pqr3dzv4la9upszfsms0pz0sh3lu6erxux"
+        ).unwrap();
+
+        assert!(
+            gateway_client
+                .check_account_is_deleted(account_address)
+                .await
+                .unwrap()
+                .1
+        )
+    }
+
+    #[actix_rt::test]
     async fn test_xrd_balance_of_account_or_zero_is_zero_for_unknown_mainnet() {
         let network_id = NetworkID::Mainnet;
         let gateway_client = new_gateway_client(network_id);


### PR DESCRIPTION
This PR allows the host to 
1. ask sargon os to tombstone an account
2. ask sargon os to sync account visibility with the status on ledger

* New flag added to `EntityFlag`
* Function that returns the accounts on current network is updated to also ignore tombstoned accounts.
* Helper methods to mark one or many accounts as tombstoned
* Sync functionality:
   1. For an account address we query its vault address on ledger that holds the `ACCOUNT_OWNER_BADGE`.
   2. If an account holds that resource badge, we need to fetch the NFTs in that vault
   3. For those NFTs if we find at least one of them referencing the account, we decide that this account is "deleted" on ledger. The badge NFT id is a byte type and the bytes derive the account address. (That way we don't need to fetch the data for that NFT)
* Since the vault request does not accept an array of account addresses, when we check against the profile we need to run the same request for all accounts. That is why join is used. 

# To be implemented:
Test the sync method. In order to do that I need to change the `MockNetworkingDriver`. It is currently implemented to expect sequential requests.

> [!note]
> The  base branch is `ABW-3926-delete-account`