### PR TITLE
lift HasSampleValues restriction on Signable trait

### DIFF
--- a/crates/sargon/src/signing/host_interaction/sign_request.rs
+++ b/crates/sargon/src/signing/host_interaction/sign_request.rs
@@ -61,7 +61,11 @@ impl<S: Signable> SignRequest<S> {
     }
 }
 
-impl<S: Signable> HasSampleValues for SignRequest<S> {
+impl<S: Signable + HasSampleValues> HasSampleValues for SignRequest<S>
+where
+    S::Payload: HasSampleValues,
+    S::ID: HasSampleValues,
+{
     fn sample() -> Self {
         Self::new(
             FactorSourceKind::sample(),

--- a/crates/sargon/src/signing/host_interaction/sign_response.rs
+++ b/crates/sargon/src/signing/host_interaction/sign_response.rs
@@ -30,7 +30,7 @@ impl<ID: SignableID> SignResponse<ID> {
     }
 }
 
-impl<ID: SignableID> HasSampleValues for SignResponse<ID> {
+impl<ID: SignableID + HasSampleValues> HasSampleValues for SignResponse<ID> {
     fn sample() -> Self {
         let hd_signature = HDSignature::sample();
         let factor_source_id = hd_signature

--- a/crates/sargon/src/signing/host_interaction/transaction_sign_request_input.rs
+++ b/crates/sargon/src/signing/host_interaction/transaction_sign_request_input.rs
@@ -53,7 +53,11 @@ impl<S: Signable> TransactionSignRequestInput<S> {
     }
 }
 
-impl<S: Signable> HasSampleValues for TransactionSignRequestInput<S> {
+impl<S: Signable + HasSampleValues> HasSampleValues
+    for TransactionSignRequestInput<S>
+where
+    S::Payload: HasSampleValues,
+{
     fn sample() -> Self {
         let owned_factor_instance = OwnedFactorInstance::sample();
         let factor_source_id = &owned_factor_instance.factor_source_id();

--- a/crates/sargon/src/signing/petition_types/petition_for_entity.rs
+++ b/crates/sargon/src/signing/petition_types/petition_for_entity.rs
@@ -429,7 +429,9 @@ impl<ID: SignableID> PetitionForEntity<ID> {
     }
 }
 
-impl<ID: SignableID> HasSampleValues for PetitionForEntity<ID> {
+impl<ID: SignableID + HasSampleValues> HasSampleValues
+    for PetitionForEntity<ID>
+{
     fn sample() -> Self {
         Self::from_entity_with_role_kind(
             Account::sample_securified_mainnet(

--- a/crates/sargon/src/signing/petition_types/petition_for_factors_types/petition_for_factors/petition_for_factors_state_snapshot.rs
+++ b/crates/sargon/src/signing/petition_types/petition_for_factors_types/petition_for_factors/petition_for_factors_state_snapshot.rs
@@ -51,7 +51,9 @@ impl<ID: SignableID> PetitionForFactorsStateSnapshot<ID> {
     }
 }
 
-impl<ID: SignableID> HasSampleValues for PetitionForFactorsStateSnapshot<ID> {
+impl<ID: SignableID + HasSampleValues> HasSampleValues
+    for PetitionForFactorsStateSnapshot<ID>
+{
     fn sample() -> Self {
         Self::new(
             IndexSet::from_iter([

--- a/crates/sargon/src/signing/signables/signable.rs
+++ b/crates/sargon/src/signing/signables/signable.rs
@@ -4,7 +4,7 @@ use std::hash::Hasher;
 /// Any type conforming to `Signable` can be used with `SignaturesCollector` and collect
 /// signatures from all involved entities according to their security structure.
 pub trait Signable:
-    std::hash::Hash + PartialEq + Eq + Clone + Debug + HasSampleValues + Send + Sync
+    std::hash::Hash + PartialEq + Eq + Clone + Debug + Send + Sync
 {
     /// A stable identifier for this `Signable`.
     type ID: SignableID;
@@ -17,7 +17,6 @@ pub trait Signable:
         + std::hash::Hash
         + Into<Self::ID>
         + From<Self>
-        + HasSampleValues
         + Send
         + Sync;
 
@@ -128,6 +127,6 @@ pub trait Signable:
 
 /// An identifier that is unique for each `Signable`
 pub trait SignableID:
-    Eq + StdHash + Clone + Debug + Into<Hash> + HasSampleValues + Send + Sync
+    Eq + StdHash + Clone + Debug + Into<Hash> + Send + Sync
 {
 }

--- a/crates/sargon/src/signing/signatures_outecome_types/maybe_signed_transactions.rs
+++ b/crates/sargon/src/signing/signatures_outecome_types/maybe_signed_transactions.rs
@@ -119,7 +119,9 @@ impl<ID: SignableID> MaybeSignedTransactions<ID> {
     }
 }
 
-impl<ID: SignableID> HasSampleValues for MaybeSignedTransactions<ID> {
+impl<ID: SignableID + HasSampleValues> HasSampleValues
+    for MaybeSignedTransactions<ID>
+{
     fn sample() -> Self {
         let tx_a = ID::sample();
 

--- a/crates/sargon/src/signing/signatures_outecome_types/sign_with_factors_outcome.rs
+++ b/crates/sargon/src/signing/signatures_outecome_types/sign_with_factors_outcome.rs
@@ -15,7 +15,9 @@ pub enum SignWithFactorsOutcome<ID: SignableID> {
     Neglected(NeglectedFactors),
 }
 
-impl<ID: SignableID> HasSampleValues for SignWithFactorsOutcome<ID> {
+impl<ID: SignableID + HasSampleValues> HasSampleValues
+    for SignWithFactorsOutcome<ID>
+{
     fn sample() -> Self {
         Self::signed(SignResponse::sample())
     }

--- a/crates/sargon/src/types/hd_signature.rs
+++ b/crates/sargon/src/types/hd_signature.rs
@@ -66,7 +66,7 @@ impl<ID: SignableID> HDSignature<ID> {
     }
 }
 
-impl<ID: SignableID> HasSampleValues for HDSignature<ID> {
+impl<ID: SignableID + HasSampleValues> HasSampleValues for HDSignature<ID> {
     fn sample() -> Self {
         Self::fake_sign_by_looking_up_mnemonic_amongst_samples(
             HDSignatureInput::<ID>::sample(),

--- a/crates/sargon/src/types/hd_signature_input.rs
+++ b/crates/sargon/src/types/hd_signature_input.rs
@@ -30,7 +30,9 @@ impl<ID: SignableID> HDSignatureInput<ID> {
     }
 }
 
-impl<ID: SignableID> HasSampleValues for HDSignatureInput<ID> {
+impl<ID: SignableID + HasSampleValues> HasSampleValues
+    for HDSignatureInput<ID>
+{
     fn sample() -> Self {
         Self::new(ID::sample(), OwnedFactorInstance::sample())
     }

--- a/crates/sargon/src/types/invalid_transaction_if_neglected.rs
+++ b/crates/sargon/src/types/invalid_transaction_if_neglected.rs
@@ -56,7 +56,9 @@ impl<ID: SignableID> InvalidTransactionIfNeglected<ID> {
     }
 }
 
-impl<ID: SignableID> HasSampleValues for InvalidTransactionIfNeglected<ID> {
+impl<ID: SignableID + HasSampleValues> HasSampleValues
+    for InvalidTransactionIfNeglected<ID>
+{
     fn sample() -> Self {
         Self::new(ID::sample(), vec![AddressOfAccountOrPersona::sample()])
     }


### PR DESCRIPTION
we use:

```rust
impl<S: Signable + HasSampleValues> HasSampleValues for SignRequest<S>
where
    S::Payload: HasSampleValues,
    S::ID: HasSampleValues,
{
...
}
```

And in many more places
