### PR TITLE
[ABW-3982] Check asset deposit rules before transferring on Delete Account

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2759,7 +2759,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.1.55"
+version = "1.1.56"
 dependencies = [
  "actix-rt",
  "aes-gcm",
@@ -2814,7 +2814,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-uniffi"
-version = "1.1.55"
+version = "1.1.56"
 dependencies = [
  "actix-rt",
  "assert-json-diff",

--- a/crates/sargon-uniffi/Cargo.toml
+++ b/crates/sargon-uniffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sargon-uniffi"
 # Don't forget to update version in crates/sargon/Cargo.toml
-version = "1.1.55"
+version = "1.1.56"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/sargon-uniffi/src/core/error/common_error.rs
+++ b/crates/sargon-uniffi/src/core/error/common_error.rs
@@ -732,14 +732,11 @@ pub enum CommonError {
     #[error("Subintent has already expired")]
     SubintentExpired = 10206,
 
-    #[error("Unexpected collection item aggregation")]
-    UnexpectedCollectionItemAggregation = 10207,
-
     #[error("Unable to make {amount} transfers in one single transaction")]
-    MaxTransfersPerTransactionReached { amount: u64 } = 10208,
+    MaxTransfersPerTransactionReached { amount: u64 } = 10207,
 
     #[error("Transaction Manifest class is reserved: {class}")]
-    ReservedManifestClass { class: DetailedManifestClass } = 10209,
+    ReservedManifestClass { class: DetailedManifestClass } = 10208,
 }
 
 #[uniffi::export]

--- a/crates/sargon-uniffi/src/system/sargon_os/delete_account/mod.rs
+++ b/crates/sargon-uniffi/src/system/sargon_os/delete_account/mod.rs
@@ -1,0 +1,5 @@
+mod sargon_os_delete_account;
+mod support;
+
+pub use sargon_os_delete_account::*;
+pub use support::*;

--- a/crates/sargon-uniffi/src/system/sargon_os/delete_account/sargon_os_delete_account.rs
+++ b/crates/sargon-uniffi/src/system/sargon_os/delete_account/sargon_os_delete_account.rs
@@ -12,7 +12,7 @@ impl SargonOS {
         &self,
         account_address: AccountAddress,
         recipient_account_address: Option<AccountAddress>,
-    ) -> Result<TransactionManifest> {
+    ) -> Result<DeleteAccountResult> {
         self.wrapped
             .create_delete_account_manifest(
                 account_address.into_internal(),

--- a/crates/sargon-uniffi/src/system/sargon_os/delete_account/sargon_os_delete_account.rs
+++ b/crates/sargon-uniffi/src/system/sargon_os/delete_account/sargon_os_delete_account.rs
@@ -12,7 +12,7 @@ impl SargonOS {
         &self,
         account_address: AccountAddress,
         recipient_account_address: Option<AccountAddress>,
-    ) -> Result<CreateDeleteAccountManifestResult> {
+    ) -> Result<CreateDeleteAccountManifestOutcome> {
         self.wrapped
             .create_delete_account_manifest(
                 account_address.into_internal(),

--- a/crates/sargon-uniffi/src/system/sargon_os/delete_account/sargon_os_delete_account.rs
+++ b/crates/sargon-uniffi/src/system/sargon_os/delete_account/sargon_os_delete_account.rs
@@ -12,7 +12,7 @@ impl SargonOS {
         &self,
         account_address: AccountAddress,
         recipient_account_address: Option<AccountAddress>,
-    ) -> Result<DeleteAccountResult> {
+    ) -> Result<CreateDeleteAccountManifestResult> {
         self.wrapped
             .create_delete_account_manifest(
                 account_address.into_internal(),

--- a/crates/sargon-uniffi/src/system/sargon_os/delete_account/support/mod.rs
+++ b/crates/sargon-uniffi/src/system/sargon_os/delete_account/support/mod.rs
@@ -1,0 +1,3 @@
+mod result;
+
+pub use result::*;

--- a/crates/sargon-uniffi/src/system/sargon_os/delete_account/support/mod.rs
+++ b/crates/sargon-uniffi/src/system/sargon_os/delete_account/support/mod.rs
@@ -1,3 +1,3 @@
-mod result;
+mod outcome;
 
-pub use result::*;
+pub use outcome::*;

--- a/crates/sargon-uniffi/src/system/sargon_os/delete_account/support/outcome.rs
+++ b/crates/sargon-uniffi/src/system/sargon_os/delete_account/support/outcome.rs
@@ -1,8 +1,8 @@
 use crate::prelude::*;
-use sargon::CreateDeleteAccountManifestResult as InternalCreateDeleteAccountManifestResult;
+use sargon::CreateDeleteAccountManifestOutcome as InternalCreateDeleteAccountManifestOutcome;
 
 #[derive(Clone, PartialEq, Eq, InternalConversion, uniffi::Record)]
-pub struct CreateDeleteAccountManifestResult {
+pub struct CreateDeleteAccountManifestOutcome {
     pub manifest: TransactionManifest,
     pub non_transferable_resources: Vec<ResourceAddress>,
 }

--- a/crates/sargon-uniffi/src/system/sargon_os/delete_account/support/result.rs
+++ b/crates/sargon-uniffi/src/system/sargon_os/delete_account/support/result.rs
@@ -1,8 +1,8 @@
 use crate::prelude::*;
-use sargon::DeleteAccountResult as InternalDeleteAccountResult;
+use sargon::CreateDeleteAccountManifestResult as InternalCreateDeleteAccountManifestResult;
 
 #[derive(Clone, PartialEq, Eq, InternalConversion, uniffi::Record)]
-pub struct DeleteAccountResult {
+pub struct CreateDeleteAccountManifestResult {
     pub manifest: TransactionManifest,
     pub non_transferable_resources: Vec<ResourceAddress>,
 }

--- a/crates/sargon-uniffi/src/system/sargon_os/delete_account/support/result.rs
+++ b/crates/sargon-uniffi/src/system/sargon_os/delete_account/support/result.rs
@@ -1,0 +1,8 @@
+use crate::prelude::*;
+use sargon::DeleteAccountResult as InternalDeleteAccountResult;
+
+#[derive(Clone, PartialEq, Eq, InternalConversion, uniffi::Record)]
+pub struct DeleteAccountResult {
+    pub manifest: TransactionManifest,
+    pub non_transferable_resources: Vec<ResourceAddress>,
+}

--- a/crates/sargon-uniffi/src/system/sargon_os/mod.rs
+++ b/crates/sargon-uniffi/src/system/sargon_os/mod.rs
@@ -1,8 +1,8 @@
+mod delete_account;
 mod pre_authorization;
 mod profile_state_holder;
 mod sargon_os;
 mod sargon_os_accounts;
-mod sargon_os_delete_account;
 mod sargon_os_factors;
 mod sargon_os_gateway;
 mod sargon_os_profile;
@@ -10,6 +10,7 @@ mod sargon_os_security_structures;
 mod sargon_os_sync_accounts;
 mod transactions;
 
+pub use delete_account::*;
 pub use profile_state_holder::*;
 pub use sargon_os::*;
 pub use sargon_os_accounts::*;

--- a/crates/sargon/Cargo.toml
+++ b/crates/sargon/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sargon"
 # Don't forget to update version in crates/sargon-uniffi/Cargo.toml
-version = "1.1.55"
+version = "1.1.56"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/sargon/fixtures/models/gateway/state/response_entity_details_details__fungible_resource.json
+++ b/crates/sargon/fixtures/models/gateway/state/response_entity_details_details__fungible_resource.json
@@ -1,0 +1,347 @@
+{
+  "role_assignments": {
+    "owner": {
+      "rule": {
+        "type": "Protected",
+        "access_rule": {
+          "type": "ProofRule",
+          "proof_rule": {
+            "type": "Require",
+            "requirement": {
+              "type": "NonFungible",
+              "non_fungible": {
+                "local_id": {
+                  "id_type": "Integer",
+                  "sbor_hex": "5cc0010000000000000000",
+                  "simple_rep": "#0#"
+                },
+                "resource_address": "resource_tdx_2_1nfxxxxxxxxxxsystxnxxxxxxxxx002683325037xxxxxxxxxcss8hx"
+              }
+            }
+          }
+        }
+      },
+      "updater": "None"
+    },
+    "entries": [
+      {
+        "role_key": {
+          "module": "Main",
+          "name": "burner"
+        },
+        "assignment": {
+          "resolution": "Explicit",
+          "explicit_rule": {
+            "type": "Protected",
+            "access_rule": {
+              "type": "ProofRule",
+              "proof_rule": {
+                "type": "Require",
+                "requirement": {
+                  "type": "NonFungible",
+                  "non_fungible": {
+                    "local_id": {
+                      "id_type": "Bytes",
+                      "sbor_hex": "5cc0022068c44e9d432e71c51e2a2ac285897b372328d8b31374ff29131bc6b25b6bd070",
+                      "simple_rep": "[68c44e9d432e71c51e2a2ac285897b372328d8b31374ff29131bc6b25b6bd070]"
+                    },
+                    "resource_address": "resource_tdx_2_1nfxxxxxxxxxxglcllrxxxxxxxxx002350006550xxxxxxxxxqtcnwk"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "updater_roles": [
+          {
+            "module": "Main",
+            "name": "burner_updater"
+          }
+        ]
+      },
+      {
+        "role_key": {
+          "module": "Main",
+          "name": "minter"
+        },
+        "assignment": {
+          "resolution": "Explicit",
+          "explicit_rule": {
+            "type": "Protected",
+            "access_rule": {
+              "type": "ProofRule",
+              "proof_rule": {
+                "type": "Require",
+                "requirement": {
+                  "type": "NonFungible",
+                  "non_fungible": {
+                    "local_id": {
+                      "id_type": "Bytes",
+                      "sbor_hex": "5cc0022068c44e9d432e71c51e2a2ac285897b372328d8b31374ff29131bc6b25b6bd070",
+                      "simple_rep": "[68c44e9d432e71c51e2a2ac285897b372328d8b31374ff29131bc6b25b6bd070]"
+                    },
+                    "resource_address": "resource_tdx_2_1nfxxxxxxxxxxglcllrxxxxxxxxx002350006550xxxxxxxxxqtcnwk"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "updater_roles": [
+          {
+            "module": "Main",
+            "name": "minter_updater"
+          }
+        ]
+      },
+      {
+        "role_key": {
+          "module": "Main",
+          "name": "freezer"
+        },
+        "assignment": {
+          "resolution": "Explicit",
+          "explicit_rule": {
+            "type": "DenyAll"
+          }
+        },
+        "updater_roles": [
+          {
+            "module": "Main",
+            "name": "freezer_updater"
+          }
+        ]
+      },
+      {
+        "role_key": {
+          "module": "Main",
+          "name": "recaller"
+        },
+        "assignment": {
+          "resolution": "Explicit",
+          "explicit_rule": {
+            "type": "DenyAll"
+          }
+        },
+        "updater_roles": [
+          {
+            "module": "Main",
+            "name": "recaller_updater"
+          }
+        ]
+      },
+      {
+        "role_key": {
+          "module": "Main",
+          "name": "depositor"
+        },
+        "assignment": {
+          "resolution": "Explicit",
+          "explicit_rule": {
+            "type": "AllowAll"
+          }
+        },
+        "updater_roles": [
+          {
+            "module": "Main",
+            "name": "depositor_updater"
+          }
+        ]
+      },
+      {
+        "role_key": {
+          "module": "Main",
+          "name": "withdrawer"
+        },
+        "assignment": {
+          "resolution": "Explicit",
+          "explicit_rule": {
+            "type": "AllowAll"
+          }
+        },
+        "updater_roles": [
+          {
+            "module": "Main",
+            "name": "withdrawer_updater"
+          }
+        ]
+      },
+      {
+        "role_key": {
+          "module": "Main",
+          "name": "burner_updater"
+        },
+        "assignment": {
+          "resolution": "Explicit",
+          "explicit_rule": {
+            "type": "DenyAll"
+          }
+        },
+        "updater_roles": [
+          {
+            "module": "Main",
+            "name": "burner_updater"
+          }
+        ]
+      },
+      {
+        "role_key": {
+          "module": "Main",
+          "name": "minter_updater"
+        },
+        "assignment": {
+          "resolution": "Explicit",
+          "explicit_rule": {
+            "type": "DenyAll"
+          }
+        },
+        "updater_roles": [
+          {
+            "module": "Main",
+            "name": "minter_updater"
+          }
+        ]
+      },
+      {
+        "role_key": {
+          "module": "Main",
+          "name": "freezer_updater"
+        },
+        "assignment": {
+          "resolution": "Explicit",
+          "explicit_rule": {
+            "type": "DenyAll"
+          }
+        },
+        "updater_roles": [
+          {
+            "module": "Main",
+            "name": "freezer_updater"
+          }
+        ]
+      },
+      {
+        "role_key": {
+          "module": "Main",
+          "name": "recaller_updater"
+        },
+        "assignment": {
+          "resolution": "Explicit",
+          "explicit_rule": {
+            "type": "DenyAll"
+          }
+        },
+        "updater_roles": [
+          {
+            "module": "Main",
+            "name": "recaller_updater"
+          }
+        ]
+      },
+      {
+        "role_key": {
+          "module": "Main",
+          "name": "depositor_updater"
+        },
+        "assignment": {
+          "resolution": "Explicit",
+          "explicit_rule": {
+            "type": "DenyAll"
+          }
+        },
+        "updater_roles": [
+          {
+            "module": "Main",
+            "name": "depositor_updater"
+          }
+        ]
+      },
+      {
+        "role_key": {
+          "module": "Main",
+          "name": "withdrawer_updater"
+        },
+        "assignment": {
+          "resolution": "Explicit",
+          "explicit_rule": {
+            "type": "DenyAll"
+          }
+        },
+        "updater_roles": [
+          {
+            "module": "Main",
+            "name": "withdrawer_updater"
+          }
+        ]
+      },
+      {
+        "role_key": {
+          "module": "Metadata",
+          "name": "metadata_locker"
+        },
+        "assignment": {
+          "resolution": "Owner"
+        },
+        "updater_roles": [
+          {
+            "module": "Metadata",
+            "name": "metadata_locker_updater"
+          }
+        ]
+      },
+      {
+        "role_key": {
+          "module": "Metadata",
+          "name": "metadata_locker_updater"
+        },
+        "assignment": {
+          "resolution": "Owner"
+        },
+        "updater_roles": [
+          {
+            "module": "Metadata",
+            "name": "metadata_locker_updater"
+          }
+        ]
+      },
+      {
+        "role_key": {
+          "module": "Metadata",
+          "name": "metadata_setter"
+        },
+        "assignment": {
+          "resolution": "Owner"
+        },
+        "updater_roles": [
+          {
+            "module": "Metadata",
+            "name": "metadata_setter_updater"
+          }
+        ]
+      },
+      {
+        "role_key": {
+          "module": "Metadata",
+          "name": "metadata_setter_updater"
+        },
+        "assignment": {
+          "resolution": "Owner"
+        },
+        "updater_roles": [
+          {
+            "module": "Metadata",
+            "name": "metadata_setter_updater"
+          }
+        ]
+      }
+    ]
+  },
+  "divisibility": 18,
+  "total_supply": "1704148276154.93015940148695633",
+  "total_minted": "1704148839860.06441597855528793",
+  "total_burned": "563705.1342565770683316",
+  "native_resource_details": {
+    "kind": "Xrd"
+  },
+  "type": "FungibleResource"
+}

--- a/crates/sargon/fixtures/models/gateway/state/response_entity_details_details__non_fungible_resource.json
+++ b/crates/sargon/fixtures/models/gateway/state/response_entity_details_details__non_fungible_resource.json
@@ -1,0 +1,344 @@
+{
+  "non_fungible_id_type": "String",
+  "role_assignments": {
+    "owner": {
+      "rule": {
+        "type": "Protected",
+        "access_rule": {
+          "type": "ProofRule",
+          "proof_rule": {
+            "type": "Require",
+            "requirement": {
+              "type": "Resource",
+              "resource": "resource_tdx_2_1thwucrt37ajfknluwmj9s483qxz7cqcwlvf9xaun9wx5yxn3r8zh7v"
+            }
+          }
+        }
+      },
+      "updater": "None"
+    },
+    "entries": [
+      {
+        "role_key": {
+          "module": "Main",
+          "name": "burner"
+        },
+        "assignment": {
+          "resolution": "Owner"
+        },
+        "updater_roles": [
+          {
+            "module": "Main",
+            "name": "burner_updater"
+          }
+        ]
+      },
+      {
+        "role_key": {
+          "module": "Main",
+          "name": "minter"
+        },
+        "assignment": {
+          "resolution": "Explicit",
+          "explicit_rule": {
+            "type": "Protected",
+            "access_rule": {
+              "type": "ProofRule",
+              "proof_rule": {
+                "type": "Require",
+                "requirement": {
+                  "type": "Resource",
+                  "resource": "resource_tdx_2_1tkewy5e4cgwr6qztyum8zch85fgccfjpujkp3jx45ag9qzwev3ud49"
+                }
+              }
+            }
+          }
+        },
+        "updater_roles": [
+          {
+            "module": "Main",
+            "name": "minter_updater"
+          }
+        ]
+      },
+      {
+        "role_key": {
+          "module": "Main",
+          "name": "freezer"
+        },
+        "assignment": {
+          "resolution": "Explicit",
+          "explicit_rule": {
+            "type": "DenyAll"
+          }
+        },
+        "updater_roles": [
+          {
+            "module": "Main",
+            "name": "freezer_updater"
+          }
+        ]
+      },
+      {
+        "role_key": {
+          "module": "Main",
+          "name": "recaller"
+        },
+        "assignment": {
+          "resolution": "Owner"
+        },
+        "updater_roles": [
+          {
+            "module": "Main",
+            "name": "recaller_updater"
+          }
+        ]
+      },
+      {
+        "role_key": {
+          "module": "Main",
+          "name": "depositor"
+        },
+        "assignment": {
+          "resolution": "Explicit",
+          "explicit_rule": {
+            "type": "AllowAll"
+          }
+        },
+        "updater_roles": [
+          {
+            "module": "Main",
+            "name": "depositor_updater"
+          }
+        ]
+      },
+      {
+        "role_key": {
+          "module": "Main",
+          "name": "withdrawer"
+        },
+        "assignment": {
+          "resolution": "Explicit",
+          "explicit_rule": {
+            "type": "DenyAll"
+          }
+        },
+        "updater_roles": [
+          {
+            "module": "Main",
+            "name": "withdrawer_updater"
+          }
+        ]
+      },
+      {
+        "role_key": {
+          "module": "Main",
+          "name": "burner_updater"
+        },
+        "assignment": {
+          "resolution": "Owner"
+        },
+        "updater_roles": [
+          {
+            "module": "Main",
+            "name": "burner_updater"
+          }
+        ]
+      },
+      {
+        "role_key": {
+          "module": "Main",
+          "name": "minter_updater"
+        },
+        "assignment": {
+          "resolution": "Owner"
+        },
+        "updater_roles": [
+          {
+            "module": "Main",
+            "name": "minter_updater"
+          }
+        ]
+      },
+      {
+        "role_key": {
+          "module": "Main",
+          "name": "freezer_updater"
+        },
+        "assignment": {
+          "resolution": "Explicit",
+          "explicit_rule": {
+            "type": "DenyAll"
+          }
+        },
+        "updater_roles": [
+          {
+            "module": "Main",
+            "name": "freezer_updater"
+          }
+        ]
+      },
+      {
+        "role_key": {
+          "module": "Main",
+          "name": "recaller_updater"
+        },
+        "assignment": {
+          "resolution": "Owner"
+        },
+        "updater_roles": [
+          {
+            "module": "Main",
+            "name": "recaller_updater"
+          }
+        ]
+      },
+      {
+        "role_key": {
+          "module": "Main",
+          "name": "depositor_updater"
+        },
+        "assignment": {
+          "resolution": "Explicit",
+          "explicit_rule": {
+            "type": "DenyAll"
+          }
+        },
+        "updater_roles": [
+          {
+            "module": "Main",
+            "name": "depositor_updater"
+          }
+        ]
+      },
+      {
+        "role_key": {
+          "module": "Main",
+          "name": "withdrawer_updater"
+        },
+        "assignment": {
+          "resolution": "Owner"
+        },
+        "updater_roles": [
+          {
+            "module": "Main",
+            "name": "withdrawer_updater"
+          }
+        ]
+      },
+      {
+        "role_key": {
+          "module": "Main",
+          "name": "non_fungible_data_updater"
+        },
+        "assignment": {
+          "resolution": "Explicit",
+          "explicit_rule": {
+            "type": "Protected",
+            "access_rule": {
+              "type": "ProofRule",
+              "proof_rule": {
+                "type": "Require",
+                "requirement": {
+                  "type": "Resource",
+                  "resource": "resource_tdx_2_1tkewy5e4cgwr6qztyum8zch85fgccfjpujkp3jx45ag9qzwev3ud49"
+                }
+              }
+            }
+          }
+        },
+        "updater_roles": [
+          {
+            "module": "Main",
+            "name": "non_fungible_data_updater_updater"
+          }
+        ]
+      },
+      {
+        "role_key": {
+          "module": "Main",
+          "name": "non_fungible_data_updater_updater"
+        },
+        "assignment": {
+          "resolution": "Owner"
+        },
+        "updater_roles": [
+          {
+            "module": "Main",
+            "name": "non_fungible_data_updater_updater"
+          }
+        ]
+      },
+      {
+        "role_key": {
+          "module": "Metadata",
+          "name": "metadata_locker"
+        },
+        "assignment": {
+          "resolution": "Owner"
+        },
+        "updater_roles": [
+          {
+            "module": "Metadata",
+            "name": "metadata_locker_updater"
+          }
+        ]
+      },
+      {
+        "role_key": {
+          "module": "Metadata",
+          "name": "metadata_locker_updater"
+        },
+        "assignment": {
+          "resolution": "Owner"
+        },
+        "updater_roles": [
+          {
+            "module": "Metadata",
+            "name": "metadata_locker_updater"
+          }
+        ]
+      },
+      {
+        "role_key": {
+          "module": "Metadata",
+          "name": "metadata_setter"
+        },
+        "assignment": {
+          "resolution": "Owner"
+        },
+        "updater_roles": [
+          {
+            "module": "Metadata",
+            "name": "metadata_setter_updater"
+          }
+        ]
+      },
+      {
+        "role_key": {
+          "module": "Metadata",
+          "name": "metadata_setter_updater"
+        },
+        "assignment": {
+          "resolution": "Owner"
+        },
+        "updater_roles": [
+          {
+            "module": "Metadata",
+            "name": "metadata_setter_updater"
+          }
+        ]
+      }
+    ]
+  },
+  "total_supply": "3100",
+  "total_minted": "3100",
+  "total_burned": "0",
+  "non_fungible_data_mutable_fields": [
+    "description",
+    "key_image_url",
+    "quests_completed",
+    "quest_counter"
+  ],
+  "type": "NonFungibleResource"
+}

--- a/crates/sargon/src/core/error/common_error.rs
+++ b/crates/sargon/src/core/error/common_error.rs
@@ -729,14 +729,11 @@ pub enum CommonError {
     #[error("Subintent has already expired")]
     SubintentExpired = 10206,
 
-    #[error("Unexpected collection item aggregation")]
-    UnexpectedCollectionItemAggregation = 10207,
-
     #[error("Unable to make {amount} transfers in one single transaction")]
-    MaxTransfersPerTransactionReached { amount: u64 } = 10208,
+    MaxTransfersPerTransactionReached { amount: u64 } = 10207,
 
     #[error("Transaction Manifest class is reserved: {class}")]
-    ReservedManifestClass { class: DetailedManifestClass } = 10209,
+    ReservedManifestClass { class: DetailedManifestClass } = 10208,
 }
 
 impl CommonError {

--- a/crates/sargon/src/core/utils/constants.rs
+++ b/crates/sargon/src/core/utils/constants.rs
@@ -17,5 +17,5 @@ pub const MAX_TRANSFERS_PER_TRANSACTION: u64 = 50;
 // Max amount of non fungibles to be queried in one request.
 pub const GATEWAY_CHUNK_NON_FUNGIBLES: u64 = 100;
 
-// Max amount of addresses to be queried in one request.
-pub const GATEWAY_CHUNK_ADDRESSES: u64 = 20;
+// Max amount of addresses to be queried in one request to `/state/entity/details/`.
+pub const GATEWAY_ENTITY_DETAILS_CHUNK_ADDRESSES: u64 = 20;

--- a/crates/sargon/src/core/utils/constants.rs
+++ b/crates/sargon/src/core/utils/constants.rs
@@ -16,3 +16,6 @@ pub const MAX_TRANSFERS_PER_TRANSACTION: u64 = 50;
 
 // Max amount of non fungibles to be queried in one request.
 pub const GATEWAY_CHUNK_NON_FUNGIBLES: u64 = 100;
+
+// Max amount of addresses to be queried in one request.
+pub const GATEWAY_CHUNK_ADDRESSES: u64 = 20;

--- a/crates/sargon/src/gateway_api/methods/state_methods.rs
+++ b/crates/sargon/src/gateway_api/methods/state_methods.rs
@@ -530,6 +530,7 @@ mod fetch_all_resources_tests {
             None,
             None,
             EntityMetadataCollection::empty(),
+            None,
         );
         let response = MockNetworkingDriverResponse::new_success(
             StateEntityDetailsResponse::new(LedgerState::sample(), vec![item]),
@@ -605,6 +606,7 @@ mod fetch_all_resources_tests {
             fungible_collection,
             non_fungible_collection,
             EntityMetadataCollection::empty(),
+            None,
         );
         MockNetworkingDriverResponse::new_success(
             StateEntityDetailsResponse::new(ledger_state, vec![item]),

--- a/crates/sargon/src/gateway_api/models/logic/response/state/entity/details/state_entity_details_response_item.rs
+++ b/crates/sargon/src/gateway_api/models/logic/response/state/entity/details/state_entity_details_response_item.rs
@@ -1,3 +1,61 @@
 use crate::prelude::*;
 
-impl StateEntityDetailsResponseItem {}
+impl StateEntityDetailsResponseItem {
+    pub fn can_be_transferred(&self) -> bool {
+        let Some(details) = &self.details else {
+            return false;
+        };
+        details.can_be_transferred()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[allow(clippy::upper_case_acronyms)]
+    type SUT = StateEntityDetailsResponseItem;
+
+    #[test]
+    fn can_be_transferred() {
+        // Test case: details is None
+        let sut = SUT::new(
+            Address::sample(),
+            None,
+            None,
+            EntityMetadataCollection::empty(),
+            None,
+        );
+        assert!(!sut.can_be_transferred());
+
+        // Test case: details can be transferred
+        let details = StateEntityDetailsResponseItemDetails::FungibleResource(
+            StateEntityDetailsResponseFungibleResourceDetails::new(
+                ComponentEntityRoleAssignments::sample_allow_all(),
+            ),
+        );
+        let sut = SUT::new(
+            Address::sample(),
+            None,
+            None,
+            EntityMetadataCollection::empty(),
+            details,
+        );
+        assert!(sut.can_be_transferred());
+
+        // Test case: details cannot be transferred
+        let details = StateEntityDetailsResponseItemDetails::FungibleResource(
+            StateEntityDetailsResponseFungibleResourceDetails::new(
+                ComponentEntityRoleAssignments::sample_deny_all(),
+            ),
+        );
+        let sut = SUT::new(
+            Address::sample(),
+            None,
+            None,
+            EntityMetadataCollection::empty(),
+            details,
+        );
+        assert!(!sut.can_be_transferred());
+    }
+}

--- a/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/item.rs
+++ b/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/item.rs
@@ -12,7 +12,47 @@ pub enum StateEntityDetailsResponseItemDetails {
 }
 
 impl StateEntityDetailsResponseItemDetails {
-    pub fn role_assignments(&self) -> Option<ComponentEntityRoleAssignments> {
+    /// Returns true if the entity can be transferred.
+    ///
+    /// To determine whether an entity can be transferred, we need to check its assignments
+    /// for the ("Main", "depositor") & ("Main", "withdrawer") roles.
+    /// Once we have them, we first check if the assignments are `Explicit` or `Owner`.
+    /// - If they are `Explicit`, the entity will be transferable if both the depositor & withdrawer
+    /// have `AllowAll` rules.
+    /// - If they are `Owner`, the entity will be transferable if the owner has `AllowAll` rule.
+    pub fn can_be_transferred(&self) -> bool {
+        let Some(role_assignments) = self.role_assignments() else {
+            return false;
+        };
+        let Some(depositor) = role_assignments
+            .entries
+            .clone()
+            .into_iter()
+            .find(|entry| entry.role_key == RoleKey::main_depositor())
+        else {
+            return false;
+        };
+
+        if depositor.assignment.resolution == RoleAssignmentResolution::Owner {
+            // No need to check for withdrawer, as its `resolution` will be the same.
+            return role_assignments.owner.explicit_rule
+                == ExplicitRule::AllowAll;
+        }
+
+        let Some(withdrawer) = role_assignments
+            .entries
+            .into_iter()
+            .find(|entry| entry.role_key == RoleKey::main_withdrawer())
+        else {
+            return false;
+        };
+
+        depositor.assignment.explicit_rule == Some(ExplicitRule::AllowAll)
+            && withdrawer.assignment.explicit_rule
+                == Some(ExplicitRule::AllowAll)
+    }
+
+    fn role_assignments(&self) -> Option<ComponentEntityRoleAssignments> {
         match self {
             Self::FungibleResource(details) => {
                 Some(details.role_assignments.clone())
@@ -35,6 +75,153 @@ mod tests {
 
     #[allow(clippy::upper_case_acronyms)]
     type SUT = StateEntityDetailsResponseItemDetails;
+
+    #[test]
+    fn can_be_transferred() {
+        type Assignments = ComponentEntityRoleAssignments;
+
+        // Define a few resolution combinations
+        let explicit = ComponentEntityRoleAssignmentOwner::sample_protected();
+        let owner_allow_all =
+            ComponentEntityRoleAssignmentOwner::sample_allow_all();
+        let owner_deny_all =
+            ComponentEntityRoleAssignmentOwner::sample_deny_all();
+
+        // Define a few assignments combinations that cannot be transferred
+        // Naming will be like this: <resolution>__<assignments>
+        let explicit__empty = Assignments::new(explicit.clone(), vec![]);
+        let explicit__only_depositor = Assignments::new(
+            explicit.clone(),
+            vec![
+                ComponentEntityRoleAssignmentEntry::sample_depositor_explicit_allow_all(
+                ),
+            ],
+        );
+        let explicit__depositor_allow_withdrawer_deny = Assignments::new(explicit.clone(), vec![
+            ComponentEntityRoleAssignmentEntry::new(
+                RoleKey::main_depositor(),
+                ComponentEntityRoleAssignmentEntryAssignment::sample_explicit_allow_all(
+                ),
+            ),
+            ComponentEntityRoleAssignmentEntry::new(
+                RoleKey::main_withdrawer(),
+                ComponentEntityRoleAssignmentEntryAssignment::sample_explicit_deny_all(),
+            ),
+        ]);
+        let explicit__depositor_deny_withdrawer_allow = Assignments::new(explicit.clone(), vec![
+            ComponentEntityRoleAssignmentEntry::new(
+                RoleKey::main_depositor(),
+                ComponentEntityRoleAssignmentEntryAssignment::sample_explicit_deny_all(),
+            ),
+            ComponentEntityRoleAssignmentEntry::new(
+                RoleKey::main_withdrawer(),
+                ComponentEntityRoleAssignmentEntryAssignment::sample_explicit_allow_all(
+                ),
+            ),
+        ]);
+        let owner__deny_all =
+            Assignments::new(
+                owner_deny_all.clone(),
+                vec![
+                    ComponentEntityRoleAssignmentEntry::sample_depositor_owner_allow_all(),
+                    ComponentEntityRoleAssignmentEntry::sample_withdrawer_owner_allow_all(),
+        ],
+            );
+
+        // Define a few assignments combinations that can be transferred
+        let explicit__allow_all = Assignments::sample_allow_all();
+        let owner__allow_all =
+            Assignments::new(owner_allow_all.clone(), vec![
+                ComponentEntityRoleAssignmentEntry::sample_depositor_owner_allow_all(),
+                ComponentEntityRoleAssignmentEntry::sample_withdrawer_owner_allow_all(),
+            ]);
+
+        // Define the two outcomes
+        let cannot_be_transferred = vec![
+            explicit__empty,
+            explicit__only_depositor,
+            explicit__depositor_allow_withdrawer_deny,
+            explicit__depositor_deny_withdrawer_allow,
+            owner__deny_all,
+        ];
+        let can_be_transferred = vec![explicit__allow_all, owner__allow_all];
+
+        // Test the combinations for FungibleResource
+        for assignments in cannot_be_transferred.clone() {
+            let sut = SUT::FungibleResource(
+                StateEntityDetailsResponseFungibleResourceDetails::new(
+                    assignments.clone(),
+                ),
+            );
+            assert!(!sut.can_be_transferred());
+        }
+        for assignments in can_be_transferred.clone() {
+            let sut = SUT::FungibleResource(
+                StateEntityDetailsResponseFungibleResourceDetails::new(
+                    assignments.clone(),
+                ),
+            );
+            assert!(sut.can_be_transferred());
+        }
+
+        // Test the combinations for NonFungibleResource
+        for assignments in cannot_be_transferred.clone() {
+            let sut = SUT::NonFungibleResource(
+                StateEntityDetailsResponseNonFungibleResourceDetails::new(
+                    assignments.clone(),
+                ),
+            );
+            assert!(!sut.can_be_transferred());
+        }
+        for assignments in can_be_transferred.clone() {
+            let sut = SUT::NonFungibleResource(
+                StateEntityDetailsResponseNonFungibleResourceDetails::new(
+                    assignments.clone(),
+                ),
+            );
+            assert!(sut.can_be_transferred());
+        }
+
+        // Test the combinations for Package
+        for assignments in cannot_be_transferred.clone() {
+            let sut =
+                SUT::Package(StateEntityDetailsResponsePackageDetails::new(
+                    assignments.clone(),
+                ));
+            assert!(!sut.can_be_transferred());
+        }
+        for assignments in can_be_transferred.clone() {
+            let sut =
+                SUT::Package(StateEntityDetailsResponsePackageDetails::new(
+                    assignments.clone(),
+                ));
+            assert!(sut.can_be_transferred());
+        }
+
+        // Test the combinations for Component
+        for assignments in cannot_be_transferred.clone() {
+            let sut = SUT::Component(
+                StateEntityDetailsResponseComponentDetails::new(
+                    assignments.clone(),
+                ),
+            );
+            assert!(!sut.can_be_transferred());
+        }
+        for assignments in can_be_transferred.clone() {
+            let sut = SUT::Component(
+                StateEntityDetailsResponseComponentDetails::new(
+                    assignments.clone(),
+                ),
+            );
+            assert!(sut.can_be_transferred());
+        }
+
+        // Test for FungibleVault & NonFungibleVault
+        let sut = SUT::FungibleVault;
+        assert!(!sut.can_be_transferred());
+        let sut = SUT::NonFungibleVault;
+        assert!(!sut.can_be_transferred());
+    }
 
     #[test]
     fn json() {

--- a/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/item.rs
+++ b/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/item.rs
@@ -46,9 +46,15 @@ impl StateEntityDetailsResponseItemDetails {
             return false;
         };
 
-        depositor.assignment.explicit_rule == Some(ExplicitRule::AllowAll)
-            && withdrawer.assignment.explicit_rule
-                == Some(ExplicitRule::AllowAll)
+        let allows_all =
+            |role_assignment: &ComponentEntityRoleAssignmentEntry| {
+                role_assignment.assignment.explicit_rule
+                    == Some(ExplicitRule::AllowAll)
+            };
+        let depositor_allows_all = allows_all(&depositor);
+        let withdrawer_allows_all = allows_all(&withdrawer);
+        // Both depositor and withdrawer must allow
+        depositor_allows_all && withdrawer_allows_all
     }
 
     fn role_assignments(&self) -> Option<ComponentEntityRoleAssignments> {
@@ -70,7 +76,6 @@ impl StateEntityDetailsResponseItemDetails {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::prelude::*;
 
     #[allow(clippy::upper_case_acronyms)]
     type SUT = StateEntityDetailsResponseItemDetails;
@@ -89,15 +94,15 @@ mod tests {
 
         // Define a few assignments combinations that cannot be transferred
         // Naming will be like this: <resolution>__<assignments>
-        let explicit__empty = Assignments::new(explicit.clone(), vec![]);
+        let explicit__empty = Assignments::new(explicit.clone(), []);
         let explicit__only_depositor = Assignments::new(
             explicit.clone(),
-            vec![
+            [
                 ComponentEntityRoleAssignmentEntry::sample_depositor_explicit_allow_all(
                 ),
             ],
         );
-        let explicit__depositor_allow_withdrawer_deny = Assignments::new(explicit.clone(), vec![
+        let explicit__depositor_allow_withdrawer_deny = Assignments::new(explicit.clone(), [
             ComponentEntityRoleAssignmentEntry::new(
                 RoleKey::main_depositor(),
                 ComponentEntityRoleAssignmentEntryAssignment::sample_explicit_allow_all(
@@ -108,7 +113,7 @@ mod tests {
                 ComponentEntityRoleAssignmentEntryAssignment::sample_explicit_deny_all(),
             ),
         ]);
-        let explicit__depositor_deny_withdrawer_allow = Assignments::new(explicit.clone(), vec![
+        let explicit__depositor_deny_withdrawer_allow = Assignments::new(explicit.clone(), [
             ComponentEntityRoleAssignmentEntry::new(
                 RoleKey::main_depositor(),
                 ComponentEntityRoleAssignmentEntryAssignment::sample_explicit_deny_all(),
@@ -122,7 +127,7 @@ mod tests {
         let owner__deny_all =
             Assignments::new(
                 owner_deny_all.clone(),
-                vec![
+                [
                     ComponentEntityRoleAssignmentEntry::sample_depositor_owner_allow_all(),
                     ComponentEntityRoleAssignmentEntry::sample_withdrawer_owner_allow_all(),
         ],
@@ -131,7 +136,7 @@ mod tests {
         // Define a few assignments combinations that can be transferred
         let explicit__allow_all = Assignments::sample_allow_all();
         let owner__allow_all =
-            Assignments::new(owner_allow_all.clone(), vec![
+            Assignments::new(owner_allow_all.clone(), [
                 ComponentEntityRoleAssignmentEntry::sample_depositor_owner_allow_all(),
                 ComponentEntityRoleAssignmentEntry::sample_withdrawer_owner_allow_all(),
             ]);

--- a/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/item.rs
+++ b/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/item.rs
@@ -35,8 +35,7 @@ impl StateEntityDetailsResponseItemDetails {
 
         if depositor.assignment.resolution == RoleAssignmentResolution::Owner {
             // No need to check for withdrawer, as its `resolution` will be the same.
-            return role_assignments.owner.explicit_rule
-                == ExplicitRule::AllowAll;
+            return role_assignments.owner.rule == ExplicitRule::AllowAll;
         }
 
         let Some(withdrawer) = role_assignments
@@ -77,6 +76,7 @@ mod tests {
     type SUT = StateEntityDetailsResponseItemDetails;
 
     #[test]
+    #[allow(non_snake_case)]
     fn can_be_transferred() {
         type Assignments = ComponentEntityRoleAssignments;
 
@@ -228,58 +228,24 @@ mod tests {
         // Note: we aren't using `assert_eq_after_json_roundtrip` to verify the roundtrip because there
         // are multiple fields that we aren't parsing, so we can't compare the entire struct.
 
-        let sut = SUT::FungibleResource(
-            StateEntityDetailsResponseFungibleResourceDetails::new(
-                ComponentEntityRoleAssignments::sample_allow_all(),
-            ),
-        );
-        let json = r#"
-{
-  "type": "FungibleResource",
-  "role_assignments": {
-    "entries": [
-      {
-        "role_key": {
-          "module": "Main",
-          "name": "depositor"
-        },
-        "assignment": {
-          "resolution": "Explicit",
-          "explicit_rule": {
-            "type": "AllowAll"
-          }
-        },
-        "updater_roles": [
-          {
-            "module": "Main",
-            "name": "depositor_updater"
-          }
-        ]
-      },
-      {
-        "role_key": {
-          "module": "Main",
-          "name": "withdrawer"
-        },
-        "assignment": {
-          "resolution": "Explicit",
-          "explicit_rule": {
-            "type": "AllowAll"
-          }
-        },
-        "updater_roles": [
-          {
-            "module": "Main",
-            "name": "withdrawer_updater"
-          }
-        ]
-      }
-    ]
-  }
-}
-        "#;
+        // Fungible Resource (XRD)
+        let result = fixture_and_json::<SUT>(include_str!(concat!(
+            env!("FIXTURES_MODELS_GW"),
+            "state/response_entity_details_details__fungible_resource.json"
+        )))
+        .unwrap()
+        .0;
 
-        let result: SUT = serde_json::from_str(json).unwrap();
-        assert_eq!(result, sut);
+        assert!(matches!(result, SUT::FungibleResource(_)));
+
+        // Non-Fungible Resource (XRD)
+        let result = fixture_and_json::<SUT>(include_str!(concat!(
+            env!("FIXTURES_MODELS_GW"),
+            "state/response_entity_details_details__non_fungible_resource.json"
+        )))
+        .unwrap()
+        .0;
+
+        assert!(matches!(result, SUT::NonFungibleResource(_)));
     }
 }

--- a/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/item.rs
+++ b/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/item.rs
@@ -1,0 +1,98 @@
+use crate::prelude::*;
+
+#[derive(Deserialize, Serialize, Clone, PartialEq, Eq, Debug, EnumAsInner)]
+#[serde(tag = "type")]
+pub enum StateEntityDetailsResponseItemDetails {
+    FungibleResource(StateEntityDetailsResponseFungibleResourceDetails),
+    NonFungibleResource(StateEntityDetailsResponseNonFungibleResourceDetails),
+    FungibleVault,
+    NonFungibleVault,
+    Package(StateEntityDetailsResponsePackageDetails),
+    Component(StateEntityDetailsResponseComponentDetails),
+}
+
+impl StateEntityDetailsResponseItemDetails {
+    pub fn role_assignments(&self) -> Option<ComponentEntityRoleAssignments> {
+        match self {
+            Self::FungibleResource(details) => {
+                Some(details.role_assignments.clone())
+            }
+            Self::NonFungibleResource(details) => {
+                Some(details.role_assignments.clone())
+            }
+            Self::FungibleVault => None,
+            Self::NonFungibleVault => None,
+            Self::Package(details) => details.role_assignments.clone(),
+            Self::Component(details) => details.role_assignments.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::prelude::*;
+
+    #[allow(clippy::upper_case_acronyms)]
+    type SUT = StateEntityDetailsResponseItemDetails;
+
+    #[test]
+    fn json() {
+        // Note: we aren't using `assert_eq_after_json_roundtrip` to verify the roundtrip because there
+        // are multiple fields that we aren't parsing, so we can't compare the entire struct.
+
+        let sut = SUT::FungibleResource(
+            StateEntityDetailsResponseFungibleResourceDetails::new(
+                ComponentEntityRoleAssignments::sample_allow_all(),
+            ),
+        );
+        let json = r#"
+{
+  "type": "FungibleResource",
+  "role_assignments": {
+    "entries": [
+      {
+        "role_key": {
+          "module": "Main",
+          "name": "depositor"
+        },
+        "assignment": {
+          "resolution": "Explicit",
+          "explicit_rule": {
+            "type": "AllowAll"
+          }
+        },
+        "updater_roles": [
+          {
+            "module": "Main",
+            "name": "depositor_updater"
+          }
+        ]
+      },
+      {
+        "role_key": {
+          "module": "Main",
+          "name": "withdrawer"
+        },
+        "assignment": {
+          "resolution": "Explicit",
+          "explicit_rule": {
+            "type": "AllowAll"
+          }
+        },
+        "updater_roles": [
+          {
+            "module": "Main",
+            "name": "withdrawer_updater"
+          }
+        ]
+      }
+    ]
+  }
+}
+        "#;
+
+        let result: SUT = serde_json::from_str(json).unwrap();
+        assert_eq!(result, sut);
+    }
+}

--- a/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/item_component.rs
+++ b/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/item_component.rs
@@ -1,0 +1,16 @@
+use crate::prelude::*;
+
+#[derive(Deserialize, Serialize, Clone, PartialEq, Eq, Debug)]
+pub struct StateEntityDetailsResponseComponentDetails {
+    pub role_assignments: Option<ComponentEntityRoleAssignments>,
+}
+
+impl StateEntityDetailsResponseComponentDetails {
+    pub fn new(
+        role_assignments: impl Into<Option<ComponentEntityRoleAssignments>>,
+    ) -> Self {
+        Self {
+            role_assignments: role_assignments.into(),
+        }
+    }
+}

--- a/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/item_fungible_resource.rs
+++ b/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/item_fungible_resource.rs
@@ -1,0 +1,12 @@
+use crate::prelude::*;
+
+#[derive(Deserialize, Serialize, Clone, PartialEq, Eq, Debug)]
+pub struct StateEntityDetailsResponseFungibleResourceDetails {
+    pub role_assignments: ComponentEntityRoleAssignments,
+}
+
+impl StateEntityDetailsResponseFungibleResourceDetails {
+    pub fn new(role_assignments: ComponentEntityRoleAssignments) -> Self {
+        Self { role_assignments }
+    }
+}

--- a/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/item_non_fungible_resource.rs
+++ b/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/item_non_fungible_resource.rs
@@ -1,0 +1,12 @@
+use crate::prelude::*;
+
+#[derive(Deserialize, Serialize, Clone, PartialEq, Eq, Debug)]
+pub struct StateEntityDetailsResponseNonFungibleResourceDetails {
+    pub role_assignments: ComponentEntityRoleAssignments,
+}
+
+impl StateEntityDetailsResponseNonFungibleResourceDetails {
+    pub fn new(role_assignments: ComponentEntityRoleAssignments) -> Self {
+        Self { role_assignments }
+    }
+}

--- a/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/item_package.rs
+++ b/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/item_package.rs
@@ -1,0 +1,16 @@
+use crate::prelude::*;
+
+#[derive(Deserialize, Serialize, Clone, PartialEq, Eq, Debug)]
+pub struct StateEntityDetailsResponsePackageDetails {
+    pub role_assignments: Option<ComponentEntityRoleAssignments>,
+}
+
+impl StateEntityDetailsResponsePackageDetails {
+    pub fn new(
+        role_assignments: impl Into<Option<ComponentEntityRoleAssignments>>,
+    ) -> Self {
+        Self {
+            role_assignments: role_assignments.into(),
+        }
+    }
+}

--- a/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/mod.rs
+++ b/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/mod.rs
@@ -1,0 +1,13 @@
+mod item;
+mod item_component;
+mod item_fungible_resource;
+mod item_non_fungible_resource;
+mod item_package;
+pub mod role_assignments;
+
+pub use item::*;
+pub use item_component::*;
+pub use item_fungible_resource::*;
+pub use item_non_fungible_resource::*;
+pub use item_package::*;
+pub use role_assignments::*;

--- a/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/role_assignments/assignment.rs
+++ b/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/role_assignments/assignment.rs
@@ -1,0 +1,34 @@
+use crate::prelude::*;
+
+#[derive(Deserialize, Serialize, Clone, PartialEq, Eq, Debug)]
+pub struct ComponentEntityRoleAssignmentEntryAssignment {
+    pub explicit_rule: Option<ExplicitRule>,
+}
+
+impl ComponentEntityRoleAssignmentEntryAssignment {
+    pub fn new(explicit_rule: impl Into<Option<ExplicitRule>>) -> Self {
+        Self {
+            explicit_rule: explicit_rule.into(),
+        }
+    }
+}
+
+impl HasSampleValues for ComponentEntityRoleAssignmentEntryAssignment {
+    fn sample() -> Self {
+        Self::sample_allow_all()
+    }
+
+    fn sample_other() -> Self {
+        Self::sample_deny_all()
+    }
+}
+
+impl ComponentEntityRoleAssignmentEntryAssignment {
+    pub fn sample_allow_all() -> Self {
+        Self::new(ExplicitRule::AllowAll)
+    }
+
+    pub fn sample_deny_all() -> Self {
+        Self::new(ExplicitRule::DenyAll)
+    }
+}

--- a/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/role_assignments/assignment.rs
+++ b/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/role_assignments/assignment.rs
@@ -40,8 +40,4 @@ impl ComponentEntityRoleAssignmentEntryAssignment {
     pub fn sample_owner_allow_all() -> Self {
         Self::new(RoleAssignmentResolution::Owner, ExplicitRule::AllowAll)
     }
-
-    pub fn sample_owner_deny_all() -> Self {
-        Self::new(RoleAssignmentResolution::Owner, ExplicitRule::DenyAll)
-    }
 }

--- a/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/role_assignments/assignment.rs
+++ b/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/role_assignments/assignment.rs
@@ -41,3 +41,22 @@ impl ComponentEntityRoleAssignmentEntryAssignment {
         Self::new(RoleAssignmentResolution::Owner, ExplicitRule::AllowAll)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[allow(clippy::upper_case_acronyms)]
+    type SUT = ComponentEntityRoleAssignmentEntryAssignment;
+
+    #[test]
+    fn equality() {
+        assert_eq!(SUT::sample(), SUT::sample());
+        assert_eq!(SUT::sample_other(), SUT::sample_other());
+    }
+
+    #[test]
+    fn inequality() {
+        assert_ne!(SUT::sample(), SUT::sample_other());
+    }
+}

--- a/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/role_assignments/assignment.rs
+++ b/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/role_assignments/assignment.rs
@@ -2,12 +2,17 @@ use crate::prelude::*;
 
 #[derive(Deserialize, Serialize, Clone, PartialEq, Eq, Debug)]
 pub struct ComponentEntityRoleAssignmentEntryAssignment {
+    pub resolution: RoleAssignmentResolution,
     pub explicit_rule: Option<ExplicitRule>,
 }
 
 impl ComponentEntityRoleAssignmentEntryAssignment {
-    pub fn new(explicit_rule: impl Into<Option<ExplicitRule>>) -> Self {
+    pub fn new(
+        resolution: RoleAssignmentResolution,
+        explicit_rule: impl Into<Option<ExplicitRule>>,
+    ) -> Self {
         Self {
+            resolution,
             explicit_rule: explicit_rule.into(),
         }
     }
@@ -15,20 +20,28 @@ impl ComponentEntityRoleAssignmentEntryAssignment {
 
 impl HasSampleValues for ComponentEntityRoleAssignmentEntryAssignment {
     fn sample() -> Self {
-        Self::sample_allow_all()
+        Self::sample_explicit_allow_all()
     }
 
     fn sample_other() -> Self {
-        Self::sample_deny_all()
+        Self::sample_explicit_deny_all()
     }
 }
 
 impl ComponentEntityRoleAssignmentEntryAssignment {
-    pub fn sample_allow_all() -> Self {
-        Self::new(ExplicitRule::AllowAll)
+    pub fn sample_explicit_allow_all() -> Self {
+        Self::new(RoleAssignmentResolution::Explicit, ExplicitRule::AllowAll)
     }
 
-    pub fn sample_deny_all() -> Self {
-        Self::new(ExplicitRule::DenyAll)
+    pub fn sample_explicit_deny_all() -> Self {
+        Self::new(RoleAssignmentResolution::Explicit, ExplicitRule::DenyAll)
+    }
+
+    pub fn sample_owner_allow_all() -> Self {
+        Self::new(RoleAssignmentResolution::Owner, ExplicitRule::AllowAll)
+    }
+
+    pub fn sample_owner_deny_all() -> Self {
+        Self::new(RoleAssignmentResolution::Owner, ExplicitRule::DenyAll)
     }
 }

--- a/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/role_assignments/collection.rs
+++ b/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/role_assignments/collection.rs
@@ -1,0 +1,38 @@
+use crate::prelude::*;
+
+#[derive(Deserialize, Serialize, Clone, PartialEq, Eq, Debug)]
+pub struct ComponentEntityRoleAssignments {
+    pub entries: Vec<ComponentEntityRoleAssignmentEntry>,
+}
+
+impl ComponentEntityRoleAssignments {
+    pub fn new(entries: Vec<ComponentEntityRoleAssignmentEntry>) -> Self {
+        Self { entries }
+    }
+}
+
+impl HasSampleValues for ComponentEntityRoleAssignments {
+    fn sample() -> Self {
+        Self::sample_allow_all()
+    }
+
+    fn sample_other() -> Self {
+        Self::sample_deny_all()
+    }
+}
+
+impl ComponentEntityRoleAssignments {
+    pub fn sample_allow_all() -> Self {
+        Self::new(vec![
+            ComponentEntityRoleAssignmentEntry::sample_depositor_allow_all(),
+            ComponentEntityRoleAssignmentEntry::sample_withdrawer_allow_all(),
+        ])
+    }
+
+    pub fn sample_deny_all() -> Self {
+        Self::new(vec![
+            ComponentEntityRoleAssignmentEntry::sample_depositor_deny_all(),
+            ComponentEntityRoleAssignmentEntry::sample_withdrawer_deny_all(),
+        ])
+    }
+}

--- a/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/role_assignments/collection.rs
+++ b/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/role_assignments/collection.rs
@@ -2,12 +2,16 @@ use crate::prelude::*;
 
 #[derive(Deserialize, Serialize, Clone, PartialEq, Eq, Debug)]
 pub struct ComponentEntityRoleAssignments {
+    pub owner: ComponentEntityRoleAssignmentOwner,
     pub entries: Vec<ComponentEntityRoleAssignmentEntry>,
 }
 
 impl ComponentEntityRoleAssignments {
-    pub fn new(entries: Vec<ComponentEntityRoleAssignmentEntry>) -> Self {
-        Self { entries }
+    pub fn new(
+        owner: ComponentEntityRoleAssignmentOwner,
+        entries: Vec<ComponentEntityRoleAssignmentEntry>,
+    ) -> Self {
+        Self { owner, entries }
     }
 }
 
@@ -23,16 +27,25 @@ impl HasSampleValues for ComponentEntityRoleAssignments {
 
 impl ComponentEntityRoleAssignments {
     pub fn sample_allow_all() -> Self {
-        Self::new(vec![
-            ComponentEntityRoleAssignmentEntry::sample_depositor_allow_all(),
-            ComponentEntityRoleAssignmentEntry::sample_withdrawer_allow_all(),
-        ])
+        Self::new(
+            ComponentEntityRoleAssignmentOwner::sample_protected(),
+            vec![
+                ComponentEntityRoleAssignmentEntry::sample_depositor_explicit_allow_all(
+                ),
+                ComponentEntityRoleAssignmentEntry::sample_withdrawer_explicit_allow_all(
+                ),
+            ],
+        )
     }
 
     pub fn sample_deny_all() -> Self {
-        Self::new(vec![
-            ComponentEntityRoleAssignmentEntry::sample_depositor_deny_all(),
-            ComponentEntityRoleAssignmentEntry::sample_withdrawer_deny_all(),
-        ])
+        Self::new(
+            ComponentEntityRoleAssignmentOwner::sample_protected(),
+            vec![
+                ComponentEntityRoleAssignmentEntry::sample_depositor_explicit_deny_all(),
+                ComponentEntityRoleAssignmentEntry::sample_withdrawer_explicit_deny_all(
+                ),
+            ],
+        )
     }
 }

--- a/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/role_assignments/collection.rs
+++ b/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/role_assignments/collection.rs
@@ -9,9 +9,12 @@ pub struct ComponentEntityRoleAssignments {
 impl ComponentEntityRoleAssignments {
     pub fn new(
         owner: ComponentEntityRoleAssignmentOwner,
-        entries: Vec<ComponentEntityRoleAssignmentEntry>,
+        entries: impl IntoIterator<Item = ComponentEntityRoleAssignmentEntry>,
     ) -> Self {
-        Self { owner, entries }
+        Self {
+            owner,
+            entries: Vec::from_iter(entries),
+        }
     }
 }
 
@@ -29,7 +32,7 @@ impl ComponentEntityRoleAssignments {
     pub fn sample_allow_all() -> Self {
         Self::new(
             ComponentEntityRoleAssignmentOwner::sample_protected(),
-            vec![
+            [
                 ComponentEntityRoleAssignmentEntry::sample_depositor_explicit_allow_all(
                 ),
                 ComponentEntityRoleAssignmentEntry::sample_withdrawer_explicit_allow_all(
@@ -41,7 +44,7 @@ impl ComponentEntityRoleAssignments {
     pub fn sample_deny_all() -> Self {
         Self::new(
             ComponentEntityRoleAssignmentOwner::sample_protected(),
-            vec![
+            [
                 ComponentEntityRoleAssignmentEntry::sample_depositor_explicit_deny_all(),
                 ComponentEntityRoleAssignmentEntry::sample_withdrawer_explicit_deny_all(
                 ),

--- a/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/role_assignments/entry.rs
+++ b/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/role_assignments/entry.rs
@@ -1,0 +1,59 @@
+use crate::prelude::*;
+
+#[derive(Deserialize, Serialize, Clone, PartialEq, Eq, Debug)]
+pub struct ComponentEntityRoleAssignmentEntry {
+    pub role_key: RoleKey,
+    pub assignment: ComponentEntityRoleAssignmentEntryAssignment,
+}
+
+impl ComponentEntityRoleAssignmentEntry {
+    pub fn new(
+        role_key: RoleKey,
+        assignment: ComponentEntityRoleAssignmentEntryAssignment,
+    ) -> Self {
+        Self {
+            role_key,
+            assignment,
+        }
+    }
+}
+
+impl HasSampleValues for ComponentEntityRoleAssignmentEntry {
+    fn sample() -> Self {
+        Self::sample_depositor_allow_all()
+    }
+
+    fn sample_other() -> Self {
+        Self::sample_withdrawer_deny_all()
+    }
+}
+
+impl ComponentEntityRoleAssignmentEntry {
+    pub fn sample_depositor_allow_all() -> Self {
+        Self::new(
+            RoleKey::sample_depositor(),
+            ComponentEntityRoleAssignmentEntryAssignment::sample_allow_all(),
+        )
+    }
+
+    pub fn sample_depositor_deny_all() -> Self {
+        Self::new(
+            RoleKey::sample_depositor(),
+            ComponentEntityRoleAssignmentEntryAssignment::sample_deny_all(),
+        )
+    }
+
+    pub fn sample_withdrawer_allow_all() -> Self {
+        Self::new(
+            RoleKey::sample_withdrawer(),
+            ComponentEntityRoleAssignmentEntryAssignment::sample_allow_all(),
+        )
+    }
+
+    pub fn sample_withdrawer_deny_all() -> Self {
+        Self::new(
+            RoleKey::sample_withdrawer(),
+            ComponentEntityRoleAssignmentEntryAssignment::sample_deny_all(),
+        )
+    }
+}

--- a/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/role_assignments/entry.rs
+++ b/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/role_assignments/entry.rs
@@ -70,20 +70,4 @@ impl ComponentEntityRoleAssignmentEntry {
             ComponentEntityRoleAssignmentEntryAssignment::sample_owner_allow_all(),
         )
     }
-
-    pub fn sample_depositor_owner_deny_all() -> Self {
-        Self::new(
-            RoleKey::main_depositor(),
-            ComponentEntityRoleAssignmentEntryAssignment::sample_owner_deny_all(
-            ),
-        )
-    }
-
-    pub fn sample_withdrawer_owner_deny_all() -> Self {
-        Self::new(
-            RoleKey::main_withdrawer(),
-            ComponentEntityRoleAssignmentEntryAssignment::sample_owner_deny_all(
-            ),
-        )
-    }
 }

--- a/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/role_assignments/entry.rs
+++ b/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/role_assignments/entry.rs
@@ -71,3 +71,22 @@ impl ComponentEntityRoleAssignmentEntry {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[allow(clippy::upper_case_acronyms)]
+    type SUT = ComponentEntityRoleAssignmentEntry;
+
+    #[test]
+    fn equality() {
+        assert_eq!(SUT::sample(), SUT::sample());
+        assert_eq!(SUT::sample_other(), SUT::sample_other());
+    }
+
+    #[test]
+    fn inequality() {
+        assert_ne!(SUT::sample(), SUT::sample_other());
+    }
+}

--- a/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/role_assignments/entry.rs
+++ b/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/role_assignments/entry.rs
@@ -20,40 +20,70 @@ impl ComponentEntityRoleAssignmentEntry {
 
 impl HasSampleValues for ComponentEntityRoleAssignmentEntry {
     fn sample() -> Self {
-        Self::sample_depositor_allow_all()
+        Self::sample_depositor_explicit_allow_all()
     }
 
     fn sample_other() -> Self {
-        Self::sample_withdrawer_deny_all()
+        Self::sample_withdrawer_explicit_deny_all()
     }
 }
 
 impl ComponentEntityRoleAssignmentEntry {
-    pub fn sample_depositor_allow_all() -> Self {
+    pub fn sample_depositor_explicit_allow_all() -> Self {
         Self::new(
-            RoleKey::sample_depositor(),
-            ComponentEntityRoleAssignmentEntryAssignment::sample_allow_all(),
+            RoleKey::main_depositor(),
+            ComponentEntityRoleAssignmentEntryAssignment::sample_explicit_allow_all(),
         )
     }
 
-    pub fn sample_depositor_deny_all() -> Self {
+    pub fn sample_depositor_explicit_deny_all() -> Self {
         Self::new(
-            RoleKey::sample_depositor(),
-            ComponentEntityRoleAssignmentEntryAssignment::sample_deny_all(),
+            RoleKey::main_depositor(),
+            ComponentEntityRoleAssignmentEntryAssignment::sample_explicit_deny_all(),
         )
     }
 
-    pub fn sample_withdrawer_allow_all() -> Self {
+    pub fn sample_withdrawer_explicit_allow_all() -> Self {
         Self::new(
-            RoleKey::sample_withdrawer(),
-            ComponentEntityRoleAssignmentEntryAssignment::sample_allow_all(),
+            RoleKey::main_withdrawer(),
+            ComponentEntityRoleAssignmentEntryAssignment::sample_explicit_allow_all(),
         )
     }
 
-    pub fn sample_withdrawer_deny_all() -> Self {
+    pub fn sample_withdrawer_explicit_deny_all() -> Self {
         Self::new(
-            RoleKey::sample_withdrawer(),
-            ComponentEntityRoleAssignmentEntryAssignment::sample_deny_all(),
+            RoleKey::main_withdrawer(),
+            ComponentEntityRoleAssignmentEntryAssignment::sample_explicit_deny_all(),
+        )
+    }
+
+    pub fn sample_depositor_owner_allow_all() -> Self {
+        Self::new(
+            RoleKey::main_depositor(),
+            ComponentEntityRoleAssignmentEntryAssignment::sample_owner_allow_all(),
+        )
+    }
+
+    pub fn sample_withdrawer_owner_allow_all() -> Self {
+        Self::new(
+            RoleKey::main_withdrawer(),
+            ComponentEntityRoleAssignmentEntryAssignment::sample_owner_allow_all(),
+        )
+    }
+
+    pub fn sample_depositor_owner_deny_all() -> Self {
+        Self::new(
+            RoleKey::main_depositor(),
+            ComponentEntityRoleAssignmentEntryAssignment::sample_owner_deny_all(
+            ),
+        )
+    }
+
+    pub fn sample_withdrawer_owner_deny_all() -> Self {
+        Self::new(
+            RoleKey::main_withdrawer(),
+            ComponentEntityRoleAssignmentEntryAssignment::sample_owner_deny_all(
+            ),
         )
     }
 }

--- a/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/role_assignments/explicit_rule.rs
+++ b/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/role_assignments/explicit_rule.rs
@@ -1,0 +1,9 @@
+use crate::prelude::*;
+
+#[derive(Deserialize, Serialize, Clone, PartialEq, Eq, Debug)]
+#[serde(tag = "type")]
+pub enum ExplicitRule {
+    AllowAll,
+    DenyAll,
+    Protected,
+}

--- a/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/role_assignments/mod.rs
+++ b/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/role_assignments/mod.rs
@@ -2,10 +2,16 @@ mod assignment;
 mod collection;
 mod entry;
 mod explicit_rule;
+mod module;
+mod owner;
+mod resolution;
 mod role_key;
 
 pub use assignment::*;
 pub use collection::*;
 pub use entry::*;
 pub use explicit_rule::*;
+pub use module::*;
+pub use owner::*;
+pub use resolution::*;
 pub use role_key::*;

--- a/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/role_assignments/mod.rs
+++ b/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/role_assignments/mod.rs
@@ -1,0 +1,11 @@
+mod assignment;
+mod collection;
+mod entry;
+mod explicit_rule;
+mod role_key;
+
+pub use assignment::*;
+pub use collection::*;
+pub use entry::*;
+pub use explicit_rule::*;
+pub use role_key::*;

--- a/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/role_assignments/module.rs
+++ b/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/role_assignments/module.rs
@@ -1,0 +1,9 @@
+use crate::prelude::*;
+
+#[derive(Deserialize, Serialize, Clone, PartialEq, Eq, Debug, EnumAsInner)]
+pub enum ObjectModuleId {
+    Main,
+    Metadata,
+    Royalty,
+    RoleAssignment,
+}

--- a/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/role_assignments/owner.rs
+++ b/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/role_assignments/owner.rs
@@ -2,12 +2,12 @@ use crate::prelude::*;
 
 #[derive(Deserialize, Serialize, Clone, PartialEq, Eq, Debug)]
 pub struct ComponentEntityRoleAssignmentOwner {
-    pub explicit_rule: ExplicitRule,
+    pub rule: ExplicitRule,
 }
 
 impl ComponentEntityRoleAssignmentOwner {
-    pub fn new(explicit_rule: ExplicitRule) -> Self {
-        Self { explicit_rule }
+    pub fn new(rule: ExplicitRule) -> Self {
+        Self { rule }
     }
 }
 

--- a/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/role_assignments/owner.rs
+++ b/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/role_assignments/owner.rs
@@ -1,0 +1,36 @@
+use crate::prelude::*;
+
+#[derive(Deserialize, Serialize, Clone, PartialEq, Eq, Debug)]
+pub struct ComponentEntityRoleAssignmentOwner {
+    pub explicit_rule: ExplicitRule,
+}
+
+impl ComponentEntityRoleAssignmentOwner {
+    pub fn new(explicit_rule: ExplicitRule) -> Self {
+        Self { explicit_rule }
+    }
+}
+
+impl HasSampleValues for ComponentEntityRoleAssignmentOwner {
+    fn sample() -> Self {
+        Self::sample_allow_all()
+    }
+
+    fn sample_other() -> Self {
+        Self::sample_deny_all()
+    }
+}
+
+impl ComponentEntityRoleAssignmentOwner {
+    pub fn sample_allow_all() -> Self {
+        Self::new(ExplicitRule::AllowAll)
+    }
+
+    pub fn sample_deny_all() -> Self {
+        Self::new(ExplicitRule::DenyAll)
+    }
+
+    pub fn sample_protected() -> Self {
+        Self::new(ExplicitRule::Protected)
+    }
+}

--- a/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/role_assignments/owner.rs
+++ b/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/role_assignments/owner.rs
@@ -34,3 +34,22 @@ impl ComponentEntityRoleAssignmentOwner {
         Self::new(ExplicitRule::Protected)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[allow(clippy::upper_case_acronyms)]
+    type SUT = ComponentEntityRoleAssignmentOwner;
+
+    #[test]
+    fn equality() {
+        assert_eq!(SUT::sample(), SUT::sample());
+        assert_eq!(SUT::sample_other(), SUT::sample_other());
+    }
+
+    #[test]
+    fn inequality() {
+        assert_ne!(SUT::sample(), SUT::sample_other());
+    }
+}

--- a/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/role_assignments/resolution.rs
+++ b/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/role_assignments/resolution.rs
@@ -1,0 +1,7 @@
+use crate::prelude::*;
+
+#[derive(Deserialize, Serialize, Clone, PartialEq, Eq, Debug, EnumAsInner)]
+pub enum RoleAssignmentResolution {
+    Explicit,
+    Owner,
+}

--- a/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/role_assignments/role_key.rs
+++ b/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/role_assignments/role_key.rs
@@ -1,0 +1,32 @@
+use crate::prelude::*;
+
+#[derive(Deserialize, Serialize, Clone, PartialEq, Eq, Debug)]
+pub struct RoleKey {
+    pub name: String,
+}
+
+impl RoleKey {
+    pub fn new(name: String) -> Self {
+        Self { name }
+    }
+}
+
+impl HasSampleValues for RoleKey {
+    fn sample() -> Self {
+        Self::sample_depositor()
+    }
+
+    fn sample_other() -> Self {
+        Self::sample_withdrawer()
+    }
+}
+
+impl RoleKey {
+    pub fn sample_depositor() -> Self {
+        Self::new("depositor".to_string())
+    }
+
+    pub fn sample_withdrawer() -> Self {
+        Self::new("withdrawer".to_string())
+    }
+}

--- a/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/role_assignments/role_key.rs
+++ b/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/role_assignments/role_key.rs
@@ -32,3 +32,22 @@ impl HasSampleValues for RoleKey {
         Self::main_withdrawer()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[allow(clippy::upper_case_acronyms)]
+    type SUT = RoleKey;
+
+    #[test]
+    fn equality() {
+        assert_eq!(SUT::sample(), SUT::sample());
+        assert_eq!(SUT::sample_other(), SUT::sample_other());
+    }
+
+    #[test]
+    fn inequality() {
+        assert_ne!(SUT::sample(), SUT::sample_other());
+    }
+}

--- a/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/role_assignments/role_key.rs
+++ b/crates/sargon/src/gateway_api/models/types/response/state/entity/details/details/role_assignments/role_key.rs
@@ -3,30 +3,32 @@ use crate::prelude::*;
 #[derive(Deserialize, Serialize, Clone, PartialEq, Eq, Debug)]
 pub struct RoleKey {
     pub name: String,
+    pub module: ObjectModuleId,
 }
 
 impl RoleKey {
-    pub fn new(name: String) -> Self {
-        Self { name }
+    pub fn new(name: String, module: ObjectModuleId) -> Self {
+        Self { name, module }
+    }
+
+    const DEPOSITOR: &str = "depositor";
+    const WITHDRAWER: &str = "withdrawer";
+
+    pub fn main_depositor() -> Self {
+        Self::new(Self::DEPOSITOR.to_string(), ObjectModuleId::Main)
+    }
+
+    pub fn main_withdrawer() -> Self {
+        Self::new(Self::WITHDRAWER.to_string(), ObjectModuleId::Main)
     }
 }
 
 impl HasSampleValues for RoleKey {
     fn sample() -> Self {
-        Self::sample_depositor()
+        Self::main_depositor()
     }
 
     fn sample_other() -> Self {
-        Self::sample_withdrawer()
-    }
-}
-
-impl RoleKey {
-    pub fn sample_depositor() -> Self {
-        Self::new("depositor".to_string())
-    }
-
-    pub fn sample_withdrawer() -> Self {
-        Self::new("withdrawer".to_string())
+        Self::main_withdrawer()
     }
 }

--- a/crates/sargon/src/gateway_api/models/types/response/state/entity/details/mod.rs
+++ b/crates/sargon/src/gateway_api/models/types/response/state/entity/details/mod.rs
@@ -1,9 +1,11 @@
+mod details;
 mod fungible;
 mod metadata;
 mod non_fungible;
 mod response;
 mod response_item;
 
+pub use details::*;
 pub use fungible::*;
 pub use metadata::*;
 pub use non_fungible::*;

--- a/crates/sargon/src/gateway_api/models/types/response/state/entity/details/non_fungible/collection_item.rs
+++ b/crates/sargon/src/gateway_api/models/types/response/state/entity/details/non_fungible/collection_item.rs
@@ -20,3 +20,11 @@ impl HasSampleValues for NonFungibleResourcesCollectionItem {
         )
     }
 }
+
+impl NonFungibleResourcesCollectionItem {
+    pub fn resource_address(&self) -> ResourceAddress {
+        match self {
+            Self::Global(item) => item.resource_address,
+        }
+    }
+}

--- a/crates/sargon/src/gateway_api/models/types/response/state/entity/details/response_item.rs
+++ b/crates/sargon/src/gateway_api/models/types/response/state/entity/details/response_item.rs
@@ -20,6 +20,9 @@ pub struct StateEntityDetailsResponseItem {
 
     /// Entity metadata collection.
     pub metadata: EntityMetadataCollection,
+
+    /// More details of this entity.
+    pub details: Option<StateEntityDetailsResponseItemDetails>,
 }
 
 impl StateEntityDetailsResponseItem {
@@ -28,12 +31,14 @@ impl StateEntityDetailsResponseItem {
         fungible_resources: impl Into<Option<FungibleResourcesCollection>>,
         non_fungible_resources: impl Into<Option<NonFungibleResourcesCollection>>,
         metadata: EntityMetadataCollection,
+        details: impl Into<Option<StateEntityDetailsResponseItemDetails>>,
     ) -> StateEntityDetailsResponseItem {
         StateEntityDetailsResponseItem {
             address,
             fungible_resources: fungible_resources.into(),
             non_fungible_resources: non_fungible_resources.into(),
             metadata,
+            details: details.into(),
         }
     }
 }

--- a/crates/sargon/src/gateway_api/models/types/support/fetch_resources_output.rs
+++ b/crates/sargon/src/gateway_api/models/types/support/fetch_resources_output.rs
@@ -1,5 +1,6 @@
 use crate::prelude::*;
 
+/// A helper struct to grpup all the resources of a given account.
 #[derive(Deserialize, Serialize, Clone, PartialEq, Eq, Debug)]
 pub struct FetchResourcesOutput {
     pub fungibles: Vec<FungibleResourcesCollectionItem>,

--- a/crates/sargon/src/gateway_api/models/types/support/fetch_resources_output.rs
+++ b/crates/sargon/src/gateway_api/models/types/support/fetch_resources_output.rs
@@ -18,3 +18,37 @@ impl FetchResourcesOutput {
         }
     }
 }
+
+impl FetchResourcesOutput {
+    pub fn resource_addresses(&self) -> Vec<ResourceAddress> {
+        self.fungibles
+            .iter()
+            .map(|item| item.resource_address())
+            .chain(
+                self.non_fungibles
+                    .iter()
+                    .map(|item| item.resource_address()),
+            )
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::prelude::*;
+
+    #[allow(clippy::upper_case_acronyms)]
+    type SUT = FetchResourcesOutput;
+
+    #[test]
+    fn resource_addresses() {
+        let fungible = FungibleResourcesCollectionItem::sample();
+        let non_fungible = NonFungibleResourcesCollectionItem::sample();
+        let sut = SUT::new(vec![fungible.clone()], vec![non_fungible.clone()]);
+
+        assert_eq!(
+            sut.resource_addresses(),
+            vec![fungible.resource_address(), non_fungible.resource_address()]
+        );
+    }
+}

--- a/crates/sargon/src/gateway_api/models/types/support/fetch_resources_output.rs
+++ b/crates/sargon/src/gateway_api/models/types/support/fetch_resources_output.rs
@@ -9,12 +9,12 @@ pub struct FetchResourcesOutput {
 
 impl FetchResourcesOutput {
     pub fn new(
-        fungibles: Vec<FungibleResourcesCollectionItem>,
-        non_fungibles: Vec<NonFungibleResourcesCollectionItem>,
+        fungibles: impl IntoIterator<Item = FungibleResourcesCollectionItem>,
+        non_fungibles: impl IntoIterator<Item = NonFungibleResourcesCollectionItem>,
     ) -> Self {
         Self {
-            fungibles,
-            non_fungibles,
+            fungibles: Vec::from_iter(fungibles),
+            non_fungibles: Vec::from_iter(non_fungibles),
         }
     }
 }
@@ -44,7 +44,7 @@ mod tests {
     fn resource_addresses() {
         let fungible = FungibleResourcesCollectionItem::sample();
         let non_fungible = NonFungibleResourcesCollectionItem::sample();
-        let sut = SUT::new(vec![fungible.clone()], vec![non_fungible.clone()]);
+        let sut = SUT::new([fungible.clone()], [non_fungible.clone()]);
 
         assert_eq!(
             sut.resource_addresses(),

--- a/crates/sargon/src/gateway_api/models/types/support/fetch_resources_output.rs
+++ b/crates/sargon/src/gateway_api/models/types/support/fetch_resources_output.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 
-/// A helper struct to grpup all the resources of a given account.
+/// A helper struct to group all the resources of a given account.
 #[derive(Deserialize, Serialize, Clone, PartialEq, Eq, Debug)]
 pub struct FetchResourcesOutput {
     pub fungibles: Vec<FungibleResourcesCollectionItem>,

--- a/crates/sargon/src/gateway_api/models/types/support/fetch_transferable_resources_output.rs
+++ b/crates/sargon/src/gateway_api/models/types/support/fetch_transferable_resources_output.rs
@@ -4,10 +4,11 @@ use crate::prelude::*;
 #[derive(Deserialize, Serialize, Clone, PartialEq, Eq, Debug)]
 pub struct FetchTransferableResourcesOutput {
     /// The list of fungible resources that can be transferred.
-    pub fungibles: Vec<FungibleResourcesCollectionItem>,
+    pub fungibles: Vec<FungibleResourcesCollectionItemGloballyAggregated>,
 
     /// The list of non-fungible resources that can be transferred.
-    pub non_fungibles: Vec<NonFungibleResourcesCollectionItem>,
+    pub non_fungibles:
+        Vec<NonFungibleResourcesCollectionItemGloballyAggregated>,
 
     /// The list of non-transferable resources.
     pub non_transferable_resources: Vec<ResourceAddress>,
@@ -15,8 +16,10 @@ pub struct FetchTransferableResourcesOutput {
 
 impl FetchTransferableResourcesOutput {
     pub fn new(
-        fungibles: Vec<FungibleResourcesCollectionItem>,
-        non_fungibles: Vec<NonFungibleResourcesCollectionItem>,
+        fungibles: Vec<FungibleResourcesCollectionItemGloballyAggregated>,
+        non_fungibles: Vec<
+            NonFungibleResourcesCollectionItemGloballyAggregated,
+        >,
         non_transferable_resources: Vec<ResourceAddress>,
     ) -> Self {
         Self {

--- a/crates/sargon/src/gateway_api/models/types/support/fetch_transferable_resources_output.rs
+++ b/crates/sargon/src/gateway_api/models/types/support/fetch_transferable_resources_output.rs
@@ -1,0 +1,28 @@
+use crate::prelude::*;
+
+/// A helper struct to group all the transferable resources of a given account.
+#[derive(Deserialize, Serialize, Clone, PartialEq, Eq, Debug)]
+pub struct FetchTransferableResourcesOutput {
+    /// The list of fungible resources that can be transferred.
+    pub fungibles: Vec<FungibleResourcesCollectionItem>,
+
+    /// The list of non-fungible resources that can be transferred.
+    pub non_fungibles: Vec<NonFungibleResourcesCollectionItem>,
+
+    /// The list of non-transferable resources.
+    pub non_transferable_resources: Vec<ResourceAddress>,
+}
+
+impl FetchTransferableResourcesOutput {
+    pub fn new(
+        fungibles: Vec<FungibleResourcesCollectionItem>,
+        non_fungibles: Vec<NonFungibleResourcesCollectionItem>,
+        non_transferable_resources: Vec<ResourceAddress>,
+    ) -> Self {
+        Self {
+            fungibles,
+            non_fungibles,
+            non_transferable_resources,
+        }
+    }
+}

--- a/crates/sargon/src/gateway_api/models/types/support/mod.rs
+++ b/crates/sargon/src/gateway_api/models/types/support/mod.rs
@@ -1,3 +1,5 @@
 mod fetch_resources_output;
+mod fetch_transferable_resources_output;
 
 pub use fetch_resources_output::*;
+pub use fetch_transferable_resources_output::*;

--- a/crates/sargon/src/home_cards/deferred_deep_link/parser.rs
+++ b/crates/sargon/src/home_cards/deferred_deep_link/parser.rs
@@ -147,6 +147,7 @@ mod tests_transform {
                             },
                         }],
                     },
+                    details: None,
                 }],
             });
         SUT::new(GatewayClient::new(

--- a/crates/sargon/src/system/sargon_os/delete_account/mod.rs
+++ b/crates/sargon/src/system/sargon_os/delete_account/mod.rs
@@ -1,0 +1,5 @@
+mod sargon_os_delete_account;
+mod support;
+
+pub use sargon_os_delete_account::*;
+pub use support::*;

--- a/crates/sargon/src/system/sargon_os/delete_account/sargon_os_delete_account.rs
+++ b/crates/sargon/src/system/sargon_os/delete_account/sargon_os_delete_account.rs
@@ -123,7 +123,7 @@ impl SargonOS {
 
         // Filter transferable resources
         let transferable_resources = gateway_client
-            .filter_transferrable_resources(resources)
+            .filter_transferable_resources(resources)
             .await?;
 
         // Try to build the DeleteAccountTransfers from output and return it.

--- a/crates/sargon/src/system/sargon_os/delete_account/sargon_os_delete_account.rs
+++ b/crates/sargon/src/system/sargon_os/delete_account/sargon_os_delete_account.rs
@@ -13,7 +13,7 @@ impl SargonOS {
         &self,
         account_address: AccountAddress,
         recipient_account_address: Option<AccountAddress>,
-    ) -> Result<CreateDeleteAccountManifestResult> {
+    ) -> Result<CreateDeleteAccountManifestOutcome> {
         let network_id = account_address.network_id();
         let gateway_client = GatewayClient::new(
             self.clients.http_client.driver.clone(),
@@ -60,7 +60,7 @@ impl SargonOS {
         );
 
         // Build result
-        let result = CreateDeleteAccountManifestResult::new(
+        let result = CreateDeleteAccountManifestOutcome::new(
             manifest,
             account_transfers
                 .map_or_else(Vec::new, |t| t.non_transferable_resources),

--- a/crates/sargon/src/system/sargon_os/delete_account/sargon_os_delete_account.rs
+++ b/crates/sargon/src/system/sargon_os/delete_account/sargon_os_delete_account.rs
@@ -13,7 +13,7 @@ impl SargonOS {
         &self,
         account_address: AccountAddress,
         recipient_account_address: Option<AccountAddress>,
-    ) -> Result<TransactionManifest> {
+    ) -> Result<DeleteAccountResult> {
         let network_id = account_address.network_id();
         let gateway_client = GatewayClient::new(
             self.clients.http_client.driver.clone(),
@@ -54,12 +54,18 @@ impl SargonOS {
         // Build Manifest
         let manifest = TransactionManifest::delete_account(
             &account_address,
-            account_transfers,
+            account_transfers.clone(),
             resource_preferences,
             authorized_depositors,
         );
 
-        Ok(manifest)
+        // Build result
+        let result = DeleteAccountResult::new(
+            manifest,
+            account_transfers
+                .map_or_else(Vec::new, |t| t.non_transferable_resources),
+        );
+        Ok(result)
     }
 
     async fn fetch_resource_preferences(
@@ -212,7 +218,8 @@ mod tests {
             vec![],
         );
 
-        assert_eq!(result, expected);
+        assert_eq!(result.manifest, expected);
+        assert!(result.non_transferable_resources.is_empty());
     }
 
     /// Boots SargonOS with a mock networking driver that will return the provided responses.
@@ -363,7 +370,7 @@ mod integration_tests {
     type SUT = SargonOS;
 
     #[actix_rt::test]
-    async fn delete_account_manifest_from_empty_account() {
+    async fn empty_account() {
         // This test verifies that we can correctly create a manifest for the deletion of a virtual account.
         let request = SUT::boot_test();
 
@@ -380,5 +387,33 @@ mod integration_tests {
             .await;
 
         assert!(result.is_ok());
+    }
+
+    #[actix_rt::test]
+    async fn account_with_non_transferable_assets() {
+        // This test verifies that we can correctly create a manifest for the deletion of an account with non-transferable assets.
+        let request = SUT::boot_test();
+
+        let os = timeout(SARGON_OS_TEST_MAX_ASYNC_DURATION, request)
+            .await
+            .unwrap()
+            .unwrap();
+
+        // Account with RadQuest Hero Badge
+        let account_address = AccountAddress::try_from_bech32("account_tdx_2_129ty2n42x82qe6unxxpq8m8avjqaff54zfpfpepaaqn2tapqwnc0vw").unwrap();
+
+        let recipient_address = AccountAddress::sample_stokenet();
+
+        let result = os
+            .create_delete_account_manifest(
+                account_address,
+                recipient_address.into(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.non_transferable_resources, vec![
+            "resource_tdx_2_1nt72qwswkjkaayfwgyy0d2un8wvpjlq2dg5lq54382wlmf6yly8vz5".parse().unwrap(), // RadQuest Hero Badge
+        ]);
     }
 }

--- a/crates/sargon/src/system/sargon_os/delete_account/sargon_os_delete_account.rs
+++ b/crates/sargon/src/system/sargon_os/delete_account/sargon_os_delete_account.rs
@@ -13,7 +13,7 @@ impl SargonOS {
         &self,
         account_address: AccountAddress,
         recipient_account_address: Option<AccountAddress>,
-    ) -> Result<DeleteAccountResult> {
+    ) -> Result<CreateDeleteAccountManifestResult> {
         let network_id = account_address.network_id();
         let gateway_client = GatewayClient::new(
             self.clients.http_client.driver.clone(),
@@ -60,7 +60,7 @@ impl SargonOS {
         );
 
         // Build result
-        let result = DeleteAccountResult::new(
+        let result = CreateDeleteAccountManifestResult::new(
             manifest,
             account_transfers
                 .map_or_else(Vec::new, |t| t.non_transferable_resources),
@@ -412,8 +412,11 @@ mod integration_tests {
             .await
             .unwrap();
 
-        assert_eq!(result.non_transferable_resources, vec![
+        assert_eq!(
+            result.non_transferable_resources,
+            vec![
             "resource_tdx_2_1nt72qwswkjkaayfwgyy0d2un8wvpjlq2dg5lq54382wlmf6yly8vz5".parse().unwrap(), // RadQuest Hero Badge
-        ]);
+        ]
+        );
     }
 }

--- a/crates/sargon/src/system/sargon_os/delete_account/support/mod.rs
+++ b/crates/sargon/src/system/sargon_os/delete_account/support/mod.rs
@@ -1,0 +1,3 @@
+mod result;
+
+pub use result::*;

--- a/crates/sargon/src/system/sargon_os/delete_account/support/mod.rs
+++ b/crates/sargon/src/system/sargon_os/delete_account/support/mod.rs
@@ -1,3 +1,3 @@
-mod result;
+mod outcome;
 
-pub use result::*;
+pub use outcome::*;

--- a/crates/sargon/src/system/sargon_os/delete_account/support/outcome.rs
+++ b/crates/sargon/src/system/sargon_os/delete_account/support/outcome.rs
@@ -1,12 +1,12 @@
 use crate::prelude::*;
 
 #[derive(Clone, PartialEq, Eq, Debug)]
-pub struct CreateDeleteAccountManifestResult {
+pub struct CreateDeleteAccountManifestOutcome {
     pub manifest: TransactionManifest,
     pub non_transferable_resources: Vec<ResourceAddress>,
 }
 
-impl CreateDeleteAccountManifestResult {
+impl CreateDeleteAccountManifestOutcome {
     pub fn new(
         manifest: TransactionManifest,
         non_transferable_resources: Vec<ResourceAddress>,
@@ -18,7 +18,7 @@ impl CreateDeleteAccountManifestResult {
     }
 }
 
-impl HasSampleValues for CreateDeleteAccountManifestResult {
+impl HasSampleValues for CreateDeleteAccountManifestOutcome {
     fn sample() -> Self {
         Self::new(TransactionManifest::sample(), vec![])
     }

--- a/crates/sargon/src/system/sargon_os/delete_account/support/result.rs
+++ b/crates/sargon/src/system/sargon_os/delete_account/support/result.rs
@@ -1,12 +1,12 @@
 use crate::prelude::*;
 
 #[derive(Clone, PartialEq, Eq, Debug)]
-pub struct DeleteAccountResult {
+pub struct CreateDeleteAccountManifestResult {
     pub manifest: TransactionManifest,
     pub non_transferable_resources: Vec<ResourceAddress>,
 }
 
-impl DeleteAccountResult {
+impl CreateDeleteAccountManifestResult {
     pub fn new(
         manifest: TransactionManifest,
         non_transferable_resources: Vec<ResourceAddress>,
@@ -18,7 +18,7 @@ impl DeleteAccountResult {
     }
 }
 
-impl HasSampleValues for DeleteAccountResult {
+impl HasSampleValues for CreateDeleteAccountManifestResult {
     fn sample() -> Self {
         Self::new(TransactionManifest::sample(), vec![])
     }

--- a/crates/sargon/src/system/sargon_os/delete_account/support/result.rs
+++ b/crates/sargon/src/system/sargon_os/delete_account/support/result.rs
@@ -1,0 +1,32 @@
+use crate::prelude::*;
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct DeleteAccountResult {
+    pub manifest: TransactionManifest,
+    pub non_transferable_resources: Vec<ResourceAddress>,
+}
+
+impl DeleteAccountResult {
+    pub fn new(
+        manifest: TransactionManifest,
+        non_transferable_resources: Vec<ResourceAddress>,
+    ) -> Self {
+        Self {
+            manifest,
+            non_transferable_resources,
+        }
+    }
+}
+
+impl HasSampleValues for DeleteAccountResult {
+    fn sample() -> Self {
+        Self::new(TransactionManifest::sample(), vec![])
+    }
+
+    fn sample_other() -> Self {
+        Self::new(
+            TransactionManifest::sample_other(),
+            vec![ResourceAddress::sample_other()],
+        )
+    }
+}

--- a/crates/sargon/src/system/sargon_os/mod.rs
+++ b/crates/sargon/src/system/sargon_os/mod.rs
@@ -1,8 +1,8 @@
+mod delete_account;
 mod pre_authorization;
 mod profile_state_holder;
 mod sargon_os;
 mod sargon_os_accounts;
-mod sargon_os_delete_account;
 mod sargon_os_factors;
 mod sargon_os_gateway;
 mod sargon_os_profile;
@@ -10,6 +10,7 @@ mod sargon_os_security_structures;
 mod sargon_os_sync_accounts;
 mod transactions;
 
+pub use delete_account::*;
 pub use pre_authorization::*;
 pub use profile_state_holder::*;
 pub use sargon_os::*;

--- a/crates/sargon/src/system/sargon_os/sargon_os_delete_account.rs
+++ b/crates/sargon/src/system/sargon_os/sargon_os_delete_account.rs
@@ -111,12 +111,20 @@ impl SargonOS {
         };
 
         // Get all resources
-        let output = gateway_client
+        let resources = gateway_client
             .fetch_all_resources(account_address, ledger_state.into())
             .await?;
 
+        // Filter transferable resources
+        let transferable_resources = gateway_client
+            .filter_transferrable_resources(resources)
+            .await?;
+
         // Try to build the DeleteAccountTransfers from output and return it.
-        let transfers = DeleteAccountTransfers::try_from((output, recipient))?;
+        let transfers = DeleteAccountTransfers::try_from((
+            transferable_resources,
+            recipient,
+        ))?;
         Ok(Some(transfers))
     }
 }

--- a/crates/sargon/src/wrapped_radix_engine_toolkit/high_level/manifest_building/delete_account/delete_account_transfer.rs
+++ b/crates/sargon/src/wrapped_radix_engine_toolkit/high_level/manifest_building/delete_account/delete_account_transfer.rs
@@ -31,30 +31,25 @@ impl DeleteAccountTransfer {
     }
 }
 
-impl TryFrom<FungibleResourcesCollectionItem> for DeleteAccountTransfer {
-    type Error = CommonError;
-    fn try_from(value: FungibleResourcesCollectionItem) -> Result<Self> {
-        let value = value
-            .as_global()
-            .ok_or(CommonError::UnexpectedCollectionItemAggregation)?;
-        let result =
-            Self::new(value.resource_address.scrypto(), value.amount.into(), 1);
-        Ok(result)
+impl From<FungibleResourcesCollectionItemGloballyAggregated>
+    for DeleteAccountTransfer
+{
+    fn from(value: FungibleResourcesCollectionItemGloballyAggregated) -> Self {
+        Self::new(value.resource_address.scrypto(), value.amount.into(), 1)
     }
 }
 
-impl TryFrom<NonFungibleResourcesCollectionItem> for DeleteAccountTransfer {
-    type Error = CommonError;
-    fn try_from(value: NonFungibleResourcesCollectionItem) -> Result<Self> {
-        let value = value
-            .as_global()
-            .ok_or(CommonError::UnexpectedCollectionItemAggregation)?;
-        let result = Self::new(
+impl From<NonFungibleResourcesCollectionItemGloballyAggregated>
+    for DeleteAccountTransfer
+{
+    fn from(
+        value: NonFungibleResourcesCollectionItemGloballyAggregated,
+    ) -> Self {
+        Self::new(
             value.resource_address.scrypto(),
             value.amount.into(),
             value.amount,
-        );
-        Ok(result)
+        )
     }
 }
 
@@ -98,35 +93,27 @@ mod tests {
     fn from_fungible_resources_collection_item() {
         let resource_address = ResourceAddress::sample();
         let amount = Decimal192::sample();
-        let item = FungibleResourcesCollectionItem::Global(
-            FungibleResourcesCollectionItemGloballyAggregated::new(
-                resource_address,
-                amount,
-            ),
+        let item = FungibleResourcesCollectionItemGloballyAggregated::new(
+            resource_address,
+            amount,
         );
-        let result = DeleteAccountTransfer::try_from(item).unwrap();
+        let result = DeleteAccountTransfer::from(item);
         assert_eq!(result.resource_address, resource_address.scrypto());
         assert_eq!(result.amount, amount.into());
         assert_eq!(result.weight, 1);
-
-        // TODO: Add test that returns `UnexpectedCollectionItemAggregation` whenever we support `FungibleResourcesCollectionItem::Vault`
     }
 
     #[test]
     fn from_non_fungible_resources_collection_item() {
         let resource_address = ResourceAddress::sample();
         let amount = 5;
-        let item = NonFungibleResourcesCollectionItem::Global(
-            NonFungibleResourcesCollectionItemGloballyAggregated::new(
-                resource_address,
-                amount,
-            ),
+        let item = NonFungibleResourcesCollectionItemGloballyAggregated::new(
+            resource_address,
+            amount,
         );
-        let result = DeleteAccountTransfer::try_from(item).unwrap();
+        let result = DeleteAccountTransfer::from(item);
         assert_eq!(result.resource_address, resource_address.scrypto());
         assert_eq!(result.amount, amount.into());
         assert_eq!(result.weight, 5);
-
-        // TODO: Add test that returns `UnexpectedCollectionItemAggregation` whenever we support `NonFungibleResourcesCollectionItem::Vault`
     }
 }

--- a/crates/sargon/src/wrapped_radix_engine_toolkit/high_level/manifest_building/delete_account/delete_account_transfers.rs
+++ b/crates/sargon/src/wrapped_radix_engine_toolkit/high_level/manifest_building/delete_account/delete_account_transfers.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 
 /// A struct detailing the transfers for a given account to be deleted.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct DeleteAccountTransfers {
     /// The recipient account to which the resources are going to be transferred.
     pub recipient: AccountAddress,
@@ -24,15 +24,6 @@ impl DeleteAccountTransfers {
             transfers,
             non_transferable_resources,
         }
-    }
-}
-
-impl DeleteAccountTransfers {
-    pub async fn build(
-        output: FetchResourcesOutput,
-        recipient: AccountAddress,
-    ) -> Result<Self> {
-        Err(CommonError::Unknown)
     }
 }
 

--- a/crates/sargon/src/wrapped_radix_engine_toolkit/high_level/manifest_building/delete_account/delete_account_transfers.rs
+++ b/crates/sargon/src/wrapped_radix_engine_toolkit/high_level/manifest_building/delete_account/delete_account_transfers.rs
@@ -41,15 +41,15 @@ impl TryFrom<(FetchTransferableResourcesOutput, AccountAddress)>
             .fungibles
             .clone()
             .into_iter()
-            .map(DeleteAccountTransfer::try_from)
-            .collect::<Result<Vec<_>, _>>()?;
+            .map(DeleteAccountTransfer::from)
+            .collect::<Vec<_>>();
 
         // Convert non-fungibles
         let non_fungibles = output
             .non_fungibles
             .into_iter()
-            .map(DeleteAccountTransfer::try_from)
-            .collect::<Result<Vec<_>, _>>()?;
+            .map(DeleteAccountTransfer::from)
+            .collect::<Vec<_>>();
 
         // Merge in one collection
         let transfers = [fungibles, non_fungibles].concat();
@@ -83,8 +83,10 @@ mod tests {
     #[test]
     fn from_fetch_resources_output_and_recipient() {
         // Test the case where the total weight of the transfers is less than the maximum.
-        let fungible = FungibleResourcesCollectionItem::sample();
-        let non_fungible = NonFungibleResourcesCollectionItem::sample();
+        let fungible =
+            FungibleResourcesCollectionItemGloballyAggregated::sample();
+        let non_fungible =
+            NonFungibleResourcesCollectionItemGloballyAggregated::sample();
         let non_transferable_resources = vec![ResourceAddress::sample()];
         let output = FetchTransferableResourcesOutput::new(
             vec![fungible.clone()],
@@ -108,12 +110,11 @@ mod tests {
         );
 
         // Test the case where the total weight of the transfers is over the maximum.
-        let non_fungible = NonFungibleResourcesCollectionItem::Global(
+        let non_fungible =
             NonFungibleResourcesCollectionItemGloballyAggregated::new(
                 ResourceAddress::sample(),
                 50,
-            ),
-        );
+            );
 
         let output = FetchTransferableResourcesOutput::new(
             vec![fungible.clone()],

--- a/crates/sargon/src/wrapped_radix_engine_toolkit/high_level/manifest_building/delete_account/manifest_delete_account.rs
+++ b/crates/sargon/src/wrapped_radix_engine_toolkit/high_level/manifest_building/delete_account/manifest_delete_account.rs
@@ -203,6 +203,7 @@ CALL_METHOD
                 DeleteAccountTransfer::sample(),
                 DeleteAccountTransfer::sample_other(),
             ],
+            vec![],
         );
         let manifest = SUT::delete_account(
                 &"account_tdx_2_16yll6clntk9za0wvrw0nat848uazduyqy635m8ms77md99q7yf9fzg".into(),


### PR DESCRIPTION
When creating the `TransactionManifest` for an account deletion, exclude the resources that cannot be transferred (and keep track of them).