### PR TITLE
Expose sign auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2772,7 +2772,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.1.78"
+version = "1.1.79"
 dependencies = [
  "actix-rt",
  "aes-gcm",
@@ -2827,7 +2827,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-uniffi"
-version = "1.1.78"
+version = "1.1.79"
 dependencies = [
  "actix-rt",
  "assert-json-diff",

--- a/apple/Sources/Sargon/SargonOS/ThrowingHostInteractor+Static+Shared.swift
+++ b/apple/Sources/Sargon/SargonOS/ThrowingHostInteractor+Static+Shared.swift
@@ -2,6 +2,10 @@
 public class ThrowingHostInteractor: HostInteractor {
 	public nonisolated(unsafe) static var shared: HostInteractor = ThrowingHostInteractor()
 
+	public func signAuth(request: SargonUniFFI.AuthenticationSigningRequest) async throws -> SargonUniFFI.AuthenticationSigningResponse {
+		throw CommonError.SigningRejected
+	}
+
 	public func signTransactions(request: SargonUniFFI.SignRequestOfTransactionIntent) async throws -> SargonUniFFI.SignWithFactorsOutcomeOfTransactionIntentHash {
 		throw CommonError.SigningRejected
 	}
@@ -11,6 +15,6 @@ public class ThrowingHostInteractor: HostInteractor {
 	}
 
 	public func deriveKeys(request: SargonUniFFI.KeyDerivationRequest) async throws -> SargonUniFFI.KeyDerivationResponse {
-		throw CommonError.Unknown
+		throw CommonError.SigningRejected
 	}
 }

--- a/crates/sargon-uniffi/Cargo.toml
+++ b/crates/sargon-uniffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sargon-uniffi"
 # Don't forget to update version in crates/sargon/Cargo.toml
-version = "1.1.78"
+version = "1.1.79"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/sargon-uniffi/src/core/error/common_error.rs
+++ b/crates/sargon-uniffi/src/core/error/common_error.rs
@@ -822,8 +822,11 @@ pub enum CommonError {
     #[error("Could not validate signature for the given input.")]
     InvalidHDSignature = 10230,
 
+    #[error("Could not validate signature for the given rola challenge.")]
+    InvalidSignatureForRolaChallenge = 10231,
+
     #[error("Signing was rejected by the user")]
-    SigningRejected = 10231,
+    SigningRejected = 10232,
 }
 
 #[uniffi::export]

--- a/crates/sargon-uniffi/src/signing/authentication_signing_input.rs
+++ b/crates/sargon-uniffi/src/signing/authentication_signing_input.rs
@@ -8,6 +8,29 @@ pub struct AuthenticationSigningInput {
     /// with.
     pub owned_factor_instance: OwnedFactorInstance,
 
-    /// The challenge that will be signed by `owned_factor_instance`
-    pub challenge: RolaChallenge,
+    /// The challenge nonce that with some `metadata` values are generating the `RolaChallenge`
+    /// needed to be signed
+    pub challenge_nonce: DappToWalletInteractionAuthChallengeNonce,
+
+    /// The metadata that together with the `challenge_nonce` are generating the `RolaChallenge`
+    /// needed to be signed
+    pub metadata: DappToWalletInteractionMetadata,
+}
+
+#[uniffi::export]
+pub fn authentication_signing_input_get_rola_challenge(
+    input: &AuthenticationSigningInput,
+) -> Result<RolaChallenge> {
+    input.into_internal().rola_challenge().into_result()
+}
+
+#[uniffi::export]
+pub fn new_authentication_signing_input_sample() -> AuthenticationSigningInput {
+    InternalAuthenticationSigningInput::sample().into()
+}
+
+#[uniffi::export]
+pub fn new_authentication_signing_input_sample_other(
+) -> AuthenticationSigningInput {
+    InternalAuthenticationSigningInput::sample_other().into()
 }

--- a/crates/sargon-uniffi/src/signing/authentication_signing_input.rs
+++ b/crates/sargon-uniffi/src/signing/authentication_signing_input.rs
@@ -1,0 +1,13 @@
+use crate::prelude::*;
+use sargon::AuthenticationSigningInput as InternalAuthenticationSigningInput;
+
+#[derive(Clone, PartialEq, InternalConversion, uniffi::Record)]
+pub struct AuthenticationSigningInput {
+    /// The account or identity address of the entity which signs the rola challenge,
+    /// with expected public key and with derivation path to derive PrivateKey
+    /// with.
+    pub owned_factor_instance: OwnedFactorInstance,
+
+    /// The challenge that will be signed by `owned_factor_instance`
+    pub challenge: RolaChallenge,
+}

--- a/crates/sargon-uniffi/src/signing/authentication_signing_request.rs
+++ b/crates/sargon-uniffi/src/signing/authentication_signing_request.rs
@@ -1,0 +1,7 @@
+use crate::prelude::*;
+use sargon::AuthenticationSigningRequest as InternalAuthenticationSigningRequest;
+
+#[derive(Clone, PartialEq, InternalConversion, uniffi::Record)]
+pub struct AuthenticationSigningRequest {
+    pub input: AuthenticationSigningInput,
+}

--- a/crates/sargon-uniffi/src/signing/authentication_signing_response.rs
+++ b/crates/sargon-uniffi/src/signing/authentication_signing_response.rs
@@ -1,0 +1,7 @@
+use crate::prelude::*;
+use sargon::AuthenticationSigningResponse as InternalAuthenticationSigningResponse;
+
+#[derive(Clone, PartialEq, InternalConversion, uniffi::Record)]
+pub struct AuthenticationSigningResponse {
+    pub signature_with_public_key: SignatureWithPublicKey,
+}

--- a/crates/sargon-uniffi/src/signing/authentication_signing_response.rs
+++ b/crates/sargon-uniffi/src/signing/authentication_signing_response.rs
@@ -3,5 +3,30 @@ use sargon::AuthenticationSigningResponse as InternalAuthenticationSigningRespon
 
 #[derive(Clone, PartialEq, InternalConversion, uniffi::Record)]
 pub struct AuthenticationSigningResponse {
+    pub rola_challenge: RolaChallenge,
     pub signature_with_public_key: SignatureWithPublicKey,
+}
+
+#[uniffi::export]
+pub fn new_authentication_signing_response(
+    rola_challenge: RolaChallenge,
+    signature_with_public_key: SignatureWithPublicKey,
+) -> Result<AuthenticationSigningResponse> {
+    InternalAuthenticationSigningResponse::new(
+        rola_challenge.into(),
+        signature_with_public_key.into(),
+    )
+    .into_result()
+}
+
+#[uniffi::export]
+pub fn new_authentication_signing_response_sample(
+) -> AuthenticationSigningResponse {
+    InternalAuthenticationSigningResponse::sample().into()
+}
+
+#[uniffi::export]
+pub fn new_authentication_signing_response_sample_other(
+) -> AuthenticationSigningResponse {
+    InternalAuthenticationSigningResponse::sample_other().into()
 }

--- a/crates/sargon-uniffi/src/signing/mod.rs
+++ b/crates/sargon-uniffi/src/signing/mod.rs
@@ -1,7 +1,11 @@
+mod authentication_signing_input;
+mod authentication_signing_request;
+mod authentication_signing_response;
 mod hd_signature;
 mod hd_signature_input;
 mod invalid_transaction_if_neglected;
 mod neglected_factors;
+mod rola_challenge;
 mod sign_request;
 mod sign_response;
 mod sign_with_factors_outcome;
@@ -9,10 +13,14 @@ mod signatures_per_fractor_source;
 mod transaction_sign_request_input;
 mod transactions_to_sign_per_factor_source;
 
+pub use authentication_signing_input::*;
+pub use authentication_signing_request::*;
+pub use authentication_signing_response::*;
 pub use hd_signature::*;
 pub use hd_signature_input::*;
 pub use invalid_transaction_if_neglected::*;
 pub use neglected_factors::*;
+pub use rola_challenge::*;
 pub use sign_request::*;
 pub use sign_response::*;
 pub use sign_with_factors_outcome::*;

--- a/crates/sargon-uniffi/src/signing/rola_challenge.rs
+++ b/crates/sargon-uniffi/src/signing/rola_challenge.rs
@@ -1,0 +1,22 @@
+use crate::prelude::*;
+use sargon::RolaChallenge as InternalRolaChallenge;
+
+#[derive(Debug, Clone, PartialEq, InternalConversion, uniffi::Record)]
+pub struct RolaChallenge {
+    pub payload: BagOfBytes,
+}
+
+#[uniffi::export]
+pub fn rola_challenge_get_hash(rola_challenge: &RolaChallenge) -> Hash {
+    rola_challenge.into_internal().hash().into()
+}
+
+#[uniffi::export]
+pub fn new_rola_challenge_sample() -> RolaChallenge {
+    InternalRolaChallenge::sample().into()
+}
+
+#[uniffi::export]
+pub fn new_rola_challenge_sample_other() -> RolaChallenge {
+    InternalRolaChallenge::sample_other().into()
+}

--- a/crates/sargon-uniffi/src/system/interactors/host_interactor.rs
+++ b/crates/sargon-uniffi/src/system/interactors/host_interactor.rs
@@ -1,4 +1,7 @@
 use crate::prelude::*;
+use sargon::AuthenticationSigningInteractor as InternalAuthenticationSigningInteractor;
+use sargon::AuthenticationSigningRequest as InternalAuthenticationSigningInteractorRequest;
+use sargon::AuthenticationSigningResponse as InternalAuthenticationSigningResponse;
 use sargon::KeyDerivationInteractor as InternalKeyDerivationInteractor;
 use sargon::KeyDerivationRequest as InternalKeyDerivationRequest;
 use sargon::KeyDerivationResponse as InternalKeyDerivationResponse;
@@ -36,6 +39,11 @@ pub trait HostInteractor: Send + Sync + std::fmt::Debug {
         &self,
         request: KeyDerivationRequest,
     ) -> Result<KeyDerivationResponse>;
+
+    async fn sign_auth(
+        &self,
+        request: AuthenticationSigningRequest,
+    ) -> Result<AuthenticationSigningResponse>;
 }
 
 #[derive(Debug)]
@@ -90,6 +98,21 @@ impl InternalKeyDerivationInteractor for UseFactorSourcesInteractorAdapter {
     ) -> InternalResult<InternalKeyDerivationResponse> {
         self.wrapped
             .derive_keys(request.into())
+            .await
+            .into_internal_result()
+    }
+}
+
+#[async_trait::async_trait]
+impl InternalAuthenticationSigningInteractor
+    for UseFactorSourcesInteractorAdapter
+{
+    async fn sign(
+        &self,
+        request: InternalAuthenticationSigningInteractorRequest,
+    ) -> InternalResult<InternalAuthenticationSigningResponse> {
+        self.wrapped
+            .sign_auth(request.into())
             .await
             .into_internal_result()
     }

--- a/crates/sargon-uniffi/src/system/sargon_os/sargon_os_signing.rs
+++ b/crates/sargon-uniffi/src/system/sargon_os/sargon_os_signing.rs
@@ -25,4 +25,20 @@ impl SargonOS {
             .await
             .into_result()
     }
+
+    pub async fn sign_auth(
+        &self,
+        address_of_entity: AddressOfAccountOrPersona,
+        challenge_nonce: DappToWalletInteractionAuthChallengeNonce,
+        metadata: DappToWalletInteractionMetadata,
+    ) -> Result<WalletToDappInteractionAuthProof> {
+        self.wrapped
+            .sign_auth(
+                address_of_entity.into(),
+                challenge_nonce.into(),
+                metadata.into(),
+            )
+            .await
+            .into_result()
+    }
 }

