### PR TITLE
Expose `askForBiometrics()` to host

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2759,7 +2759,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.1.66"
+version = "1.1.67"
 dependencies = [
  "actix-rt",
  "aes-gcm",
@@ -2814,7 +2814,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-uniffi"
-version = "1.1.66"
+version = "1.1.67"
 dependencies = [
  "actix-rt",
  "assert-json-diff",

--- a/crates/sargon-uniffi/Cargo.toml
+++ b/crates/sargon-uniffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sargon-uniffi"
 # Don't forget to update version in crates/sargon/Cargo.toml
-version = "1.1.66"
+version = "1.1.67"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/sargon/Cargo.toml
+++ b/crates/sargon/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sargon"
 # Don't forget to update version in crates/sargon-uniffi/Cargo.toml
-version = "1.1.66"
+version = "1.1.67"
 edition = "2021"
 build = "build.rs"
 

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/os/driver/AndroidBiometricAuthorizationDriver.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/os/driver/AndroidBiometricAuthorizationDriver.kt
@@ -63,7 +63,7 @@ class BiometricsHandler(
             .launchIn(activity.lifecycleScope)
     }
 
-    internal suspend fun askForBiometrics(): Result<Unit> {
+    suspend fun askForBiometrics(): Result<Unit> {
         // Suspend until an activity is subscribed to this channel and is at least started
         biometricRequestsChannel.send(Unit)
 


### PR DESCRIPTION
> [!note]
> Kotlin only change

In order for the secure storage driver to work with the android system and encrypt/decrypt data successfully, biometrics need to be provided. In order to ask for biometrics on Android, we need a reference to the activity/context that is currently visible in order to show the dialog for biometrics. 

This has already been handled by exposing a `BiometricsHandler` kotlin class that bridges this gap. Although the `askForBiometrics()` method was kept internal to the sargon kotlin library. There is real value to expose such method to host. The host can reuse the same mechanism and offload the biometrics authentication to `BiometricsHandler` improving the code on our view models.