### PR TITLE
disable pre-derivation of factor sources in prod.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2759,7 +2759,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.1.70"
+version = "1.1.71"
 dependencies = [
  "actix-rt",
  "aes-gcm",
@@ -2814,7 +2814,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-uniffi"
-version = "1.1.70"
+version = "1.1.71"
 dependencies = [
  "actix-rt",
  "assert-json-diff",

--- a/crates/sargon-uniffi/Cargo.toml
+++ b/crates/sargon-uniffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sargon-uniffi"
 # Don't forget to update version in crates/sargon/Cargo.toml
-version = "1.1.70"
+version = "1.1.71"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/sargon/Cargo.toml
+++ b/crates/sargon/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sargon"
 # Don't forget to update version in crates/sargon-uniffi/Cargo.toml
-version = "1.1.70"
+version = "1.1.71"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/sargon/src/system/sargon_os/sargon_os.rs
+++ b/crates/sargon/src/system/sargon_os/sargon_os.rs
@@ -108,6 +108,10 @@ impl SargonOS {
         &self,
         should_pre_derive_instances: bool,
     ) -> Result<()> {
+        if should_pre_derive_instances {
+            #[cfg(not(test))]
+            warn!("Pre-deriving instances is not supported in production yet. Param `should_pre_derive_instances` ignored.");
+        }
         self.new_wallet_with_mnemonic(None, should_pre_derive_instances)
             .await
     }
@@ -133,6 +137,8 @@ impl SargonOS {
         }
 
         if should_pre_derive_instances {
+            #[cfg(test)]
+            // only tests for now, need more work in hosts before we can do this in prod
             self.pre_derive_and_fill_cache_with_instances_for_factor_source(
                 bdfs.clone().factor_source.into(),
             )

--- a/crates/sargon/src/system/sargon_os/sargon_os_factors.rs
+++ b/crates/sargon/src/system/sargon_os/sargon_os_factors.rs
@@ -218,6 +218,7 @@ impl SargonOS {
 }
 
 impl SargonOS {
+    #[cfg(test)] // only for test for now, need integration work in hosts before enabling this
     pub async fn pre_derive_and_fill_cache_with_instances_for_factor_source(
         &self,
         factor_source: FactorSource,
@@ -293,12 +294,13 @@ impl SargonOS {
             new_factors_only.iter().any(|x| x.is_main_bdfs());
         let id_of_old_bdfs = self.bdfs()?.factor_source_id();
 
-        // Use FactorInstancesProvider to eagerly fill cache...
-
         for factor_source in new_factors_only.iter() {
             if !factor_source.factor_source_id().is_hash() {
                 continue;
             }
+            // Use FactorInstancesProvider to eagerly fill cache...
+            #[cfg(test)]
+            // only test for now, need to do more integration work in hosts before enabling this
             let _ = self
                 .pre_derive_and_fill_cache_with_instances_for_factor_source(
                     factor_source,


### PR DESCRIPTION
I had accidentally missed some exucution paths in which we eagerly pre-derived FactorInstances for FactorSources. 

This PR gates pre-derivation behind `cfg(test)`. It is not possible for hosts to trigger prederivation. meaning passing `true` for `should_pre_derive_instances` to `new_wallet` is NOOP from hosts (I log a warning about it).