--- a/crates/sargon/Cargo.toml
+++ b/crates/sargon/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sargon"
 # Don't forget to update version in crates/sargon-uniffi/Cargo.toml
-version = "1.1.78"
+version = "1.1.79"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/sargon/src/core/error/common_error.rs
+++ b/crates/sargon/src/core/error/common_error.rs
@@ -819,8 +819,11 @@ pub enum CommonError {
     #[error("Could not validate signature for the given input.")]
     InvalidHDSignature = 10230,
 
+    #[error("Could not validate signature for the given rola challenge.")]
+    InvalidSignatureForRolaChallenge = 10231,
+
     #[error("Signing was rejected by the user")]
-    SigningRejected = 10231,
+    SigningRejected = 10232,
 }
 
 impl CommonError {

--- a/crates/sargon/src/signing/authentication/authentication_signing_input.rs
+++ b/crates/sargon/src/signing/authentication/authentication_signing_input.rs
@@ -76,6 +76,17 @@ mod test {
     type SUT = AuthenticationSigningInput;
 
     #[test]
+    fn equality() {
+        assert_eq!(SUT::sample(), SUT::sample());
+        assert_eq!(SUT::sample_other(), SUT::sample_other());
+    }
+
+    #[test]
+    fn inequality() {
+        assert_eq!(SUT::sample(), SUT::sample_other());
+    }
+
+    #[test]
     fn test_with_usecurified_account() {
         let expected_factor_instance =
             HierarchicalDeterministicFactorInstance::sample_fia0();

--- a/crates/sargon/src/signing/authentication/authentication_signing_input.rs
+++ b/crates/sargon/src/signing/authentication/authentication_signing_input.rs
@@ -55,6 +55,19 @@ impl AuthenticationSigningInput {
     }
 }
 
+impl HasSampleValues for AuthenticationSigningInput {
+    fn sample() -> Self {
+        Self::new(OwnedFactorInstance::sample(), RolaChallenge::sample())
+    }
+
+    fn sample_other() -> Self {
+        Self::new(
+            OwnedFactorInstance::sample_other(),
+            RolaChallenge::sample_other(),
+        )
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/crates/sargon/src/signing/authentication/authentication_signing_interactor.rs
+++ b/crates/sargon/src/signing/authentication/authentication_signing_interactor.rs
@@ -1,33 +1,61 @@
 use crate::prelude::*;
 
 #[async_trait::async_trait]
-pub trait AuthenticationSigningInteractor {
+pub trait AuthenticationSigningInteractor: Send + Sync {
     async fn sign(
         &self,
-        request: AuthenticationSigningInteractorRequest,
+        request: AuthenticationSigningRequest,
     ) -> Result<AuthenticationSigningResponse>;
 }
 
-pub struct AuthenticationSigningInteractorRequest {
+#[derive(Debug, Clone, PartialEq)]
+pub struct AuthenticationSigningRequest {
     pub input: AuthenticationSigningInput,
 }
 
-impl AuthenticationSigningInteractorRequest {
+impl AuthenticationSigningRequest {
     pub fn new(input: AuthenticationSigningInput) -> Self {
         Self { input }
     }
 }
 
-impl From<AuthenticationSigningInput>
-    for AuthenticationSigningInteractorRequest
-{
+impl From<AuthenticationSigningInput> for AuthenticationSigningRequest {
     fn from(value: AuthenticationSigningInput) -> Self {
         Self::new(value)
     }
 }
 
+impl HasSampleValues for AuthenticationSigningRequest {
+    fn sample() -> Self {
+        Self::new(AuthenticationSigningInput::sample())
+    }
+
+    fn sample_other() -> Self {
+        Self::new(AuthenticationSigningInput::sample_other())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub struct AuthenticationSigningResponse {
     pub signature_with_public_key: SignatureWithPublicKey,
+}
+
+impl AuthenticationSigningResponse {
+    pub fn new(signature_with_public_key: SignatureWithPublicKey) -> Self {
+        Self {
+            signature_with_public_key,
+        }
+    }
+}
+
+impl HasSampleValues for AuthenticationSigningResponse {
+    fn sample() -> Self {
+        Self::new(SignatureWithPublicKey::sample())
+    }
+
+    fn sample_other() -> Self {
+        Self::new(SignatureWithPublicKey::sample_other())
+    }
 }
 
 impl From<AuthenticationSigningResponse> for WalletToDappInteractionAuthProof {
@@ -35,7 +63,7 @@ impl From<AuthenticationSigningResponse> for WalletToDappInteractionAuthProof {
         let signature_with_public_key = value.signature_with_public_key;
 
         let public_key = signature_with_public_key.public_key();
-        WalletToDappInteractionAuthProof::new(
+        Self::new(
             public_key,
             public_key.curve(),
             signature_with_public_key.signature(),

--- a/crates/sargon/src/signing/authentication/authentication_signing_interactor.rs
+++ b/crates/sargon/src/signing/authentication/authentication_signing_interactor.rs
@@ -108,7 +108,7 @@ mod test_auth_sign_request {
 
     #[test]
     fn inequality() {
-        assert_eq!(SUT::sample(), SUT::sample_other());
+        assert_ne!(SUT::sample(), SUT::sample_other());
     }
 }
 
@@ -127,6 +127,6 @@ mod test_auth_sign_response {
 
     #[test]
     fn inequality() {
-        assert_eq!(SUT::sample(), SUT::sample_other());
+        assert_ne!(SUT::sample(), SUT::sample_other());
     }
 }

--- a/crates/sargon/src/signing/authentication/authentication_signing_interactor.rs
+++ b/crates/sargon/src/signing/authentication/authentication_signing_interactor.rs
@@ -129,4 +129,16 @@ mod test_auth_sign_response {
     fn inequality() {
         assert_ne!(SUT::sample(), SUT::sample_other());
     }
+
+    #[test]
+    fn test_invalid_signature_for_rola_challenge() {
+        let challenge = RolaChallenge::sample();
+        let invalid_signature_with_public_key =
+            SignatureWithPublicKey::sample();
+
+        assert_eq!(
+            SUT::new(challenge, invalid_signature_with_public_key),
+            Err(CommonError::InvalidSignatureForRolaChallenge)
+        )
+    }
 }

--- a/crates/sargon/src/signing/authentication/rola_challenge.rs
+++ b/crates/sargon/src/signing/authentication/rola_challenge.rs
@@ -5,7 +5,7 @@ const ROLA_PREFIX: u8 = 0x52;
 #[derive(Debug, Clone, PartialEq, derive_more::Display)]
 #[display("{}", self.payload.to_hex())]
 pub struct RolaChallenge {
-    payload: BagOfBytes,
+    pub payload: BagOfBytes,
 }
 
 impl RolaChallenge {

--- a/crates/sargon/src/signing/testing/interactors/test_authentication_interactor.rs
+++ b/crates/sargon/src/signing/testing/interactors/test_authentication_interactor.rs
@@ -26,18 +26,16 @@ impl AuthenticationSigningInteractor for TestAuthenticationInteractor {
 
         let mnemonic_with_passphrase = id.sample_associated_mnemonic();
 
+        let challenge = request.input.rola_challenge()?;
         let signature = mnemonic_with_passphrase.sign(
-            &request.input.challenge.hash(),
+            &challenge.hash(),
             &request.input.owned_factor_instance.value.derivation_path(),
         );
 
         if self.should_fail {
             Err(CommonError::SigningRejected)
         } else {
-            AuthenticationSigningResponse::new(
-                request.input.challenge,
-                signature,
-            )
+            AuthenticationSigningResponse::new(challenge, signature)
         }
     }
 }

--- a/crates/sargon/src/signing/testing/interactors/test_authentication_interactor.rs
+++ b/crates/sargon/src/signing/testing/interactors/test_authentication_interactor.rs
@@ -32,11 +32,12 @@ impl AuthenticationSigningInteractor for TestAuthenticationInteractor {
         );
 
         if self.should_fail {
-            Err(CommonError::Unknown)
+            Err(CommonError::SigningRejected)
         } else {
-            Ok(AuthenticationSigningResponse {
-                signature_with_public_key: signature,
-            })
+            AuthenticationSigningResponse::new(
+                request.input.challenge,
+                signature,
+            )
         }
     }
 }

--- a/crates/sargon/src/signing/testing/interactors/test_authentication_interactor.rs
+++ b/crates/sargon/src/signing/testing/interactors/test_authentication_interactor.rs
@@ -20,7 +20,7 @@ impl TestAuthenticationInteractor {
 impl AuthenticationSigningInteractor for TestAuthenticationInteractor {
     async fn sign(
         &self,
-        request: AuthenticationSigningInteractorRequest,
+        request: AuthenticationSigningRequest,
     ) -> Result<AuthenticationSigningResponse> {
         let id = request.input.owned_factor_instance.factor_source_id();
 

--- a/crates/sargon/src/system/interactors/interactors.rs
+++ b/crates/sargon/src/system/interactors/interactors.rs
@@ -31,6 +31,7 @@ impl Interactors {
                     SimulatedUser::prudent_no_fail(),
                 )),
                 keys_derivation_interactor,
+                Arc::new(TestAuthenticationInteractor::new_succeeding()),
             );
 
         Self::new(Arc::new(use_factor_sources_interactors))

--- a/crates/sargon/src/system/interactors/testing/test_use_factor_sources_interactors.rs
+++ b/crates/sargon/src/system/interactors/testing/test_use_factor_sources_interactors.rs
@@ -4,6 +4,7 @@ pub struct TestUseFactorSourcesInteractors {
     transaction_signing: Arc<dyn SignInteractor<TransactionIntent>>,
     subintent_signing: Arc<dyn SignInteractor<Subintent>>,
     key_derivation: Arc<dyn KeyDerivationInteractor>,
+    auth_signing: Arc<dyn AuthenticationSigningInteractor>,
 }
 
 impl TestUseFactorSourcesInteractors {
@@ -11,11 +12,13 @@ impl TestUseFactorSourcesInteractors {
         transaction_signing: Arc<dyn SignInteractor<TransactionIntent>>,
         subintent_signing: Arc<dyn SignInteractor<Subintent>>,
         key_derivation: Arc<dyn KeyDerivationInteractor>,
+        auth_signing: Arc<dyn AuthenticationSigningInteractor>,
     ) -> Self {
         Self {
             transaction_signing,
             subintent_signing,
             key_derivation,
+            auth_signing,
         }
     }
 }
@@ -49,5 +52,15 @@ impl KeyDerivationInteractor for TestUseFactorSourcesInteractors {
         request: KeyDerivationRequest,
     ) -> Result<KeyDerivationResponse> {
         self.key_derivation.derive(request).await
+    }
+}
+
+#[async_trait::async_trait]
+impl AuthenticationSigningInteractor for TestUseFactorSourcesInteractors {
+    async fn sign(
+        &self,
+        request: AuthenticationSigningRequest,
+    ) -> Result<AuthenticationSigningResponse> {
+        self.auth_signing.sign(request).await
     }
 }

--- a/crates/sargon/src/system/interactors/use_factor_sources_interactor.rs
+++ b/crates/sargon/src/system/interactors/use_factor_sources_interactor.rs
@@ -10,5 +10,6 @@ pub trait UseFactorSourcesInteractor:
     SignInteractor<TransactionIntent>
     + SignInteractor<Subintent>
     + KeyDerivationInteractor
+    + AuthenticationSigningInteractor
 {
 }

--- a/crates/sargon/src/system/interactors/use_factor_sources_interactor.rs
+++ b/crates/sargon/src/system/interactors/use_factor_sources_interactor.rs
@@ -6,6 +6,7 @@ use crate::prelude::*;
 /// - sign transactions with `SignInteractor<TransactionIntent>` which is used by `SignaturesCollector`
 /// - sign subintents with `SignInteractor<Subintent>` which is used by `SignaturesCollector`
 /// - derive keys with `KeyDerivationInteractor` which is used by `KeysCollector`
+/// - sign rola challenges with `AuthenticationSigningInteractor` which is used by `AuthenticationSigner`
 pub trait UseFactorSourcesInteractor:
     SignInteractor<TransactionIntent>
     + SignInteractor<Subintent>

--- a/crates/sargon/src/system/sargon_os/sargon_os.rs
+++ b/crates/sargon/src/system/sargon_os/sargon_os.rs
@@ -274,6 +274,13 @@ impl SargonOS {
             as Arc<dyn KeyDerivationInteractor>
     }
 
+    pub(crate) fn auth_signing_interactor(
+        &self,
+    ) -> Arc<dyn AuthenticationSigningInteractor> {
+        self.interactors.use_factor_sources_interactor.clone()
+            as Arc<dyn AuthenticationSigningInteractor>
+    }
+
     pub async fn resolve_host_id(&self) -> Result<HostId> {
         self.host_id().await
     }

--- a/crates/sargon/src/system/sargon_os/sargon_os_signing.rs
+++ b/crates/sargon/src/system/sargon_os/sargon_os_signing.rs
@@ -93,6 +93,72 @@ mod test {
     type SUT = SargonOS;
 
     #[actix_rt::test]
+    async fn test_sign_auth_success() {
+        let profile = Profile::sample();
+        let sut = boot_with_profile(&profile, None).await;
+
+        let all_accounts = profile.accounts_on_current_network().unwrap();
+        let account = all_accounts.first().unwrap();
+        let nonce = DappToWalletInteractionAuthChallengeNonce::sample();
+        let metadata = DappToWalletInteractionMetadata::new(
+            WalletInteractionVersion::current(),
+            NetworkID::Mainnet,
+            "https://example.com",
+            DappDefinitionAddress::sample(),
+        );
+
+        let expected_challenge =
+            RolaChallenge::from_request(nonce.clone(), metadata.clone())
+                .unwrap();
+
+        let signed = sut
+            .sign_auth(
+                AddressOfAccountOrPersona::Account(account.address),
+                nonce,
+                metadata,
+            )
+            .await
+            .unwrap();
+
+        let signature_with_public_key = SignatureWithPublicKey::from((
+            signed.public_key.as_ed25519().unwrap().clone(),
+            signed.signature.as_ed25519().unwrap().clone(),
+        ));
+
+        assert!(signature_with_public_key
+            .is_valid_for_hash(&expected_challenge.hash()))
+    }
+
+    #[actix_rt::test]
+    async fn test_sign_auth_failure() {
+        let profile = Profile::sample();
+
+        let sut =
+            boot_with_profile(&profile, Some(SigningFailure::UserRejected))
+                .await;
+
+        let all_accounts = profile.accounts_on_current_network().unwrap();
+        let account = all_accounts.first().unwrap();
+        let nonce = DappToWalletInteractionAuthChallengeNonce::sample();
+        let metadata = DappToWalletInteractionMetadata::new(
+            WalletInteractionVersion::current(),
+            NetworkID::Mainnet,
+            "https://example.com",
+            DappDefinitionAddress::sample(),
+        );
+
+        let result = sut
+            .sign_auth(
+                AddressOfAccountOrPersona::Account(account.address),
+                nonce,
+                metadata,
+            )
+            .await;
+
+        assert_eq!(result, Err(CommonError::SigningRejected))
+    }
+
+    #[actix_rt::test]
     async fn test_sign_transaction_intent_success() {
         let profile = Profile::sample();
         let sut = boot_with_profile(&profile, None).await;
@@ -266,7 +332,7 @@ mod test {
                     false,
                     Arc::new(clients.secure_storage.clone()),
                 )),
-                Arc::new(TestAuthenticationInteractor::new_succeeding()),
+                get_test_auth_interactor(&maybe_signing_failure),
             ));
         let interactors = Interactors::new(use_factor_sources_interactors);
         SUT::boot_with_clients_and_interactor(clients, interactors).await
@@ -287,6 +353,15 @@ mod test {
                 }
                 SigningFailure::UserRejected => SimulatedUser::<S>::rejecting(),
             },
+        }
+    }
+
+    fn get_test_auth_interactor(
+        maybe_signing_failure: &Option<SigningFailure>,
+    ) -> Arc<dyn AuthenticationSigningInteractor> {
+        match maybe_signing_failure {
+            None => Arc::new(TestAuthenticationInteractor::new_succeeding()),
+            Some(_) => Arc::new(TestAuthenticationInteractor::new_failing()),
         }
     }
 

--- a/crates/sargon/src/system/sargon_os/sargon_os_signing.rs
+++ b/crates/sargon/src/system/sargon_os/sargon_os_signing.rs
@@ -5,6 +5,25 @@ use std::ops::Index;
 // Sign Signables
 // ==================
 impl SargonOS {
+    pub async fn sign_auth(
+        &self,
+        address_of_entity: AddressOfAccountOrPersona,
+        challenge_nonce: DappToWalletInteractionAuthChallengeNonce,
+        metadata: DappToWalletInteractionMetadata,
+    ) -> Result<WalletToDappInteractionAuthProof> {
+        let profile = &self.profile_state_holder.profile()?;
+
+        let auth_signer = AuthenticationSigner::new(
+            self.auth_signing_interactor(),
+            profile,
+            address_of_entity,
+            challenge_nonce,
+            metadata,
+        )?;
+
+        auth_signer.sign().await
+    }
+
     pub async fn sign_transaction(
         &self,
         transaction_intent: TransactionIntent,
@@ -247,6 +266,7 @@ mod test {
                     false,
                     Arc::new(clients.secure_storage.clone()),
                 )),
+                Arc::new(TestAuthenticationInteractor::new_succeeding()),
             ));
         let interactors = Interactors::new(use_factor_sources_interactors);
         SUT::boot_with_clients_and_interactor(clients, interactors).await

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/RolaChallenge.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/RolaChallenge.kt
@@ -1,2 +1,7 @@
 package com.radixdlt.sargon.extensions
 
+import com.radixdlt.sargon.Hash
+import com.radixdlt.sargon.RolaChallenge
+import com.radixdlt.sargon.rolaChallengeGetHash
+
+fun RolaChallenge.hash(): Hash = rolaChallengeGetHash(rolaChallenge = this)

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/RolaChallenge.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/RolaChallenge.kt
@@ -1,0 +1,2 @@
+package com.radixdlt.sargon.extensions
+

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/RolaChallenge.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/RolaChallenge.kt
@@ -1,0 +1,14 @@
+package com.radixdlt.sargon.samples
+
+import com.radixdlt.sargon.RolaChallenge
+import com.radixdlt.sargon.annotation.UsesSampleValues
+import com.radixdlt.sargon.newRolaChallengeSample
+import com.radixdlt.sargon.newRolaChallengeSampleOther
+
+@UsesSampleValues
+val RolaChallenge.Companion.sample: Sample<RolaChallenge>
+    get() = object : Sample<RolaChallenge> {
+        override fun invoke(): RolaChallenge = newRolaChallengeSample()
+
+        override fun other(): RolaChallenge = newRolaChallengeSampleOther()
+    }

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/RolaChallengeTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/RolaChallengeTest.kt
@@ -1,0 +1,22 @@
+package com.radixdlt.sargon
+
+import com.radixdlt.sargon.extensions.hash
+import com.radixdlt.sargon.extensions.hex
+import com.radixdlt.sargon.samples.Sample
+import com.radixdlt.sargon.samples.sample
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class RolaChallengeTest: SampleTestable<RolaChallenge> {
+    override val samples: List<Sample<RolaChallenge>>
+        get() = listOf(RolaChallenge.sample)
+
+    @Test
+    fun testHash() {
+
+        assertEquals(
+            "6fc75ec1d5c00941dc587c0a07409da1740c423c337c323ba7bdf68d61d4dd8e",
+            RolaChallenge.sample().hash().hex,
+        )
+    }
+}

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/os/interactor/FakeHostInteractor.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/os/interactor/FakeHostInteractor.kt
@@ -1,5 +1,7 @@
 package com.radixdlt.sargon.os.interactor
 
+import com.radixdlt.sargon.AuthenticationSigningRequest
+import com.radixdlt.sargon.AuthenticationSigningResponse
 import com.radixdlt.sargon.CommonException
 import com.radixdlt.sargon.HostInteractor
 import com.radixdlt.sargon.KeyDerivationRequest
@@ -23,6 +25,10 @@ class FakeHostInteractor: HostInteractor {
     }
 
     override suspend fun deriveKeys(request: KeyDerivationRequest): KeyDerivationResponse {
-        throw CommonException.Unknown()
+        throw CommonException.SigningRejected()
+    }
+
+    override suspend fun signAuth(request: AuthenticationSigningRequest): AuthenticationSigningResponse {
+        throw CommonException.SigningRejected()
     }
 }


### PR DESCRIPTION
Signing auth is used in login flows by the host. In similar fashion with `sign_transaction` and `sign_subintent`, `sign_auth` is exposed by sargon os. The `AuthenticationSigningInteractor` is added in `UseFactorSourcesInteractor`. Notable fact is that `RolaChallenge` also exposes the `hash` method used by host in order to sign it.