### PR TITLE
[ABW-3037] Move proof of ownership data models from unauthorized request to authorized request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2759,7 +2759,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.1.56"
+version = "1.1.57"
 dependencies = [
  "actix-rt",
  "aes-gcm",
@@ -2814,7 +2814,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-uniffi"
-version = "1.1.56"
+version = "1.1.57"
 dependencies = [
  "actix-rt",
  "assert-json-diff",

--- a/crates/sargon-uniffi/Cargo.toml
+++ b/crates/sargon-uniffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sargon-uniffi"
 # Don't forget to update version in crates/sargon/Cargo.toml
-version = "1.1.56"
+version = "1.1.57"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/sargon-uniffi/src/radix_connect/wallet_interaction/dapp_wallet_interaction/dapp_to_wallet/interaction_items/request/authorized_request.rs
+++ b/crates/sargon-uniffi/src/radix_connect/wallet_interaction/dapp_wallet_interaction/dapp_to_wallet/interaction_items/request/authorized_request.rs
@@ -12,4 +12,6 @@ pub struct DappToWalletInteractionAuthorizedRequestItems {
     pub one_time_accounts: Option<DappToWalletInteractionAccountsRequestItem>,
     pub one_time_persona_data:
         Option<DappToWalletInteractionPersonaDataRequestItem>,
+    pub proof_of_ownership:
+        Option<DappToWalletInteractionProofOfOwnershipRequestItem>,
 }

--- a/crates/sargon-uniffi/src/radix_connect/wallet_interaction/dapp_wallet_interaction/dapp_to_wallet/interaction_items/request/unauthorized_request.rs
+++ b/crates/sargon-uniffi/src/radix_connect/wallet_interaction/dapp_wallet_interaction/dapp_to_wallet/interaction_items/request/unauthorized_request.rs
@@ -5,5 +5,5 @@ use sargon::DappToWalletInteractionUnauthorizedRequestItems as InternalDappToWal
 pub struct DappToWalletInteractionUnauthorizedRequestItems {
     pub one_time_accounts: Option<DappToWalletInteractionAccountsRequestItem>,
     pub one_time_persona_data:
-        Option<DappToWalletInteractionPersonaDataRequestItem>
+        Option<DappToWalletInteractionPersonaDataRequestItem>,
 }

--- a/crates/sargon-uniffi/src/radix_connect/wallet_interaction/dapp_wallet_interaction/dapp_to_wallet/interaction_items/request/unauthorized_request.rs
+++ b/crates/sargon-uniffi/src/radix_connect/wallet_interaction/dapp_wallet_interaction/dapp_to_wallet/interaction_items/request/unauthorized_request.rs
@@ -5,7 +5,5 @@ use sargon::DappToWalletInteractionUnauthorizedRequestItems as InternalDappToWal
 pub struct DappToWalletInteractionUnauthorizedRequestItems {
     pub one_time_accounts: Option<DappToWalletInteractionAccountsRequestItem>,
     pub one_time_persona_data:
-        Option<DappToWalletInteractionPersonaDataRequestItem>,
-    pub proof_of_ownership:
-        Option<DappToWalletInteractionProofOfOwnershipRequestItem>,
+        Option<DappToWalletInteractionPersonaDataRequestItem>
 }

--- a/crates/sargon-uniffi/src/radix_connect/wallet_interaction/dapp_wallet_interaction/wallet_to_dapp/success_response/authorized_request.rs
+++ b/crates/sargon-uniffi/src/radix_connect/wallet_interaction/dapp_wallet_interaction/wallet_to_dapp/success_response/authorized_request.rs
@@ -12,4 +12,6 @@ pub struct WalletToDappInteractionAuthorizedRequestResponseItems {
         Option<WalletToDappInteractionAccountsRequestResponseItem>,
     pub one_time_persona_data:
         Option<WalletToDappInteractionPersonaDataRequestResponseItem>,
+    pub proof_of_ownership:
+        Option<WalletToDappInteractionProofOfOwnershipRequestResponseItem>,
 }

--- a/crates/sargon-uniffi/src/radix_connect/wallet_interaction/dapp_wallet_interaction/wallet_to_dapp/success_response/unauthorized_request.rs
+++ b/crates/sargon-uniffi/src/radix_connect/wallet_interaction/dapp_wallet_interaction/wallet_to_dapp/success_response/unauthorized_request.rs
@@ -7,6 +7,4 @@ pub struct WalletToDappInteractionUnauthorizedRequestResponseItems {
         Option<WalletToDappInteractionAccountsRequestResponseItem>,
     pub one_time_persona_data:
         Option<WalletToDappInteractionPersonaDataRequestResponseItem>,
-    pub proof_of_ownership:
-        Option<WalletToDappInteractionProofOfOwnershipRequestResponseItem>,
 }

--- a/crates/sargon/Cargo.toml
+++ b/crates/sargon/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sargon"
 # Don't forget to update version in crates/sargon-uniffi/Cargo.toml
-version = "1.1.56"
+version = "1.1.57"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/sargon/fixtures/vector/wallet_interactions_dapp_to_wallet.json
+++ b/crates/sargon/fixtures/vector/wallet_interactions_dapp_to_wallet.json
@@ -157,7 +157,15 @@
   {
     "interactionId": "2916ad16-52a0-4564-a611-4971883c1322",
     "items": {
-      "discriminator": "unauthorizedRequest",
+      "discriminator" : "authorizedRequest",
+      "auth":{
+        "discriminator" :"usePersona",
+        "identityAddress":"identity_tdx_2_12fat0nh0gymw9j4rqka5344p3h3r86x4z0hkw2v78r03pt0kfv0qva"
+      },
+      "reset" : {
+        "accounts" : false,
+        "personaData" : false
+      },
       "proofOfOwnership": {
         "challenge": "4c85e4a903ab97450ef83763f8d4ca55a43efe843e1d2ced78a4940e5c397c9c",
         "accountAddresses": [
@@ -175,7 +183,15 @@
   {
     "interactionId": "17d530f6-0cb6-4122-8540-64e46a2e0f84",
     "items": {
-      "discriminator": "unauthorizedRequest",
+      "discriminator" : "authorizedRequest",
+      "auth":{
+        "discriminator" :"usePersona",
+        "identityAddress":"identity_tdx_2_12fat0nh0gymw9j4rqka5344p3h3r86x4z0hkw2v78r03pt0kfv0qva"
+      },
+      "reset" : {
+        "accounts" : false,
+        "personaData" : false
+      },
       "proofOfOwnership": {
         "challenge": "e280cfa39e1499f2862e59759cc2fc990cce28b70a7989324fe91c47814d0630",
         "accountAddresses": [

--- a/crates/sargon/fixtures/vector/wallet_interactions_wallet_to_dapp.json
+++ b/crates/sargon/fixtures/vector/wallet_interactions_wallet_to_dapp.json
@@ -116,7 +116,14 @@
           "discriminator" : "success",
           "interactionId" : "2916ad16-52a0-4564-a611-4971883c1322",
           "items" : {
-            "discriminator" : "unauthorizedRequest",
+            "discriminator" : "authorizedRequest",
+            "auth" : {
+              "discriminator" : "usePersona",
+              "persona" : {
+                "identityAddress" : "identity_tdx_2_12fat0nh0gymw9j4rqka5344p3h3r86x4z0hkw2v78r03pt0kfv0qva",
+                "label" : "alfz_psf"
+              }
+            },
             "proofOfOwnership": {
               "challenge": "4c85e4a903ab97450ef83763f8d4ca55a43efe843e1d2ced78a4940e5c397c9c",
               "proofs": [
@@ -136,7 +143,14 @@
           "discriminator" : "success",
           "interactionId" : "17d530f6-0cb6-4122-8540-64e46a2e0f84",
           "items" : {
-            "discriminator" : "unauthorizedRequest",
+            "discriminator" : "authorizedRequest",
+            "auth" : {
+              "discriminator" : "usePersona",
+              "persona" : {
+                "identityAddress" : "identity_tdx_2_12fat0nh0gymw9j4rqka5344p3h3r86x4z0hkw2v78r03pt0kfv0qva",
+                "label" : "pao13"
+              }
+            },
             "proofOfOwnership": {
               "challenge": "e280cfa39e1499f2862e59759cc2fc990cce28b70a7989324fe91c47814d0630",
               "proofs": [

--- a/crates/sargon/src/radix_connect/mobile/deep_link_parsing/parser.rs
+++ b/crates/sargon/src/radix_connect/mobile/deep_link_parsing/parser.rs
@@ -200,6 +200,7 @@ impl SampleRequestParams {
                     None,
                     None,
                     None,
+                    None
                 )
             ),
             DappToWalletInteractionMetadataUnvalidated::new(

--- a/crates/sargon/src/radix_connect/mobile/deep_link_parsing/parser.rs
+++ b/crates/sargon/src/radix_connect/mobile/deep_link_parsing/parser.rs
@@ -200,7 +200,7 @@ impl SampleRequestParams {
                     None,
                     None,
                     None,
-                    None
+                    None,
                 )
             ),
             DappToWalletInteractionMetadataUnvalidated::new(

--- a/crates/sargon/src/radix_connect/wallet_interaction/dapp_wallet_interaction/dapp_to_wallet/interaction_items/request/authorized_request.rs
+++ b/crates/sargon/src/radix_connect/wallet_interaction/dapp_wallet_interaction/dapp_to_wallet/interaction_items/request/authorized_request.rs
@@ -19,6 +19,10 @@ pub struct DappToWalletInteractionAuthorizedRequestItems {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub one_time_persona_data:
         Option<DappToWalletInteractionPersonaDataRequestItem>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub proof_of_ownership:
+        Option<DappToWalletInteractionProofOfOwnershipRequestItem>,
 }
 
 impl DappToWalletInteractionAuthorizedRequestItems {
@@ -37,6 +41,9 @@ impl DappToWalletInteractionAuthorizedRequestItems {
         one_time_persona_data: impl Into<
             Option<DappToWalletInteractionPersonaDataRequestItem>,
         >,
+        proof_of_ownership: impl Into<
+            Option<DappToWalletInteractionProofOfOwnershipRequestItem>,
+        >,
     ) -> Self {
         Self {
             auth,
@@ -45,6 +52,7 @@ impl DappToWalletInteractionAuthorizedRequestItems {
             ongoing_persona_data: ongoing_persona_data.into(),
             one_time_accounts: one_time_accounts.into(),
             one_time_persona_data: one_time_persona_data.into(),
+            proof_of_ownership: proof_of_ownership.into(),
         }
     }
 }
@@ -58,6 +66,7 @@ impl HasSampleValues for DappToWalletInteractionAuthorizedRequestItems {
             DappToWalletInteractionPersonaDataRequestItem::sample(),
             DappToWalletInteractionAccountsRequestItem::sample(),
             DappToWalletInteractionPersonaDataRequestItem::sample(),
+            DappToWalletInteractionProofOfOwnershipRequestItem::sample(),
         )
     }
 
@@ -69,6 +78,7 @@ impl HasSampleValues for DappToWalletInteractionAuthorizedRequestItems {
             DappToWalletInteractionPersonaDataRequestItem::sample_other(),
             DappToWalletInteractionAccountsRequestItem::sample_other(),
             DappToWalletInteractionPersonaDataRequestItem::sample_other(),
+            DappToWalletInteractionProofOfOwnershipRequestItem::sample_other(),
         )
     }
 }

--- a/crates/sargon/src/radix_connect/wallet_interaction/dapp_wallet_interaction/dapp_to_wallet/interaction_items/request/unauthorized_request.rs
+++ b/crates/sargon/src/radix_connect/wallet_interaction/dapp_wallet_interaction/dapp_to_wallet/interaction_items/request/unauthorized_request.rs
@@ -9,10 +9,6 @@ pub struct DappToWalletInteractionUnauthorizedRequestItems {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub one_time_persona_data:
         Option<DappToWalletInteractionPersonaDataRequestItem>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub proof_of_ownership:
-        Option<DappToWalletInteractionProofOfOwnershipRequestItem>,
 }
 
 impl DappToWalletInteractionUnauthorizedRequestItems {
@@ -23,14 +19,10 @@ impl DappToWalletInteractionUnauthorizedRequestItems {
         one_time_persona_data: impl Into<
             Option<DappToWalletInteractionPersonaDataRequestItem>,
         >,
-        proof_of_ownership: impl Into<
-            Option<DappToWalletInteractionProofOfOwnershipRequestItem>,
-        >,
     ) -> Self {
         Self {
             one_time_accounts: one_time_accounts.into(),
             one_time_persona_data: one_time_persona_data.into(),
-            proof_of_ownership: proof_of_ownership.into(),
         }
     }
 }
@@ -40,7 +32,6 @@ impl HasSampleValues for DappToWalletInteractionUnauthorizedRequestItems {
         Self::new(
             DappToWalletInteractionAccountsRequestItem::sample(),
             DappToWalletInteractionPersonaDataRequestItem::sample(),
-            DappToWalletInteractionProofOfOwnershipRequestItem::sample(),
         )
     }
 
@@ -48,7 +39,6 @@ impl HasSampleValues for DappToWalletInteractionUnauthorizedRequestItems {
         Self::new(
             DappToWalletInteractionAccountsRequestItem::sample_other(),
             DappToWalletInteractionPersonaDataRequestItem::sample_other(),
-            DappToWalletInteractionProofOfOwnershipRequestItem::sample_other(),
         )
     }
 }

--- a/crates/sargon/src/radix_connect/wallet_interaction/dapp_wallet_interaction/wallet_to_dapp/success_response/authorized_request.rs
+++ b/crates/sargon/src/radix_connect/wallet_interaction/dapp_wallet_interaction/wallet_to_dapp/success_response/authorized_request.rs
@@ -64,7 +64,8 @@ impl HasSampleValues for WalletToDappInteractionAuthorizedRequestResponseItems {
             WalletToDappInteractionPersonaDataRequestResponseItem::sample(),
             WalletToDappInteractionAccountsRequestResponseItem::sample(),
             WalletToDappInteractionPersonaDataRequestResponseItem::sample(),
-            WalletToDappInteractionProofOfOwnershipRequestResponseItem::sample(),
+            WalletToDappInteractionProofOfOwnershipRequestResponseItem::sample(
+            ),
         )
     }
 

--- a/crates/sargon/src/radix_connect/wallet_interaction/dapp_wallet_interaction/wallet_to_dapp/success_response/authorized_request.rs
+++ b/crates/sargon/src/radix_connect/wallet_interaction/dapp_wallet_interaction/wallet_to_dapp/success_response/authorized_request.rs
@@ -72,10 +72,12 @@ impl HasSampleValues for WalletToDappInteractionAuthorizedRequestResponseItems {
         Self::new(
             WalletToDappInteractionAuthRequestResponseItem::sample_other(),
             WalletToDappInteractionAccountsRequestResponseItem::sample_other(),
-            WalletToDappInteractionPersonaDataRequestResponseItem::sample_other(),
+            WalletToDappInteractionPersonaDataRequestResponseItem::sample_other(
+            ),
             WalletToDappInteractionAccountsRequestResponseItem::sample_other(),
             WalletToDappInteractionPersonaDataRequestResponseItem::sample_other(),
-            WalletToDappInteractionProofOfOwnershipRequestResponseItem::sample_other(),
+            WalletToDappInteractionProofOfOwnershipRequestResponseItem::sample_other(
+            ),
         )
     }
 }

--- a/crates/sargon/src/radix_connect/wallet_interaction/dapp_wallet_interaction/wallet_to_dapp/success_response/authorized_request.rs
+++ b/crates/sargon/src/radix_connect/wallet_interaction/dapp_wallet_interaction/wallet_to_dapp/success_response/authorized_request.rs
@@ -20,6 +20,10 @@ pub struct WalletToDappInteractionAuthorizedRequestResponseItems {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub one_time_persona_data:
         Option<WalletToDappInteractionPersonaDataRequestResponseItem>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub proof_of_ownership:
+        Option<WalletToDappInteractionProofOfOwnershipRequestResponseItem>,
 }
 
 impl WalletToDappInteractionAuthorizedRequestResponseItems {
@@ -37,6 +41,9 @@ impl WalletToDappInteractionAuthorizedRequestResponseItems {
         one_time_persona_data: impl Into<
             Option<WalletToDappInteractionPersonaDataRequestResponseItem>,
         >,
+        proof_of_ownership: impl Into<
+            Option<WalletToDappInteractionProofOfOwnershipRequestResponseItem>,
+        >,
     ) -> Self {
         Self {
             auth,
@@ -44,6 +51,7 @@ impl WalletToDappInteractionAuthorizedRequestResponseItems {
             ongoing_persona_data: ongoing_persona_data.into(),
             one_time_accounts: one_time_accounts.into(),
             one_time_persona_data: one_time_persona_data.into(),
+            proof_of_ownership: proof_of_ownership.into(),
         }
     }
 }
@@ -56,6 +64,7 @@ impl HasSampleValues for WalletToDappInteractionAuthorizedRequestResponseItems {
             WalletToDappInteractionPersonaDataRequestResponseItem::sample(),
             WalletToDappInteractionAccountsRequestResponseItem::sample(),
             WalletToDappInteractionPersonaDataRequestResponseItem::sample(),
+            WalletToDappInteractionProofOfOwnershipRequestResponseItem::sample(),
         )
     }
 
@@ -63,11 +72,10 @@ impl HasSampleValues for WalletToDappInteractionAuthorizedRequestResponseItems {
         Self::new(
             WalletToDappInteractionAuthRequestResponseItem::sample_other(),
             WalletToDappInteractionAccountsRequestResponseItem::sample_other(),
-            WalletToDappInteractionPersonaDataRequestResponseItem::sample_other(
-            ),
+            WalletToDappInteractionPersonaDataRequestResponseItem::sample_other(),
             WalletToDappInteractionAccountsRequestResponseItem::sample_other(),
-            WalletToDappInteractionPersonaDataRequestResponseItem::sample_other(
-            ),
+            WalletToDappInteractionPersonaDataRequestResponseItem::sample_other(),
+            WalletToDappInteractionProofOfOwnershipRequestResponseItem::sample_other(),
         )
     }
 }

--- a/crates/sargon/src/radix_connect/wallet_interaction/dapp_wallet_interaction/wallet_to_dapp/success_response/unauthorized_request.rs
+++ b/crates/sargon/src/radix_connect/wallet_interaction/dapp_wallet_interaction/wallet_to_dapp/success_response/unauthorized_request.rs
@@ -10,10 +10,6 @@ pub struct WalletToDappInteractionUnauthorizedRequestResponseItems {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub one_time_persona_data:
         Option<WalletToDappInteractionPersonaDataRequestResponseItem>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub proof_of_ownership:
-        Option<WalletToDappInteractionProofOfOwnershipRequestResponseItem>,
 }
 
 impl WalletToDappInteractionUnauthorizedRequestResponseItems {
@@ -24,14 +20,10 @@ impl WalletToDappInteractionUnauthorizedRequestResponseItems {
         one_time_persona_data: impl Into<
             Option<WalletToDappInteractionPersonaDataRequestResponseItem>,
         >,
-        proof_of_ownership: impl Into<
-            Option<WalletToDappInteractionProofOfOwnershipRequestResponseItem>,
-        >,
     ) -> Self {
         Self {
             one_time_accounts: one_time_accounts.into(),
             one_time_persona_data: one_time_persona_data.into(),
-            proof_of_ownership: proof_of_ownership.into(),
         }
     }
 }
@@ -43,8 +35,6 @@ impl HasSampleValues
         Self::new(
             WalletToDappInteractionAccountsRequestResponseItem::sample(),
             WalletToDappInteractionPersonaDataRequestResponseItem::sample(),
-            WalletToDappInteractionProofOfOwnershipRequestResponseItem::sample(
-            ),
         )
     }
 
@@ -53,7 +43,6 @@ impl HasSampleValues
             WalletToDappInteractionAccountsRequestResponseItem::sample_other(),
             WalletToDappInteractionPersonaDataRequestResponseItem::sample_other(
             ),
-            WalletToDappInteractionProofOfOwnershipRequestResponseItem::sample_other(),
         )
     }
 }

--- a/crates/sargon/tests/vectors/main.rs
+++ b/crates/sargon/tests/vectors/main.rs
@@ -507,6 +507,7 @@ mod dapp_to_wallet_interaction_tests {
             ),
             None,
             None,
+            None,
         )
     );
 
@@ -535,6 +536,7 @@ mod dapp_to_wallet_interaction_tests {
                     RequestedQuantity::at_least(1),
                     RequestedQuantity::at_least(1),
                 ),
+                None,
                 None,
                 None,
             )
@@ -576,7 +578,6 @@ mod dapp_to_wallet_interaction_tests {
                     RequestedQuantity::exactly(1),
                     RequestedQuantity::exactly(1),
                 ),
-                None
             )
         );
 
@@ -600,7 +601,6 @@ mod dapp_to_wallet_interaction_tests {
                     RequestedQuantity::at_least(1),
                     RequestedQuantity::at_least(1),
                 ),
-                None,
             )
         );
 
