### PR TITLE
Expose biometrics failure exception

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2772,7 +2772,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.1.77"
+version = "1.1.78"
 dependencies = [
  "actix-rt",
  "aes-gcm",
@@ -2827,7 +2827,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-uniffi"
-version = "1.1.77"
+version = "1.1.78"
 dependencies = [
  "actix-rt",
  "assert-json-diff",

--- a/crates/sargon-uniffi/Cargo.toml
+++ b/crates/sargon-uniffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sargon-uniffi"
 # Don't forget to update version in crates/sargon/Cargo.toml
-version = "1.1.77"
+version = "1.1.78"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/sargon/Cargo.toml
+++ b/crates/sargon/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sargon"
 # Don't forget to update version in crates/sargon-uniffi/Cargo.toml
-version = "1.1.77"
+version = "1.1.78"
 edition = "2021"
 build = "build.rs"
 

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/os/driver/AndroidBiometricAuthorizationDriver.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/os/driver/AndroidBiometricAuthorizationDriver.kt
@@ -9,6 +9,9 @@ import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
+import com.radixdlt.sargon.CommonException
+import com.radixdlt.sargon.SecureStorageAccessErrorKind
+import com.radixdlt.sargon.SecureStorageKey
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.launchIn
@@ -25,11 +28,36 @@ internal interface BiometricAuthorizationDriver {
 
 }
 
-internal class BiometricsFailure(
+class BiometricsFailure(
     @AuthenticationError
     val errorCode: Int,
     val errorMessage: String?
-) : Exception("[$errorCode] $errorMessage")
+) : Exception("[$errorCode] $errorMessage") {
+
+    fun toCommonException(
+        key: SecureStorageKey
+    ): CommonException = CommonException.SecureStorageAccessException(
+        key = key,
+        errorKind = when (errorCode) {
+            BiometricPrompt.ERROR_CANCELED -> SecureStorageAccessErrorKind.CANCELLED
+            BiometricPrompt.ERROR_HW_NOT_PRESENT -> SecureStorageAccessErrorKind.HARDWARE_NOT_PRESENT
+            BiometricPrompt.ERROR_HW_UNAVAILABLE -> SecureStorageAccessErrorKind.HARDWARE_UNAVAILABLE
+            BiometricPrompt.ERROR_LOCKOUT -> SecureStorageAccessErrorKind.LOCKOUT
+            BiometricPrompt.ERROR_LOCKOUT_PERMANENT -> SecureStorageAccessErrorKind.LOCKOUT_PERMANENT
+            BiometricPrompt.ERROR_NEGATIVE_BUTTON -> SecureStorageAccessErrorKind.NEGATIVE_BUTTON
+            BiometricPrompt.ERROR_NO_BIOMETRICS -> SecureStorageAccessErrorKind.NO_BIOMETRICS
+            BiometricPrompt.ERROR_NO_DEVICE_CREDENTIAL -> SecureStorageAccessErrorKind.NO_DEVICE_CREDENTIAL
+            BiometricPrompt.ERROR_NO_SPACE -> SecureStorageAccessErrorKind.NO_SPACE
+            BiometricPrompt.ERROR_TIMEOUT -> SecureStorageAccessErrorKind.TIMEOUT
+            BiometricPrompt.ERROR_UNABLE_TO_PROCESS -> SecureStorageAccessErrorKind.UNABLE_TO_PROCESS
+            BiometricPrompt.ERROR_USER_CANCELED -> SecureStorageAccessErrorKind.USER_CANCELLED
+            BiometricPrompt.ERROR_VENDOR -> SecureStorageAccessErrorKind.VENDOR
+            else -> throw CommonException.Unknown()
+        },
+        errorMessage = errorMessage.orEmpty()
+    )
+
+}
 
 internal class AndroidBiometricAuthorizationDriver(
     private val biometricsHandler: BiometricsHandler

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/os/driver/AndroidStorageDriver.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/os/driver/AndroidStorageDriver.kt
@@ -1,11 +1,9 @@
 package com.radixdlt.sargon.os.driver
 
-import androidx.biometric.BiometricPrompt
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import com.radixdlt.sargon.BagOfBytes
 import com.radixdlt.sargon.CommonException
-import com.radixdlt.sargon.SecureStorageAccessErrorKind
 import com.radixdlt.sargon.SecureStorageDriver
 import com.radixdlt.sargon.SecureStorageKey
 import com.radixdlt.sargon.UnsafeStorageDriver
@@ -120,25 +118,4 @@ internal class AndroidStorageDriver(
             else -> CommonException.UnsafeStorageWriteException()
         }
     }
-
-    private fun BiometricsFailure.toCommonException(key: SecureStorageKey) = CommonException.SecureStorageAccessException(
-        key = key,
-        errorKind = when (errorCode) {
-            BiometricPrompt.ERROR_CANCELED -> SecureStorageAccessErrorKind.CANCELLED
-            BiometricPrompt.ERROR_HW_NOT_PRESENT -> SecureStorageAccessErrorKind.HARDWARE_NOT_PRESENT
-            BiometricPrompt.ERROR_HW_UNAVAILABLE -> SecureStorageAccessErrorKind.HARDWARE_UNAVAILABLE
-            BiometricPrompt.ERROR_LOCKOUT -> SecureStorageAccessErrorKind.LOCKOUT
-            BiometricPrompt.ERROR_LOCKOUT_PERMANENT -> SecureStorageAccessErrorKind.LOCKOUT_PERMANENT
-            BiometricPrompt.ERROR_NEGATIVE_BUTTON -> SecureStorageAccessErrorKind.NEGATIVE_BUTTON
-            BiometricPrompt.ERROR_NO_BIOMETRICS -> SecureStorageAccessErrorKind.NO_BIOMETRICS
-            BiometricPrompt.ERROR_NO_DEVICE_CREDENTIAL -> SecureStorageAccessErrorKind.NO_DEVICE_CREDENTIAL
-            BiometricPrompt.ERROR_NO_SPACE -> SecureStorageAccessErrorKind.NO_SPACE
-            BiometricPrompt.ERROR_TIMEOUT -> SecureStorageAccessErrorKind.TIMEOUT
-            BiometricPrompt.ERROR_UNABLE_TO_PROCESS -> SecureStorageAccessErrorKind.UNABLE_TO_PROCESS
-            BiometricPrompt.ERROR_USER_CANCELED -> SecureStorageAccessErrorKind.USER_CANCELLED
-            BiometricPrompt.ERROR_VENDOR -> SecureStorageAccessErrorKind.VENDOR
-            else -> throw CommonException.Unknown()
-        },
-        errorMessage = errorMessage.orEmpty()
-    )
 }


### PR DESCRIPTION
This exception is needed to be `public` instead of `internal` so we can convert it back to common exception from host.

Specifically when using biometrics from host and want to return the error back to sargon (when using signing interactor), the ideal is to use the same error the secure storage driver would. That is why the `BiometricsFailure` is now public and the method inside `toCommonException` is public too.