### PR TITLE
[ABW-3969] Shield Setup Select Factors - utility functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2772,7 +2772,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.1.78"
+version = "1.1.79"
 dependencies = [
  "actix-rt",
  "aes-gcm",
@@ -2827,7 +2827,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-uniffi"
-version = "1.1.78"
+version = "1.1.79"
 dependencies = [
  "actix-rt",
  "assert-json-diff",

--- a/apple/Sources/Sargon/Extensions/Methods/Profile/MFA/SecurityShieldBuilder+Wrap+Functions.swift
+++ b/apple/Sources/Sargon/Extensions/Methods/Profile/MFA/SecurityShieldBuilder+Wrap+Functions.swift
@@ -1,0 +1,12 @@
+import Foundation
+import SargonUniFFI
+
+extension SecurityShieldBuilder {
+	public static func sortFactorSourcesForSelection(factorSources: [FactorSource]) -> [FactorSource] {
+		securityShieldBuilderSortFactorSourcesForSelection(factorSources: factorSources)
+	}
+
+	public static func selectedFactorSourcesStatus(factorSources: [FactorSource]) -> SelectedFactorSourcesStatus {
+		securityShieldBuilderSelectedFactorSourcesStatus(factorSources: factorSources)
+	}
+}

--- a/apple/Sources/Sargon/Extensions/Methods/Profile/MFA/SecurityShieldBuilder+Wrap+Functions.swift
+++ b/apple/Sources/Sargon/Extensions/Methods/Profile/MFA/SecurityShieldBuilder+Wrap+Functions.swift
@@ -5,8 +5,4 @@ extension SecurityShieldBuilder {
 	public static func sortedFactorSourcesForSelection(factorSources: [FactorSource]) -> [FactorSource] {
 		securityShieldBuilderSortedFactorSourcesForSelection(factorSources: factorSources)
 	}
-
-	public static func selectedFactorSourcesStatus(factorSources: [FactorSource]) -> SelectedFactorSourcesStatus {
-		securityShieldBuilderSelectedFactorSourcesStatus(factorSources: factorSources)
-	}
 }

--- a/apple/Sources/Sargon/Extensions/Methods/Profile/MFA/SecurityShieldBuilder+Wrap+Functions.swift
+++ b/apple/Sources/Sargon/Extensions/Methods/Profile/MFA/SecurityShieldBuilder+Wrap+Functions.swift
@@ -2,8 +2,8 @@ import Foundation
 import SargonUniFFI
 
 extension SecurityShieldBuilder {
-	public static func sortFactorSourcesForSelection(factorSources: [FactorSource]) -> [FactorSource] {
-		securityShieldBuilderSortFactorSourcesForSelection(factorSources: factorSources)
+	public static func sortedFactorSourcesForSelection(factorSources: [FactorSource]) -> [FactorSource] {
+		securityShieldBuilderSortedFactorSourcesForSelection(factorSources: factorSources)
 	}
 
 	public static func selectedFactorSourcesStatus(factorSources: [FactorSource]) -> SelectedFactorSourcesStatus {

--- a/apple/Sources/Sargon/Extensions/Methods/Profile/MFA/SecurityShieldBuilder+Wrap+Functions.swift
+++ b/apple/Sources/Sargon/Extensions/Methods/Profile/MFA/SecurityShieldBuilder+Wrap+Functions.swift
@@ -1,8 +1,0 @@
-import Foundation
-import SargonUniFFI
-
-extension SecurityShieldBuilder {
-	public static func sortedFactorSourcesForSelection(factorSources: [FactorSource]) -> [FactorSource] {
-		securityShieldBuilderSortedFactorSourcesForSelection(factorSources: factorSources)
-	}
-}

--- a/apple/Sources/Sargon/Extensions/Methods/SecurityCenter/SecurityProblemKind+Wrap+Functions.swift
+++ b/apple/Sources/Sargon/Extensions/Methods/SecurityCenter/SecurityProblemKind+Wrap+Functions.swift
@@ -3,6 +3,6 @@ import SargonUniFFI
 
 extension SecurityProblemKind: CaseIterable {
 	public static var allCases: [SecurityProblemKind] {
-		[.configurationBackup, .securityFactors]
+		[.securityShields, .securityFactors, .configurationBackup]
 	}
 }

--- a/apple/Tests/TestCases/Profile/MFA/SecurityShieldsBuilderTests.swift
+++ b/apple/Tests/TestCases/Profile/MFA/SecurityShieldsBuilderTests.swift
@@ -225,12 +225,6 @@ struct ShieldTests {
 		#expect(shield.matrixOfFactors.confirmationRole.thresholdFactors == [])
 	}
 
-	@Test("sorted factor sources for selection")
-	func sortedFactorSourcesForSelection() {
-		let factorSources = [FactorSource.sampleOther, .sample]
-		#expect(SecurityShieldBuilder.sortedFactorSourcesForSelection(factorSources: factorSources) == [FactorSource.sample, .sampleOther])
-	}
-
 	@Test("selected factor sources for role status")
 	func selectedFactorSourcesForRoleStatus() {
 		let builder = SecurityShieldBuilder()

--- a/apple/Tests/TestCases/Profile/MFA/SecurityShieldsBuilderTests.swift
+++ b/apple/Tests/TestCases/Profile/MFA/SecurityShieldsBuilderTests.swift
@@ -231,9 +231,15 @@ struct ShieldTests {
 		#expect(SecurityShieldBuilder.sortedFactorSourcesForSelection(factorSources: factorSources) == [FactorSource.sample, .sampleOther])
 	}
 
-	@Test("selected factor sources status")
-	func selectedFactorSourcesStatus() {
-		#expect(SecurityShieldBuilder.selectedFactorSourcesStatus(factorSources: [FactorSource.sample]) == .suboptimal)
+	@Test("selected factor sources for role status")
+	func selectedFactorSourcesForRoleStatus() {
+		let builder = SecurityShieldBuilder()
+		builder.addFactorSourceToPrimaryThreshold(factorSourceId: .samplePassword)
+		builder.addFactorSourceToRecoveryOverride(factorSourceId: .sampleLedger)
+
+		#expect(builder.selectedFactorSourcesForRoleStatus(role: .primary) == .invalid)
+		#expect(builder.selectedFactorSourcesForRoleStatus(role: .recovery) == .optimal)
+		#expect(builder.selectedFactorSourcesForRoleStatus(role: .confirmation) == .insufficient)
 	}
 }
 

--- a/apple/Tests/TestCases/Profile/MFA/SecurityShieldsBuilderTests.swift
+++ b/apple/Tests/TestCases/Profile/MFA/SecurityShieldsBuilderTests.swift
@@ -225,10 +225,10 @@ struct ShieldTests {
 		#expect(shield.matrixOfFactors.confirmationRole.thresholdFactors == [])
 	}
 
-	@Test("sort factor sources for selection")
-	func sortFactorSourcesForSelection() {
+	@Test("sorted factor sources for selection")
+	func sortedFactorSourcesForSelection() {
 		let factorSources = [FactorSource.sampleOther, .sample]
-		#expect(SecurityShieldBuilder.sortFactorSourcesForSelection(factorSources: factorSources) == [FactorSource.sample, .sampleOther])
+		#expect(SecurityShieldBuilder.sortedFactorSourcesForSelection(factorSources: factorSources) == [FactorSource.sample, .sampleOther])
 	}
 
 	@Test("selected factor sources status")

--- a/apple/Tests/TestCases/Profile/MFA/SecurityShieldsBuilderTests.swift
+++ b/apple/Tests/TestCases/Profile/MFA/SecurityShieldsBuilderTests.swift
@@ -224,6 +224,17 @@ struct ShieldTests {
 		#expect(shield.matrixOfFactors.confirmationRole.overrideFactors == [.sampleDevice])
 		#expect(shield.matrixOfFactors.confirmationRole.thresholdFactors == [])
 	}
+
+	@Test("sort factor sources for selection")
+	func sortFactorSourcesForSelection() {
+		let factorSources = [FactorSource.sampleOther, .sample]
+		#expect(SecurityShieldBuilder.sortFactorSourcesForSelection(factorSources: factorSources) == [FactorSource.sample, .sampleOther])
+	}
+
+	@Test("selected factor sources status")
+	func selectedFactorSourcesStatus() {
+		#expect(SecurityShieldBuilder.selectedFactorSourcesStatus(factorSources: [FactorSource.sample]) == .suboptimal)
+	}
 }
 
 #if DEBUG

--- a/crates/sargon-uniffi/Cargo.toml
+++ b/crates/sargon-uniffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sargon-uniffi"
 # Don't forget to update version in crates/sargon/Cargo.toml
-version = "1.1.78"
+version = "1.1.79"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/sargon-uniffi/src/profile/mfa/security_structures/mod.rs
+++ b/crates/sargon-uniffi/src/profile/mfa/security_structures/mod.rs
@@ -7,6 +7,7 @@ mod security_shield_prerequisites_status;
 mod security_structure_id;
 mod security_structure_metadata;
 mod security_structures;
+mod selected_factor_sources_status;
 
 pub use matrices::*;
 pub use models::*;
@@ -16,3 +17,4 @@ pub use security_shield_prerequisites_status::*;
 pub use security_structure_id::*;
 pub use security_structure_metadata::*;
 pub use security_structures::*;
+pub use selected_factor_sources_status::*;

--- a/crates/sargon-uniffi/src/profile/mfa/security_structures/security_shield_builder.rs
+++ b/crates/sargon-uniffi/src/profile/mfa/security_structures/security_shield_builder.rs
@@ -411,7 +411,7 @@ pub fn security_shield_builder_sort_factor_sources_for_selection(
 }
 
 #[uniffi::export]
-pub fn selected_factor_sources_status(
+pub fn security_shield_builder_selected_factor_sources_status(
     factor_sources: Vec<FactorSource>,
 ) -> SelectedFactorSourcesStatus {
     SelectedFactorSourcesStatus::from(

--- a/crates/sargon-uniffi/src/profile/mfa/security_structures/security_shield_builder.rs
+++ b/crates/sargon-uniffi/src/profile/mfa/security_structures/security_shield_builder.rs
@@ -400,11 +400,11 @@ impl SecurityShieldBuilder {
 // ==== STATIC ====
 // ================
 #[uniffi::export]
-pub fn security_shield_builder_sort_factor_sources_for_selection(
+pub fn security_shield_builder_sorted_factor_sources_for_selection(
     factor_sources: Vec<FactorSource>,
 ) -> Vec<FactorSource> {
     let factors =
-        InternalSecurityShieldBuilder::sort_factor_sources_for_selection(
+        InternalSecurityShieldBuilder::sorted_factor_sources_for_selection(
             factor_sources.into_internal(),
         );
     factors.into_iter().map(FactorSource::from).collect()

--- a/crates/sargon-uniffi/src/profile/mfa/security_structures/security_shield_builder.rs
+++ b/crates/sargon-uniffi/src/profile/mfa/security_structures/security_shield_builder.rs
@@ -406,6 +406,19 @@ impl SecurityShieldBuilder {
         })
     }
 
+    pub fn sorted_factor_sources_for_primary_threshold_selection(
+        &self,
+        factor_sources: Vec<FactorSource>,
+    ) -> Vec<FactorSource> {
+        self.get(|builder| {
+            builder
+                .sorted_factor_sources_for_primary_threshold_selection(
+                    factor_sources.clone().into_internal(),
+                )
+                .into_type()
+        })
+    }
+
     pub fn build(
         &self,
     ) -> Result<
@@ -416,20 +429,6 @@ impl SecurityShieldBuilder {
             .map(|shield| shield.into())
             .map_err(|x| x.into())
     }
-}
-
-// ================
-// ==== STATIC ====
-// ================
-#[uniffi::export]
-pub fn security_shield_builder_sorted_factor_sources_for_selection(
-    factor_sources: Vec<FactorSource>,
-) -> Vec<FactorSource> {
-    let factors =
-        InternalSecurityShieldBuilder::sorted_factor_sources_for_selection(
-            factor_sources.into_internal(),
-        );
-    factors.into_iter().map(FactorSource::from).collect()
 }
 
 impl FactorSourceID {

--- a/crates/sargon-uniffi/src/profile/mfa/security_structures/security_shield_builder.rs
+++ b/crates/sargon-uniffi/src/profile/mfa/security_structures/security_shield_builder.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use sargon::SecurityShieldBuilder as InternalSecurityShieldBuilder;
-use sargon::SelectedFactorSourcesStatus as InternalSelectedFactorSourcesStatus;
+use sargon::SelectedFactorSourcesForRoleStatus as InternalSelectedFactorSourcesForRoleStatus;
 use sargon::{IndexSet, MatrixBuilder};
 
 use crate::prelude::*;
@@ -384,6 +384,28 @@ impl SecurityShieldBuilder {
         self.get(|builder| builder.validate().map(|x| x.into()))
     }
 
+    pub fn validate_role_in_isolation(
+        &self,
+        role: RoleKind,
+    ) -> Option<SecurityShieldBuilderInvalidReason> {
+        self.get(|builder| {
+            builder
+                .validate_role_in_isolation(role.into_internal())
+                .map(|x| x.into())
+        })
+    }
+
+    pub fn selected_factor_sources_for_role_status(
+        &self,
+        role: RoleKind,
+    ) -> SelectedFactorSourcesForRoleStatus {
+        self.get(|builder| {
+            builder
+                .selected_factor_sources_for_role_status(role.into_internal())
+                .into()
+        })
+    }
+
     pub fn build(
         &self,
     ) -> Result<
@@ -408,17 +430,6 @@ pub fn security_shield_builder_sorted_factor_sources_for_selection(
             factor_sources.into_internal(),
         );
     factors.into_iter().map(FactorSource::from).collect()
-}
-
-#[uniffi::export]
-pub fn security_shield_builder_selected_factor_sources_status(
-    factor_sources: Vec<FactorSource>,
-) -> SelectedFactorSourcesStatus {
-    SelectedFactorSourcesStatus::from(
-        InternalSecurityShieldBuilder::selected_factor_sources_status(
-            factor_sources.into_internal(),
-        ),
-    )
 }
 
 impl FactorSourceID {

--- a/crates/sargon-uniffi/src/profile/mfa/security_structures/security_shield_builder.rs
+++ b/crates/sargon-uniffi/src/profile/mfa/security_structures/security_shield_builder.rs
@@ -7,6 +7,8 @@ use std::{
     sync::{Arc, RwLock},
 };
 
+use sargon::SecurityShieldBuilder as InternalSecurityShieldBuilder;
+use sargon::SelectedFactorSourcesStatus as InternalSelectedFactorSourcesStatus;
 use sargon::{IndexSet, MatrixBuilder};
 
 use crate::prelude::*;
@@ -392,6 +394,31 @@ impl SecurityShieldBuilder {
             .map(|shield| shield.into())
             .map_err(|x| x.into())
     }
+}
+
+// ================
+// ==== STATIC ====
+// ================
+#[uniffi::export]
+pub fn security_shield_builder_sort_factor_sources_for_selection(
+    factor_sources: Vec<FactorSource>,
+) -> Vec<FactorSource> {
+    let factors =
+        InternalSecurityShieldBuilder::sort_factor_sources_for_selection(
+            factor_sources.into_internal(),
+        );
+    factors.into_iter().map(FactorSource::from).collect()
+}
+
+#[uniffi::export]
+pub fn selected_factor_sources_status(
+    factor_sources: Vec<FactorSource>,
+) -> SelectedFactorSourcesStatus {
+    SelectedFactorSourcesStatus::from(
+        InternalSecurityShieldBuilder::selected_factor_sources_status(
+            factor_sources.into_internal(),
+        ),
+    )
 }
 
 impl FactorSourceID {

--- a/crates/sargon-uniffi/src/profile/mfa/security_structures/selected_factor_sources_status.rs
+++ b/crates/sargon-uniffi/src/profile/mfa/security_structures/selected_factor_sources_status.rs
@@ -1,17 +1,29 @@
 use crate::prelude::*;
-use sargon::SelectedFactorSourcesStatus as InternalSelectedFactorSourcesStatus;
+use sargon::SelectedFactorSourcesForRoleStatus as InternalSelectedFactorSourcesForRoleStatus;
 
-/// Represents the status of selected factor sources in the Security Shield building process.
+/// Represents the status of selected factor sources for a specific role in the Security Shield building process.
+/// Primarily used for UI logic representation in host applications.
 #[derive(
     Clone, Copy, Debug, PartialEq, Eq, InternalConversion, uniffi::Enum,
 )]
-pub enum SelectedFactorSourcesStatus {
-    /// The selected factor sources are insufficient to build a Security Shield.
-    Insufficient,
+pub enum SelectedFactorSourcesForRoleStatus {
+    /// The selected factor sources are optimal for the specified role
+    /// in the Security Shield building process.
+    Optimal,
 
-    /// The selected factor sources are suboptimal for building a Security Shield.
+    /// The selected factor sources are suboptimal for the specified role
+    /// in the Security Shield building process.
+    ///
+    /// Note: Typically used in hosts as a warning message.
     Suboptimal,
 
-    /// The selected factor sources are optimal for building a Security Shield.
-    Optimal,
+    /// The selected factor sources are insufficient for the specified role
+    /// in the Security Shield building process.
+    Insufficient,
+
+    /// The selected factor sources form an invalid combination for the specified role
+    /// in the Security Shield building process.
+    ///
+    /// Example: A Password factor source cannot be used alone for the Primary role.
+    Invalid,
 }

--- a/crates/sargon-uniffi/src/profile/mfa/security_structures/selected_factor_sources_status.rs
+++ b/crates/sargon-uniffi/src/profile/mfa/security_structures/selected_factor_sources_status.rs
@@ -1,0 +1,17 @@
+use crate::prelude::*;
+use sargon::SelectedFactorSourcesStatus as InternalSelectedFactorSourcesStatus;
+
+/// Represents the status of selected factor sources in the Security Shield building process.
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, InternalConversion, uniffi::Enum,
+)]
+pub enum SelectedFactorSourcesStatus {
+    /// The selected factor sources are insufficient to build a Security Shield.
+    Insufficient,
+
+    /// The selected factor sources are suboptimal for building a Security Shield.
+    Suboptimal,
+
+    /// The selected factor sources are optimal for building a Security Shield.
+    Optimal,
+}

--- a/crates/sargon/Cargo.toml
+++ b/crates/sargon/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sargon"
 # Don't forget to update version in crates/sargon-uniffi/Cargo.toml
-version = "1.1.78"
+version = "1.1.79"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/sargon/src/profile/mfa/security_structures/matrices/builder/matrix_builder.rs
+++ b/crates/sargon/src/profile/mfa/security_structures/matrices/builder/matrix_builder.rs
@@ -151,16 +151,37 @@ impl MatrixBuilder {
             )
     }
 
-    fn validate_each_role_in_isolation(&self) -> MatrixBuilderMutateResult {
+    pub fn validate_primary_role_in_isolation(
+        &self,
+    ) -> MatrixBuilderMutateResult {
         self.primary_role
             .validate()
             .into_matrix_err(RoleKind::Primary)?;
+        Ok(())
+    }
+
+    pub fn validate_recovery_role_in_isolation(
+        &self,
+    ) -> MatrixBuilderMutateResult {
         self.recovery_role
             .validate()
             .into_matrix_err(RoleKind::Recovery)?;
+        Ok(())
+    }
+
+    pub fn validate_confirmation_role_in_isolation(
+        &self,
+    ) -> MatrixBuilderMutateResult {
         self.confirmation_role
             .validate()
             .into_matrix_err(RoleKind::Confirmation)?;
+        Ok(())
+    }
+
+    fn validate_each_role_in_isolation(&self) -> MatrixBuilderMutateResult {
+        self.validate_primary_role_in_isolation()?;
+        self.validate_recovery_role_in_isolation()?;
+        self.validate_confirmation_role_in_isolation()?;
         Ok(())
     }
 

--- a/crates/sargon/src/profile/mfa/security_structures/mod.rs
+++ b/crates/sargon/src/profile/mfa/security_structures/mod.rs
@@ -7,6 +7,7 @@ mod security_shield_prerequisites_status;
 mod security_structure_id;
 mod security_structure_metadata;
 mod security_structure_of_factors;
+mod selected_factor_sources_status;
 
 pub use has_role_kind::*;
 pub use matrices::*;
@@ -17,3 +18,4 @@ pub use security_shield_prerequisites_status::*;
 pub use security_structure_id::*;
 pub use security_structure_metadata::*;
 pub use security_structure_of_factors::*;
+pub use selected_factor_sources_status::*;

--- a/crates/sargon/src/profile/mfa/security_structures/security_shield_builder.rs
+++ b/crates/sargon/src/profile/mfa/security_structures/security_shield_builder.rs
@@ -459,6 +459,31 @@ impl SecurityShieldBuilder {
     }
 }
 
+// ================
+// ==== STATIC ====
+// ================
+impl SecurityShieldBuilder {
+    pub fn sort_factor_sources_for_selection(
+        factor_sources: Vec<FactorSource>,
+    ) -> Vec<FactorSource> {
+        let mut sorted = factor_sources;
+        sorted.sort_by_key(|fs| fs.factor_source_kind().display_order());
+        sorted
+    }
+
+    pub fn selected_factor_sources_status(
+        factor_sources: Vec<FactorSource>,
+    ) -> SelectedFactorSourcesStatus {
+        if factor_sources.is_empty() {
+            SelectedFactorSourcesStatus::Insufficient
+        } else if factor_sources.len() == 1 {
+            SelectedFactorSourcesStatus::Suboptimal
+        } else {
+            SelectedFactorSourcesStatus::Optimal
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
 
@@ -723,6 +748,62 @@ mod tests {
             )
             .collect::<Vec<_>>()
         );
+    }
+
+    #[test]
+    fn test_sort_factor_sources_for_selection() {
+        let factor_sources = FactorSource::sample_values_all();
+        let expected = vec![
+            FactorSource::sample_device_babylon(),
+            FactorSource::sample_device_babylon_other(),
+            FactorSource::sample_device_olympia(),
+            FactorSource::sample_arculus(),
+            FactorSource::sample_arculus_other(),
+            FactorSource::sample_ledger(),
+            FactorSource::sample_ledger_other(),
+            FactorSource::sample_password(),
+            FactorSource::sample_password_other(),
+            FactorSource::sample_off_device(),
+            FactorSource::sample_off_device_other(),
+            FactorSource::sample_trusted_contact_frank(),
+            FactorSource::sample_trusted_contact_grace(),
+            FactorSource::sample_trusted_contact_judy(),
+            FactorSource::sample_trusted_contact_oscar(),
+            FactorSource::sample_trusted_contact_trudy(),
+            FactorSource::sample_trusted_contact_radix(),
+            FactorSource::sample_security_questions(),
+            FactorSource::sample_security_questions_other(),
+        ];
+        assert_eq!(
+            SUT::sort_factor_sources_for_selection(factor_sources),
+            expected
+        )
+    }
+
+    #[test]
+    fn test_selected_factor_sources_status() {
+        // Insufficient
+        assert_eq!(
+            SUT::selected_factor_sources_status(Vec::new()),
+            SelectedFactorSourcesStatus::Insufficient
+        );
+
+        // Suboptimal
+        assert_eq!(
+            SUT::selected_factor_sources_status(vec![
+                FactorSource::sample_device()
+            ]),
+            SelectedFactorSourcesStatus::Suboptimal
+        );
+
+        // Optimal
+        assert_eq!(
+            SUT::selected_factor_sources_status(vec![
+                FactorSource::sample_device(),
+                FactorSource::sample_arculus()
+            ]),
+            SelectedFactorSourcesStatus::Optimal
+        )
     }
 }
 

--- a/crates/sargon/src/profile/mfa/security_structures/security_shield_builder.rs
+++ b/crates/sargon/src/profile/mfa/security_structures/security_shield_builder.rs
@@ -463,7 +463,7 @@ impl SecurityShieldBuilder {
 // ==== STATIC ====
 // ================
 impl SecurityShieldBuilder {
-    pub fn sort_factor_sources_for_selection(
+    pub fn sorted_factor_sources_for_selection(
         factor_sources: Vec<FactorSource>,
     ) -> Vec<FactorSource> {
         let mut sorted = factor_sources;
@@ -751,7 +751,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sort_factor_sources_for_selection() {
+    fn test_sorted_factor_sources_for_selection() {
         let factor_sources = FactorSource::sample_values_all();
         let expected = vec![
             FactorSource::sample_device_babylon(),
@@ -775,7 +775,7 @@ mod tests {
             FactorSource::sample_security_questions_other(),
         ];
         assert_eq!(
-            SUT::sort_factor_sources_for_selection(factor_sources),
+            SUT::sorted_factor_sources_for_selection(factor_sources),
             expected
         )
     }

--- a/crates/sargon/src/profile/mfa/security_structures/security_shield_builder.rs
+++ b/crates/sargon/src/profile/mfa/security_structures/security_shield_builder.rs
@@ -468,6 +468,22 @@ impl SecurityShieldBuilder {
         }
     }
 
+    pub fn sorted_factor_sources_for_primary_threshold_selection(
+        &self,
+        factor_sources: Vec<FactorSource>,
+    ) -> Vec<FactorSource> {
+        let mut factor_sources: Vec<FactorSource> = factor_sources
+            .into_iter()
+            .filter(|fs| self.addition_of_factor_source_of_kind_to_primary_threshold_is_valid_or_can_be(fs.factor_source_kind()))
+            .collect();
+        factor_sources.sort_by_key(|fs| {
+            fs.factor_source_kind()
+                .display_order_for_primary_threshold_selection()
+        });
+
+        factor_sources
+    }
+
     pub fn build(
         &self,
     ) -> Result<
@@ -503,19 +519,6 @@ impl SecurityShieldBuilder {
             metadata,
         };
         Ok(shield)
-    }
-}
-
-// ================
-// ==== STATIC ====
-// ================
-impl SecurityShieldBuilder {
-    pub fn sorted_factor_sources_for_selection(
-        factor_sources: Vec<FactorSource>,
-    ) -> Vec<FactorSource> {
-        let mut sorted = factor_sources;
-        sorted.sort_by_key(|fs| fs.factor_source_kind().display_order());
-        sorted
     }
 }
 
@@ -786,7 +789,8 @@ mod tests {
     }
 
     #[test]
-    fn test_sorted_factor_sources_for_selection() {
+    fn test_sorted_factor_sources_for_primary_threshold_selection() {
+        let sut = SUT::new();
         let factor_sources = FactorSource::sample_values_all();
         let expected = vec![
             FactorSource::sample_device_babylon(),
@@ -800,17 +804,11 @@ mod tests {
             FactorSource::sample_password_other(),
             FactorSource::sample_off_device(),
             FactorSource::sample_off_device_other(),
-            FactorSource::sample_trusted_contact_frank(),
-            FactorSource::sample_trusted_contact_grace(),
-            FactorSource::sample_trusted_contact_judy(),
-            FactorSource::sample_trusted_contact_oscar(),
-            FactorSource::sample_trusted_contact_trudy(),
-            FactorSource::sample_trusted_contact_radix(),
-            FactorSource::sample_security_questions(),
-            FactorSource::sample_security_questions_other(),
         ];
         assert_eq!(
-            SUT::sorted_factor_sources_for_selection(factor_sources),
+            sut.sorted_factor_sources_for_primary_threshold_selection(
+                factor_sources
+            ),
             expected
         )
     }

--- a/crates/sargon/src/profile/mfa/security_structures/selected_factor_sources_status.rs
+++ b/crates/sargon/src/profile/mfa/security_structures/selected_factor_sources_status.rs
@@ -1,0 +1,14 @@
+use crate::prelude::*;
+
+/// Represents the status of selected factor sources in the Security Shield building process.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SelectedFactorSourcesStatus {
+    /// The selected factor sources are insufficient to build a Security Shield.
+    Insufficient,
+
+    /// The selected factor sources are suboptimal for building a Security Shield.
+    Suboptimal,
+
+    /// The selected factor sources are optimal for building a Security Shield.
+    Optimal,
+}

--- a/crates/sargon/src/profile/mfa/security_structures/selected_factor_sources_status.rs
+++ b/crates/sargon/src/profile/mfa/security_structures/selected_factor_sources_status.rs
@@ -1,14 +1,26 @@
 use crate::prelude::*;
 
-/// Represents the status of selected factor sources in the Security Shield building process.
+/// Represents the status of selected factor sources for a specific role in the Security Shield building process.
+/// Primarily used for UI logic representation in host applications.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum SelectedFactorSourcesStatus {
-    /// The selected factor sources are insufficient to build a Security Shield.
-    Insufficient,
+pub enum SelectedFactorSourcesForRoleStatus {
+    /// The selected factor sources are optimal for the specified role
+    /// in the Security Shield building process.
+    Optimal,
 
-    /// The selected factor sources are suboptimal for building a Security Shield.
+    /// The selected factor sources are suboptimal for the specified role
+    /// in the Security Shield building process.
+    ///
+    /// Note: Typically used in hosts as a warning message.
     Suboptimal,
 
-    /// The selected factor sources are optimal for building a Security Shield.
-    Optimal,
+    /// The selected factor sources are insufficient for the specified role
+    /// in the Security Shield building process.
+    Insufficient,
+
+    /// The selected factor sources form an invalid combination for the specified role
+    /// in the Security Shield building process.
+    ///
+    /// Example: A Password factor source cannot be used alone for the Primary role.
+    Invalid,
 }

--- a/crates/sargon/src/profile/v100/factors/factor_source_kind.rs
+++ b/crates/sargon/src/profile/v100/factors/factor_source_kind.rs
@@ -118,6 +118,20 @@ impl FactorSourceKind {
     }
 }
 
+impl FactorSourceKind {
+    pub fn display_order(&self) -> u8 {
+        match self {
+            FactorSourceKind::Device => 0,
+            FactorSourceKind::ArculusCard => 1,
+            FactorSourceKind::LedgerHQHardwareWallet => 2,
+            FactorSourceKind::Password => 3,
+            FactorSourceKind::OffDeviceMnemonic => 4,
+            FactorSourceKind::TrustedContact => 5,
+            FactorSourceKind::SecurityQuestions => 6,
+        }
+    }
+}
+
 impl HasSampleValues for FactorSourceKind {
     fn sample() -> Self {
         Self::Device
@@ -240,6 +254,17 @@ mod tests {
             SUT::TrustedContact.category(),
             FactorSourceCategory::Contact
         );
+    }
+
+    #[test]
+    fn display_order() {
+        assert_eq!(SUT::Device.display_order(), 0);
+        assert_eq!(SUT::ArculusCard.display_order(), 1);
+        assert_eq!(SUT::LedgerHQHardwareWallet.display_order(), 2);
+        assert_eq!(SUT::Password.display_order(), 3);
+        assert_eq!(SUT::OffDeviceMnemonic.display_order(), 4);
+        assert_eq!(SUT::TrustedContact.display_order(), 5);
+        assert_eq!(SUT::SecurityQuestions.display_order(), 6);
     }
 
     #[test]

--- a/crates/sargon/src/profile/v100/factors/factor_source_kind.rs
+++ b/crates/sargon/src/profile/v100/factors/factor_source_kind.rs
@@ -119,7 +119,7 @@ impl FactorSourceKind {
 }
 
 impl FactorSourceKind {
-    pub fn display_order(&self) -> u8 {
+    pub fn display_order_for_primary_threshold_selection(&self) -> u8 {
         match self {
             FactorSourceKind::Device => 0,
             FactorSourceKind::ArculusCard => 1,
@@ -257,14 +257,38 @@ mod tests {
     }
 
     #[test]
-    fn display_order() {
-        assert_eq!(SUT::Device.display_order(), 0);
-        assert_eq!(SUT::ArculusCard.display_order(), 1);
-        assert_eq!(SUT::LedgerHQHardwareWallet.display_order(), 2);
-        assert_eq!(SUT::Password.display_order(), 3);
-        assert_eq!(SUT::OffDeviceMnemonic.display_order(), 4);
-        assert_eq!(SUT::TrustedContact.display_order(), 5);
-        assert_eq!(SUT::SecurityQuestions.display_order(), 6);
+    fn display_order_for_primary_threshold_selection() {
+        assert_eq!(
+            SUT::Device.display_order_for_primary_threshold_selection(),
+            0
+        );
+        assert_eq!(
+            SUT::ArculusCard.display_order_for_primary_threshold_selection(),
+            1
+        );
+        assert_eq!(
+            SUT::LedgerHQHardwareWallet
+                .display_order_for_primary_threshold_selection(),
+            2
+        );
+        assert_eq!(
+            SUT::Password.display_order_for_primary_threshold_selection(),
+            3
+        );
+        assert_eq!(
+            SUT::OffDeviceMnemonic
+                .display_order_for_primary_threshold_selection(),
+            4
+        );
+        assert_eq!(
+            SUT::TrustedContact.display_order_for_primary_threshold_selection(),
+            5
+        );
+        assert_eq!(
+            SUT::SecurityQuestions
+                .display_order_for_primary_threshold_selection(),
+            6
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Changelog
- Added `sorted_factor_sources_for_selection function`, which handles the logic for sorting a list of factor sources on the `Select Factors` screen.
- Added `selected_factor_sources_status` function, which returns a newly added enum, `SelectedFactorSourcesStatus`, representing the status of selected factor sources in the Security Shield building process.
- [Swift] Fixes the `allCases` for `SecurityProblemKind`