@@ -613,8 +613,20 @@ mod dapp_to_wallet_interaction_tests {
             metadata.clone(),
         );
 
-        let account_proof_request_items = DappToWalletInteractionItems::UnauthorizedRequest(
-            DappToWalletInteractionUnauthorizedRequestItems::new(
+        let account_proof_request_items = DappToWalletInteractionItems::AuthorizedRequest(
+            DappToWalletInteractionAuthorizedRequestItems::new(
+                DappToWalletInteractionAuthRequestItem::UsePersona(
+                    DappToWalletInteractionAuthUsePersonaRequestItem::new(
+                        IdentityAddress::from_str("identity_tdx_2_12fat0nh0gymw9j4rqka5344p3h3r86x4z0hkw2v78r03pt0kfv0qva")
+                            .unwrap(),
+                    )
+                ),
+                DappToWalletInteractionResetRequestItem::new(
+                    false,
+                    false,
+                ),
+                None,
+                None,
                 None,
                 None,
                 DappToWalletInteractionProofOfOwnershipRequestItem::new(
@@ -636,8 +648,20 @@ mod dapp_to_wallet_interaction_tests {
             metadata.clone(),
         );
 
-        let accounts_and_persona_proof_request_items = DappToWalletInteractionItems::UnauthorizedRequest(
-            DappToWalletInteractionUnauthorizedRequestItems::new(
+        let accounts_and_persona_proof_request_items = DappToWalletInteractionItems::AuthorizedRequest(
+            DappToWalletInteractionAuthorizedRequestItems::new(
+                DappToWalletInteractionAuthRequestItem::UsePersona(
+                    DappToWalletInteractionAuthUsePersonaRequestItem::new(
+                        IdentityAddress::from_str("identity_tdx_2_12fat0nh0gymw9j4rqka5344p3h3r86x4z0hkw2v78r03pt0kfv0qva")
+                            .unwrap(),
+                    )
+                ),
+                DappToWalletInteractionResetRequestItem::new(
+                    false,
+                    false,
+                ),
+                None,
+                None,
                 None,
                 None,
                 DappToWalletInteractionProofOfOwnershipRequestItem::new(
@@ -782,6 +806,7 @@ mod wallet_to_dapp_interaction_tests {
                 persona_data.clone(),
                 None,
                 None,
+                None
             )
         );
 
@@ -805,7 +830,6 @@ mod wallet_to_dapp_interaction_tests {
                         None,
                     ),
                     persona_data.clone(),
-                    None,
                 ),
             );
 
@@ -842,25 +866,35 @@ mod wallet_to_dapp_interaction_tests {
             )
         ));
 
-        let account_proof_response_items =
-        WalletToDappInteractionResponseItems::UnauthorizedRequest(
-            WalletToDappInteractionUnauthorizedRequestResponseItems::new(
+        let account_proof_response_items = WalletToDappInteractionResponseItems::AuthorizedRequest(
+            WalletToDappInteractionAuthorizedRequestResponseItems::new(
+                WalletToDappInteractionAuthRequestResponseItem::UsePersona(
+                    WalletToDappInteractionAuthUsePersonaRequestResponseItem::new(
+                        DappWalletInteractionPersona::new(
+                            IdentityAddress::from_str("identity_tdx_2_12fat0nh0gymw9j4rqka5344p3h3r86x4z0hkw2v78r03pt0kfv0qva")
+                                .unwrap(),
+                            "alfz_psf",
+                        )
+                    )
+                ),
+                None,
+                None,
                 None,
                 None,
                 WalletToDappInteractionProofOfOwnershipRequestResponseItem::new(
                     DappToWalletInteractionAuthChallengeNonce(Exactly32Bytes::from_hex("4c85e4a903ab97450ef83763f8d4ca55a43efe843e1d2ced78a4940e5c397c9c").unwrap()),
                     vec![WalletToDappInteractionProofOfOwnership::Account(WalletToDappInteractionAccountProof::new(
-                        AccountAddress::from_str("account_tdx_2_12ytkalad6hfxamsz4a7r8tevz7ahurfj58dlp4phl4nca5hs0hpu90").unwrap(), 
+                        AccountAddress::from_str("account_tdx_2_12ytkalad6hfxamsz4a7r8tevz7ahurfj58dlp4phl4nca5hs0hpu90").unwrap(),
                         WalletToDappInteractionAuthProof::new(
                             PublicKey::from_str("ff8aee4c625738e35d837edb11e33b8abe0d6f40849ca1451edaba84d04d0699")
-                            .unwrap(),
+                                .unwrap(),
                             SLIP10Curve::Curve25519,
                             Signature::from_str("10177ac7d486691777133ffe59d46d55529d86cb1c4ce66aa82f432372f33e24d803d8498f42e26fe113c030fce68c526aeacff94334ba5a7f7ef84c2936eb05")
-                            .unwrap()
+                                .unwrap()
                         ),
                     ))]
                 ),
-            ),
+            )
         );
 
         let account_proof_response = WalletToDappInteractionResponse::Success(
@@ -874,8 +908,19 @@ mod wallet_to_dapp_interaction_tests {
         );
 
         let accounts_and_persona_proof_response_items =
-        WalletToDappInteractionResponseItems::UnauthorizedRequest(
-            WalletToDappInteractionUnauthorizedRequestResponseItems::new(
+        WalletToDappInteractionResponseItems::AuthorizedRequest(
+            WalletToDappInteractionAuthorizedRequestResponseItems::new(
+                WalletToDappInteractionAuthRequestResponseItem::UsePersona(
+                    WalletToDappInteractionAuthUsePersonaRequestResponseItem::new(
+                        DappWalletInteractionPersona::new(
+                            IdentityAddress::from_str("identity_tdx_2_12fat0nh0gymw9j4rqka5344p3h3r86x4z0hkw2v78r03pt0kfv0qva")
+                                .unwrap(),
+                            "pao13",
+                        )
+                    )
+                ),
+                None,
+                None,
                 None,
                 None,
                 WalletToDappInteractionProofOfOwnershipRequestResponseItem::new(


### PR DESCRIPTION
## Description
This PR is essentially a "rearrangement" of the models from the previous [PR](https://github.com/radixdlt/sargon/pull/228). Specifically, it moves the proof of ownership to the authorized request. Relevant discussion [here](https://rdxworks.slack.com/archives/C07MXKW8659/p1729495704170929). 

[This is my first PR in Sargon](https://tenor.com/hBKAmPGW5BD.gif)! 

