### PR TITLE
Automatic Assignment of Factors to Recovery & Confirmation Role

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2772,7 +2772,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.1.83"
+version = "1.1.84"
 dependencies = [
  "actix-rt",
  "aes-gcm",
@@ -2827,7 +2827,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-uniffi"
-version = "1.1.83"
+version = "1.1.84"
 dependencies = [
  "actix-rt",
  "assert-json-diff",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2772,7 +2772,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.1.82"
+version = "1.1.83"
 dependencies = [
  "actix-rt",
  "aes-gcm",
@@ -2827,7 +2827,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-uniffi"
-version = "1.1.82"
+version = "1.1.83"
 dependencies = [
  "actix-rt",
  "assert-json-diff",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2772,7 +2772,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.1.81"
+version = "1.1.82"
 dependencies = [
  "actix-rt",
  "aes-gcm",
@@ -2827,7 +2827,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-uniffi"
-version = "1.1.81"
+version = "1.1.82"
 dependencies = [
  "actix-rt",
  "assert-json-diff",

--- a/crates/sargon-uniffi/Cargo.toml
+++ b/crates/sargon-uniffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sargon-uniffi"
 # Don't forget to update version in crates/sargon/Cargo.toml
-version = "1.1.81"
+version = "1.1.82"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/sargon-uniffi/Cargo.toml
+++ b/crates/sargon-uniffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sargon-uniffi"
 # Don't forget to update version in crates/sargon/Cargo.toml
-version = "1.1.82"
+version = "1.1.83"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/sargon-uniffi/Cargo.toml
+++ b/crates/sargon-uniffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sargon-uniffi"
 # Don't forget to update version in crates/sargon/Cargo.toml
-version = "1.1.83"
+version = "1.1.84"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/sargon-uniffi/src/core/error/common_error.rs
+++ b/crates/sargon-uniffi/src/core/error/common_error.rs
@@ -824,6 +824,9 @@ pub enum CommonError {
 
     #[error("Signing was rejected by the user")]
     SigningRejected = 10231,
+
+    #[error("Failed to automatically build shield, reason: '{underlying}'")]
+    AutomaticShieldBuildingFailure { underlying: String } = 10232,
 }
 
 #[uniffi::export]

--- a/crates/sargon-uniffi/src/core/types/collections/internal_mapping.rs
+++ b/crates/sargon-uniffi/src/core/types/collections/internal_mapping.rs
@@ -1,13 +1,15 @@
 use crate::prelude::*;
 
-use sargon::IdentifiedVecOf;
+use sargon::{IdentifiedVecOf, IndexSet};
 
-// From InternalType =================================================================================================
-
+// ==========================
+// === From InternalType ====
+// ==========================
 pub trait FromInternal<InternalType, Type> {
     fn into_type(self) -> Type;
 }
 
+// =====  Vec  ======
 impl<InternalElement, Element> FromInternal<Vec<InternalElement>, Vec<Element>>
     for Vec<InternalElement>
 where
@@ -18,6 +20,7 @@ where
     }
 }
 
+// === IdentifiedVec ====
 impl<InternalElement, Element>
     FromInternal<IdentifiedVecOf<InternalElement>, Vec<Element>>
     for IdentifiedVecOf<InternalElement>
@@ -30,12 +33,50 @@ where
     }
 }
 
-// Into InternalType =================================================================================================
+// ====  IndexSet  ======
+impl<InternalElement, Element>
+    FromInternal<IndexSet<InternalElement>, Vec<Element>>
+    for IndexSet<InternalElement>
+where
+    Element: From<InternalElement>,
+{
+    fn into_type(self) -> Vec<Element> {
+        self.into_iter().map(Element::from).collect()
+    }
+}
+
+// ==========================
+// === Into InternalType ====
+// ==========================
 
 pub trait IntoInternal<Type, InternalType> {
     fn into_internal(self) -> InternalType;
 }
 
+// =====    Vec  ========
+impl<InternalElement, Element> IntoInternal<Vec<Element>, Vec<InternalElement>>
+    for Vec<Element>
+where
+    Element: Into<InternalElement>,
+{
+    fn into_internal(self) -> Vec<InternalElement> {
+        self.into_iter().map(Into::into).collect()
+    }
+}
+
+// ====  IndexSet  ======
+impl<InternalElement, Element>
+    IntoInternal<Vec<Element>, IndexSet<InternalElement>> for Vec<Element>
+where
+    Element: Into<InternalElement>,
+    InternalElement: std::hash::Hash + Eq,
+{
+    fn into_internal(self) -> IndexSet<InternalElement> {
+        self.into_iter().map(Into::into).collect::<IndexSet<_>>()
+    }
+}
+
+// === IdentifiedVec ====
 impl<InternalElement, Element>
     IntoInternal<Vec<Element>, IdentifiedVecOf<InternalElement>>
     for Vec<Element>
@@ -44,16 +85,6 @@ where
     Element: Into<InternalElement>,
 {
     fn into_internal(self) -> IdentifiedVecOf<InternalElement> {
-        self.into_iter().map(Into::into).collect()
-    }
-}
-
-impl<InternalElement, Element> IntoInternal<Vec<Element>, Vec<InternalElement>>
-    for Vec<Element>
-where
-    Element: Into<InternalElement>,
-{
-    fn into_internal(self) -> Vec<InternalElement> {
         self.into_iter().map(Into::into).collect()
     }
 }

--- a/crates/sargon-uniffi/src/core/types/requested_quantity.rs
+++ b/crates/sargon-uniffi/src/core/types/requested_quantity.rs
@@ -40,5 +40,5 @@ pub fn requested_quantity_is_fulfilled_by_ids(
 ) -> bool {
     requested_quantity
         .into_internal()
-        .is_fulfilled_by_ids(number_of_ids as usize)
+        .is_fulfilled_by_quantity(number_of_ids as usize)
 }

--- a/crates/sargon-uniffi/src/keys_collector/key_derivation_request.rs
+++ b/crates/sargon-uniffi/src/keys_collector/key_derivation_request.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 use sargon::IndexMap;
-use sargon::{IndexSet, KeyDerivationRequest as InternalKeyDerivationRequest};
+use sargon::KeyDerivationRequest as InternalKeyDerivationRequest;
 
 /// A collection of derivation paths, on a per-factor-source basis.
 #[derive(Clone, PartialEq, Eq, uniffi::Record)]
@@ -61,11 +61,7 @@ impl From<KeyDerivationRequest> for InternalKeyDerivationRequest {
             IndexMap::from_iter(value.per_factor_source.into_iter().map(|f| {
                 (
                     f.factor_source_id.into_internal(),
-                    IndexSet::from_iter(
-                        f.derivation_paths
-                            .into_iter()
-                            .map(|d| d.into_internal()),
-                    ),
+                    f.derivation_paths.into_internal(),
                 )
             })),
         )

--- a/crates/sargon-uniffi/src/keys_collector/key_derivation_response.rs
+++ b/crates/sargon-uniffi/src/keys_collector/key_derivation_response.rs
@@ -1,6 +1,5 @@
 use crate::prelude::*;
 use sargon::IndexMap;
-use sargon::IndexSet;
 use sargon::KeyDerivationResponse as InternalKeyDerivationResponse;
 
 /// A collection of `HierarchicalDeterministicFactorInstance`s, on a
@@ -58,11 +57,7 @@ impl From<KeyDerivationResponse> for InternalKeyDerivationResponse {
             value.per_factor_source.into_iter().map(|item| {
                 (
                     item.factor_source_id.into_internal(),
-                    IndexSet::from_iter(
-                        item.factor_instances
-                            .into_iter()
-                            .map(|d| d.into_internal()),
-                    ),
+                    item.factor_instances.into_internal(),
                 )
             }),
         ))

--- a/crates/sargon-uniffi/src/profile/mfa/security_structures/security_shield_builder.rs
+++ b/crates/sargon-uniffi/src/profile/mfa/security_structures/security_shield_builder.rs
@@ -400,7 +400,10 @@ impl SecurityShieldBuilder {
             .map(|x| x.into_internal())
             .collect::<IndexSet<sargon::FactorSource>>();
 
-        self.set_ret(|builder| builder.auto_assign_factors_to_recovery_and_confirmation_based_on_primary(all_factors.clone()))
+        self.set_ret(|builder| {
+            let _ = builder.auto_assign_factors_to_recovery_and_confirmation_based_on_primary(all_factors.clone());
+            Ok(())
+        })
     }
 }
 

--- a/crates/sargon-uniffi/src/profile/mfa/security_structures/security_shield_builder.rs
+++ b/crates/sargon-uniffi/src/profile/mfa/security_structures/security_shield_builder.rs
@@ -406,9 +406,9 @@ impl AutoShieldBuilderValidatorOfPickedPrimaryFactors {
     }
 }
 
-impl Into<sargon::ValidatedPrimary> for ValidatedPrimary {
-    fn into(self) -> sargon::ValidatedPrimary {
-        let factors = self
+impl From<ValidatedPrimary> for sargon::ValidatedPrimary {
+    fn from(val: ValidatedPrimary) -> Self {
+        let factors = val
             .secret_magic
             .into_iter()
             .map(|x| x.into())

--- a/crates/sargon-uniffi/src/profile/mfa/security_structures/security_shield_builder.rs
+++ b/crates/sargon-uniffi/src/profile/mfa/security_structures/security_shield_builder.rs
@@ -386,7 +386,7 @@ pub trait PickFactors: Send + Sync {
     async fn user_picked_factors(
         &self,
         possible: Vec<FactorSource>,
-    ) -> Vec<FactorSource>;
+    ) -> Vec<FactorSourceID>;
 }
 
 use sargon::FactorSource as InternalFactorSource;
@@ -406,12 +406,12 @@ impl SecurityShieldBuilder {
                 async |possible: Vec<sargon::FactorSource>| {
                     let possible_mapped: Vec<crate::FactorSource> =
                         possible.into_type();
-                    let picked: Vec<crate::FactorSource> =
+                    let ids_of_picked: Vec<crate::FactorSourceID> =
                         pick_primary_role_factors
                             .user_picked_factors(possible_mapped)
                             .await;
 
-                    picked.into_internal()
+                            ids_of_picked.into_internal()
                 },
             )
             .await

--- a/crates/sargon-uniffi/src/profile/mfa/security_structures/security_shield_builder.rs
+++ b/crates/sargon-uniffi/src/profile/mfa/security_structures/security_shield_builder.rs
@@ -8,9 +8,10 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-use sargon::SecurityShieldBuilder as InternalSecurityShieldBuilder;
-use sargon::SelectedFactorSourcesForRoleStatus as InternalSelectedFactorSourcesForRoleStatus;
-use sargon::{IndexSet, MatrixBuilder};
+use sargon::{
+    SecurityShieldBuilder as InternalSecurityShieldBuilder,
+    SelectedFactorSourcesForRoleStatus as InternalSelectedFactorSourcesForRoleStatus,
+};
 
 use crate::prelude::*;
 
@@ -49,16 +50,6 @@ impl SecurityShieldBuilder {
     ) {
         let mut binding = self.wrapped.write().expect("No poison");
         _ = write(&mut binding);
-    }
-
-    fn set_ret<R>(
-        &self,
-        mut write: impl FnMut(
-            &mut sargon::SecurityShieldBuilder,
-        ) -> sargon::Result<R>,
-    ) -> Result<R> {
-        let mut binding = self.wrapped.write().expect("No poison");
-        write(&mut binding).into_result()
     }
 
     fn validation_for_addition_of_factor_source_by_calling(
@@ -397,15 +388,12 @@ impl SecurityShieldBuilder {
         &self,
         all_factors: Vec<FactorSource>,
     ) -> Result<()> {
-        let all_factors = all_factors
-            .into_iter()
-            .map(|x| x.into_internal())
-            .collect::<IndexSet<sargon::FactorSource>>();
-
-        self.set_ret(|builder| {
-            let _ = builder.auto_assign_factors_to_recovery_and_confirmation_based_on_primary(all_factors.clone());
-            Ok(())
-        })
+        let binding = self.wrapped.write().expect("No poison");
+        let _ = binding
+            .auto_assign_factors_to_recovery_and_confirmation_based_on_primary(
+                all_factors.into_internal(),
+            );
+        Ok(())
     }
 }
 

--- a/crates/sargon-uniffi/src/profile/mfa/security_structures/security_shield_builder.rs
+++ b/crates/sargon-uniffi/src/profile/mfa/security_structures/security_shield_builder.rs
@@ -449,6 +449,10 @@ impl FactorSourceID {
         Self::new(sargon::FactorSourceID::sample_ledger_other())
     }
 
+    pub fn sample_trusted_contact() -> Self {
+        Self::new(sargon::FactorSourceID::sample_trusted_contact())
+    }
+
     pub fn sample_arculus() -> Self {
         Self::new(sargon::FactorSourceID::sample_arculus())
     }
@@ -463,6 +467,48 @@ impl FactorSourceID {
 
     pub fn sample_password_other() -> Self {
         Self::new(sargon::FactorSourceID::sample_password_other())
+    }
+}
+
+impl FactorSource {
+    pub fn new(inner: impl Borrow<sargon::FactorSource>) -> Self {
+        Self::from(inner.borrow().clone())
+    }
+}
+
+#[cfg(test)]
+impl FactorSource {
+    pub fn id(&self) -> FactorSourceID {
+        use sargon::BaseBaseIsFactorSource;
+        self.clone().into_internal().factor_source_id().into()
+    }
+
+    pub fn sample_device() -> Self {
+        Self::new(sargon::FactorSource::sample_device())
+    }
+    pub fn sample_password() -> Self {
+        Self::new(sargon::FactorSource::sample_password())
+    }
+    pub fn sample_trusted_contact_frank() -> Self {
+        Self::new(sargon::FactorSource::sample_trusted_contact_frank())
+    }
+    pub fn sample_device_babylon() -> Self {
+        Self::new(sargon::FactorSource::sample_device_babylon())
+    }
+    pub fn sample_device_babylon_other() -> Self {
+        Self::new(sargon::FactorSource::sample_device_babylon_other())
+    }
+    pub fn sample_ledger() -> Self {
+        Self::new(sargon::FactorSource::sample_ledger())
+    }
+    pub fn sample_arculus() -> Self {
+        Self::new(sargon::FactorSource::sample_arculus())
+    }
+    pub fn sample_arculus_other() -> Self {
+        Self::new(sargon::FactorSource::sample_arculus_other())
+    }
+    pub fn sample_ledger_other() -> Self {
+        Self::new(sargon::FactorSource::sample_ledger_other())
     }
 }
 
@@ -705,6 +751,86 @@ mod tests {
         assert_eq!(
             shield.matrix_of_factors.confirmation_role.override_factors,
             vec![FactorSourceID::sample_device()]
+        );
+    }
+
+    #[test]
+    fn auto_assign() {
+        let sut = SUT::new();
+        let all_factors_in_profile = vec![
+            FactorSource::sample_password(),
+            FactorSource::sample_trusted_contact_frank(),
+            FactorSource::sample_device_babylon(),
+            FactorSource::sample_device_babylon_other(),
+            FactorSource::sample_ledger(),
+            FactorSource::sample_arculus(),
+            FactorSource::sample_arculus_other(),
+            FactorSource::sample_ledger_other(),
+        ];
+        let name = "Auto Built";
+        let days_to_auto_confirm = 237;
+        sut.set_name(name.to_owned());
+        sut.set_number_of_days_until_auto_confirm(days_to_auto_confirm);
+        sut.set_threshold(2);
+        sut.add_factor_source_to_primary_threshold(
+            FactorSource::sample_device_babylon().id(),
+        );
+        sut.add_factor_source_to_primary_threshold(
+            FactorSource::sample_ledger().id(),
+        );
+
+        sut.auto_assign_factors_to_recovery_and_confirmation_based_on_primary(
+            all_factors_in_profile.clone(),
+        )
+        .unwrap();
+
+        let shield = sut.build().unwrap();
+
+        assert_eq!(shield.metadata.display_name.value, name.to_owned());
+        let matrix = shield.matrix_of_factors;
+        assert_eq!(
+            matrix.number_of_days_until_auto_confirm,
+            days_to_auto_confirm
+        );
+
+        pretty_assertions::assert_eq!(
+            matrix.primary_role,
+            PrimaryRoleWithFactorSourceIDs {
+                threshold: 2,
+                threshold_factors: vec![
+                    FactorSourceID::sample_device(),
+                    FactorSourceID::sample_ledger()
+                ],
+                override_factors: Vec::new()
+            }
+        );
+
+        pretty_assertions::assert_eq!(
+            matrix.recovery_role,
+            RecoveryRoleWithFactorSourceIDs {
+                threshold: 0,
+                threshold_factors: Vec::new(),
+                override_factors: vec![
+                    FactorSourceID::sample_trusted_contact(),
+                    FactorSourceID::sample_ledger(),
+                    FactorSourceID::sample_arculus_other(),
+                    FactorSourceID::sample_ledger_other(),
+                ]
+            }
+        );
+
+        pretty_assertions::assert_eq!(
+            matrix.confirmation_role,
+            ConfirmationRoleWithFactorSourceIDs {
+                threshold: 0,
+                threshold_factors: Vec::new(),
+                override_factors: vec![
+                    FactorSourceID::sample_password(),
+                    FactorSourceID::sample_arculus(),
+                    FactorSourceID::sample_device(),
+                    FactorSourceID::sample_device_other(),
+                ]
+            }
         );
     }
 }

--- a/crates/sargon-uniffi/src/signing/neglected_factors.rs
+++ b/crates/sargon-uniffi/src/signing/neglected_factors.rs
@@ -31,14 +31,7 @@ impl From<InternalNeglectedFactors> for NeglectedFactors {
 
 impl From<NeglectedFactors> for InternalNeglectedFactors {
     fn from(value: NeglectedFactors) -> Self {
-        Self::new(
-            value.reason.into_internal(),
-            value
-                .factors
-                .into_iter()
-                .map(|id| id.into_internal())
-                .collect::<sargon::IndexSet<_>>(),
-        )
+        Self::new(value.reason.into_internal(), value.factors.into_internal())
     }
 }
 

--- a/crates/sargon-uniffi/src/signing/sign_response.rs
+++ b/crates/sargon-uniffi/src/signing/sign_response.rs
@@ -1,7 +1,6 @@
 use crate::prelude::*;
 use paste::paste;
 use sargon::IndexMap;
-use sargon::IndexSet;
 
 macro_rules! decl_sign_response {
     (
@@ -47,9 +46,7 @@ macro_rules! decl_sign_response {
                         |item| {
                             (
                                 item.factor_source_id.into_internal(),
-                                sargon::IndexSet::from_iter(
-                                    item.hd_signatures.into_iter().map(|s| s.into_internal()),
-                                ),
+                                item.hd_signatures.into_internal()
                             )
                         },
                     )),

--- a/crates/sargon/Cargo.toml
+++ b/crates/sargon/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sargon"
 # Don't forget to update version in crates/sargon-uniffi/Cargo.toml
-version = "1.1.82"
+version = "1.1.83"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/sargon/Cargo.toml
+++ b/crates/sargon/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sargon"
 # Don't forget to update version in crates/sargon-uniffi/Cargo.toml
-version = "1.1.81"
+version = "1.1.82"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/sargon/Cargo.toml
+++ b/crates/sargon/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sargon"
 # Don't forget to update version in crates/sargon-uniffi/Cargo.toml
-version = "1.1.83"
+version = "1.1.84"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/sargon/src/core/error/common_error.rs
+++ b/crates/sargon/src/core/error/common_error.rs
@@ -821,6 +821,9 @@ pub enum CommonError {
 
     #[error("Signing was rejected by the user")]
     SigningRejected = 10231,
+
+    #[error("Failed to automatically build shield, reason: '{underlying}'")]
+    AutomaticShieldBuildingFailure { underlying: String } = 10232,
 }
 
 impl CommonError {

--- a/crates/sargon/src/profile/logic/account/query_security_structures.rs
+++ b/crates/sargon/src/profile/logic/account/query_security_structures.rs
@@ -48,22 +48,8 @@ impl Profile {
     pub fn security_shield_prerequisites_status(
         &self,
     ) -> SecurityShieldPrerequisitesStatus {
-        let factor_sources = self.factor_sources.clone();
-        let count_excluding_identity = factor_sources
-            .iter()
-            .filter(|f| f.category() != FactorSourceCategory::Identity)
-            .count();
-        let count_hardware = factor_sources
-            .iter()
-            .filter(|f| f.category() == FactorSourceCategory::Hardware)
-            .count();
-        if count_hardware < 1 {
-            SecurityShieldPrerequisitesStatus::HardwareRequired
-        } else if count_excluding_identity < 2 {
-            SecurityShieldPrerequisitesStatus::AnyRequired
-        } else {
-            SecurityShieldPrerequisitesStatus::Sufficient
-        }
+        let factor_sources = self.factor_sources.items();
+        SecurityShieldBuilder::prerequisites_status(&factor_sources)
     }
 }
 

--- a/crates/sargon/src/profile/logic/account/query_security_structures.rs
+++ b/crates/sargon/src/profile/logic/account/query_security_structures.rs
@@ -48,8 +48,12 @@ impl Profile {
     pub fn security_shield_prerequisites_status(
         &self,
     ) -> SecurityShieldPrerequisitesStatus {
-        let factor_sources = self.factor_sources.items();
-        SecurityShieldBuilder::prerequisites_status(&factor_sources)
+        let factor_source_ids = self
+            .factor_sources
+            .iter()
+            .map(|f| f.id())
+            .collect::<IndexSet<_>>();
+        SecurityShieldBuilder::prerequisites_status(&factor_source_ids)
     }
 }
 

--- a/crates/sargon/src/profile/mfa/security_structures/automatic_shield_builder.rs
+++ b/crates/sargon/src/profile/mfa/security_structures/automatic_shield_builder.rs
@@ -1,0 +1,17 @@
+use std::future::Future;
+
+use crate::prelude::*;
+
+pub struct AutomaticShieldBuilder;
+
+impl AutomaticShieldBuilder {
+    pub async fn build<Fut>(
+        all_factors: Vec<FactorSource>,
+        pick_primary_role_factors: impl Fn(Vec<FactorSource>) -> Fut,
+    ) -> Result<SecurityStructureOfFactorSourceIDs>
+    where
+        Fut: Future<Output = Vec<FactorSource>>,
+    {
+        todo!()
+    }
+}

--- a/crates/sargon/src/profile/mfa/security_structures/automatic_shield_builder.rs
+++ b/crates/sargon/src/profile/mfa/security_structures/automatic_shield_builder.rs
@@ -32,10 +32,19 @@ enum FactorSelector {
 }
 
 impl SecurityShieldBuilder {
-    pub fn preselect_using_currently_selected_primary_factors(
+    pub fn auto_assign_factors_to_recovery_and_confirmation_based_on_primary(
         &self,
         all_factors_in_profile: IndexSet<FactorSource>,
     ) -> Result<()> {
+        if let Some(invalid_reason) = self.validate_primary_role() {
+            return Err(CommonError::AutomaticShieldBuildingFailure {
+                underlying: format!(
+                    "Primary role is not valid: {:?}",
+                    invalid_reason
+                ),
+            });
+        }
+
         if !self.get_primary_override_factors().is_empty() {
             return Err(CommonError::AutomaticShieldBuildingFailure {
                 underlying: "Primary override factors not allowed when preselecting factors for Recovery and Confirmation".to_string(),
@@ -372,7 +381,7 @@ mod tests {
             pick_primary_role_factors.into_iter().for_each(|f| {
                 shield_builder.add_factor_source_to_primary_threshold(f);
             });
-            shield_builder.preselect_using_currently_selected_primary_factors(
+            shield_builder.auto_assign_factors_to_recovery_and_confirmation_based_on_primary(
                 all_factors_in_profile,
             )?;
 

--- a/crates/sargon/src/profile/mfa/security_structures/automatic_shield_builder.rs
+++ b/crates/sargon/src/profile/mfa/security_structures/automatic_shield_builder.rs
@@ -507,6 +507,8 @@ impl AutomaticShieldBuilder {
 mod tests {
     use std::sync::Mutex;
 
+    use indexmap::IndexSet;
+
     use super::*;
 
     #[allow(clippy::upper_case_acronyms)]
@@ -615,5 +617,14 @@ mod tests {
             built.matrix_of_factors.primary_role.get_threshold_factors(),
             &factors.into_iter().collect_vec()
         );
+    }
+
+    #[actix_rt::test]
+    #[should_panic]
+    async fn selection_of_primary_invalid_only_one_password() {
+        let _ = SUT::test_valid(
+            |_| IndexSet::just(FactorSourceID::sample_password()), // invalid for primary
+        )
+        .await;
     }
 }

--- a/crates/sargon/src/profile/mfa/security_structures/automatic_shield_builder.rs
+++ b/crates/sargon/src/profile/mfa/security_structures/automatic_shield_builder.rs
@@ -25,32 +25,31 @@ impl AutomaticShieldBuilder {
         .collect_vec()
     }
 
-    fn recovery_role_factors(&mut self) -> Result<Vec<FactorSourceID>> {
-        let contact_factors = self
-            .remaining_available_factors
+    fn factors_of_category(
+        &self,
+        category: FactorSourceCategory,
+    ) -> Vec<FactorSource> {
+        self.remaining_available_factors
             .iter()
-            .filter(|f| f.category() == FactorSourceCategory::Contact)
-            // .sorted_by_key(|x| x.)
+            .filter(|f| f.category() == category)
+            .sorted_by_key(|&f| f.common_properties().last_used_on)
             .cloned()
-            .collect_vec();
+            .collect_vec()
+    }
 
-        let hardware = self
-            .remaining_available_factors
-            .iter()
-            .filter(|f| f.category() == FactorSourceCategory::Hardware)
-            .cloned()
-            .collect_vec();
+    fn recovery_role_factors(&mut self) -> Result<Vec<FactorSourceID>> {
+        let contact_factors =
+            self.factors_of_category(FactorSourceCategory::Contact);
+        let hardware_factors =
+            self.factors_of_category(FactorSourceCategory::Hardware);
 
         todo!()
     }
 
     fn confirmation_role_factors(&mut self) -> Result<Vec<FactorSourceID>> {
-        let information_factors = self
-            .remaining_available_factors
-            .iter()
-            .filter(|f| f.category() == FactorSourceCategory::Information)
-            .cloned()
-            .collect_vec();
+        let information_factors =
+            self.factors_of_category(FactorSourceCategory::Information);
+
         Ok(vec![])
     }
 

--- a/crates/sargon/src/profile/mfa/security_structures/automatic_shield_builder.rs
+++ b/crates/sargon/src/profile/mfa/security_structures/automatic_shield_builder.rs
@@ -17,6 +17,24 @@ pub struct AutomaticShieldBuilder {
 
 use FactorSourceCategory::*;
 use RoleKind::*;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, EnumAsInner)]
+enum Quantity {
+    All,
+    Fixed(usize),
+}
+impl Quantity {
+    fn one() -> Self {
+        Self::Fixed(1)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FactorSelector {
+    Category(FactorSourceCategory),
+    Kind(FactorSourceKind),
+}
+
 impl AutomaticShieldBuilder {
     fn new(
         available_factors: IndexSet<FactorSource>,
@@ -627,7 +645,6 @@ mod tests {
             },
         )
         .await;
-
         let matrix = res.unwrap().matrix_of_factors;
 
         pretty_assertions::assert_eq!(
@@ -653,21 +670,4 @@ mod tests {
             ],)
         );
     }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, EnumAsInner)]
-enum Quantity {
-    All,
-    Fixed(usize),
-}
-impl Quantity {
-    fn one() -> Self {
-        Self::Fixed(1)
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum FactorSelector {
-    Category(FactorSourceCategory),
-    Kind(FactorSourceKind),
 }

--- a/crates/sargon/src/profile/mfa/security_structures/automatic_shield_builder.rs
+++ b/crates/sargon/src/profile/mfa/security_structures/automatic_shield_builder.rs
@@ -37,18 +37,62 @@ impl AutomaticShieldBuilder {
             .collect_vec()
     }
 
+    fn consume_factor_and_add_to(
+        &mut self,
+        factor: FactorSourceID,
+        add_to: &mut Vec<FactorSourceID>,
+    ) {
+        todo!()
+    }
+
+    fn add_factors_of_categories_if_able(
+        &mut self,
+        categories: &[FactorSourceCategory],
+        to: &mut Vec<FactorSourceID>,
+    ) {
+        categories.iter().for_each(|&category| {
+            if let Some(factor) =
+                self.factors_of_category(category).iter().next()
+            {
+                self.consume_factor_and_add_to(factor.id(), to);
+            }
+        });
+    }
+
+    fn add_custodian_and_hardware_factors_if_able(
+        &mut self,
+        to: &mut Vec<FactorSourceID>,
+    ) {
+        self.add_factors_of_categories_if_able(
+            &[
+                FactorSourceCategory::Custodian,
+                FactorSourceCategory::Hardware,
+            ],
+            to,
+        );
+    }
+
     fn recovery_role_factors(&mut self) -> Result<Vec<FactorSourceID>> {
-        let contact_factors =
-            self.factors_of_category(FactorSourceCategory::Contact);
-        let hardware_factors =
-            self.factors_of_category(FactorSourceCategory::Hardware);
+        let mut factors = self
+            .factors_of_category(FactorSourceCategory::Contact)
+            .iter()
+            .map(|f| f.id())
+            .collect_vec();
+
+        self.add_custodian_and_hardware_factors_if_able(&mut factors);
 
         todo!()
     }
 
-    fn confirmation_role_factors(&mut self) -> Result<Vec<FactorSourceID>> {
-        let information_factors =
-            self.factors_of_category(FactorSourceCategory::Information);
+    fn confirmation_role_factors(
+        &mut self,
+        recovery_factors: &[FactorSourceID],
+    ) -> Result<Vec<FactorSourceID>> {
+        let mut factors = self
+            .factors_of_category(FactorSourceCategory::Information)
+            .iter()
+            .map(|f| f.id())
+            .collect_vec();
 
         Ok(vec![])
     }
@@ -88,9 +132,14 @@ impl AutomaticShieldBuilder {
             .set_threshold(self.picked_primary_role_factors.len() as u8);
 
         let recovery_factors = &self.recovery_role_factors()?;
-        self.add_factors_to_role(recovery_factors, RoleKind::Recovery);
-
         let confirmation_factors = &self.confirmation_role_factors()?;
+
+        loop {
+            let is_done = false;
+            
+        }
+
+        self.add_factors_to_role(recovery_factors, RoleKind::Recovery);
         self.add_factors_to_role(confirmation_factors, RoleKind::Confirmation);
 
         self.shield_builder.build().map_err(|e| {

--- a/crates/sargon/src/profile/mfa/security_structures/automatic_shield_builder.rs
+++ b/crates/sargon/src/profile/mfa/security_structures/automatic_shield_builder.rs
@@ -2,8 +2,23 @@ use std::future::Future;
 
 use crate::prelude::*;
 
-pub struct AutomaticShieldBuilder;
+use super::security_shield_builder;
 
+pub struct AutomaticShieldBuilder {
+    all_factors: Vec<FactorSource>,
+    picked_primary_role_factors: Vec<FactorSource>,
+    shield_builder: SecurityShieldBuilder,
+}
+
+impl AutomaticShieldBuilder {
+    fn find_primary_role_candidates(all: &[FactorSource]) -> Vec<FactorSource> {
+        todo!()
+    }
+
+    fn build_shield(self) -> Result<SecurityStructureOfFactorSourceIDs> {
+        todo!()
+    }
+}
 impl AutomaticShieldBuilder {
     pub async fn build<Fut>(
         all_factors: Vec<FactorSource>,
@@ -12,6 +27,14 @@ impl AutomaticShieldBuilder {
     where
         Fut: Future<Output = Vec<FactorSource>>,
     {
-        todo!()
+        let candidates = Self::find_primary_role_candidates(&all_factors);
+        let picked = pick_primary_role_factors(candidates).await;
+        let security_shield_builder = SecurityShieldBuilder::new();
+        let auto_builder = Self {
+            all_factors,
+            picked_primary_role_factors: picked,
+            shield_builder: security_shield_builder,
+        };
+        auto_builder.build_shield()
     }
 }

--- a/crates/sargon/src/profile/mfa/security_structures/automatic_shield_builder.rs
+++ b/crates/sargon/src/profile/mfa/security_structures/automatic_shield_builder.rs
@@ -5,19 +5,52 @@ use crate::prelude::*;
 use super::security_shield_builder;
 
 pub struct AutomaticShieldBuilder {
+    #[allow(dead_code)]
+    #[doc(hidden)]
+    hidden: HiddenConstructor,
     remaining_available_factors: IndexSet<FactorSource>,
-    picked_primary_role_factors: IndexSet<FactorSourceID>,
+    primary: IndexSet<FactorSourceID>,
+    recovery: IndexSet<FactorSourceID>,
+    confirmation: IndexSet<FactorSourceID>,
     shield_builder: SecurityShieldBuilder,
 }
 
+use FactorSourceCategory::*;
+use RoleKind::*;
 impl AutomaticShieldBuilder {
+    fn new(
+        available_factors: IndexSet<FactorSource>,
+        user_selected_primary: IndexSet<FactorSourceID>,
+    ) -> Self {
+        assert!(
+            user_selected_primary
+                .difference(
+                    &available_factors
+                        .iter()
+                        .map(|f| f.id())
+                        .collect::<IndexSet<_>>()
+                )
+                .collect::<IndexSet<_>>()
+                .is_empty(),
+            "All user_selected_primary must be in available_factors"
+        );
+        Self {
+            hidden: HiddenConstructor,
+            remaining_available_factors: available_factors,
+            primary: user_selected_primary,
+            recovery: IndexSet::new(),
+            confirmation: IndexSet::new(),
+            shield_builder: SecurityShieldBuilder::new(),
+        }
+    }
+
     fn find_primary_role_candidates(
         all: &IndexSet<FactorSource>,
-        shield_builder: &SecurityShieldBuilder,
     ) -> IndexSet<FactorSource> {
+        let ephemeral = SecurityShieldBuilder::new();
         let factor_source_ids =
             all.iter().map(|f| f.id()).collect::<IndexSet<_>>();
-        shield_builder.validation_for_addition_of_factor_source_to_primary_threshold_for_each(factor_source_ids.into_iter().collect_vec()).into_iter().filter(|vs| match vs.validation {
+        ephemeral.validation_for_addition_of_factor_source_to_primary_threshold_for_each(factor_source_ids.into_iter().collect_vec()).into_iter().filter(|vs| match vs.validation {
             Ok(_) => true,
             Err(RoleBuilderValidation::NotYetValid(_)) => true,
             Err(RoleBuilderValidation::BasicViolation(_)) |  Err(RoleBuilderValidation::ForeverInvalid(_)) => false,
@@ -26,352 +59,203 @@ impl AutomaticShieldBuilder {
         .collect::<IndexSet<_>>()
     }
 
-    fn factors_of_category(
-        &self,
-        category: FactorSourceCategory,
-    ) -> IndexSet<FactorSource> {
-        self.remaining_available_factors
-            .iter()
-            .filter(|f| f.category() == category)
-            .sorted_by_key(|&f| f.common_properties().last_used_on)
-            .cloned()
-            .collect::<IndexSet<_>>()
-    }
-
-    fn consume(&mut self, factor: FactorSourceID) {
-        self.remaining_available_factors
-            .retain(|f| f.id() != factor);
-    }
-
-    fn consume_factor_and_add_to(
+    fn assign_factors_matching_selector(
         &mut self,
-        factor: FactorSourceID,
-        add_to: &mut IndexSet<FactorSourceID>,
+        to: RoleKind,
+        selector: FactorSelector,
+        quantity_to_add: Quantity,
     ) {
-        let was_inserted = add_to.insert(factor);
-        assert!(was_inserted);
-        self.consume(factor);
-    }
-}
+        let target_role = to;
 
-struct ShouldAddFactorToListEvaluation {
-    target_categories_with_kind_restrictions:
-        IndexMap<FactorSourceCategory, IndexSet<FactorSourceKind>>,
-    target_amount: Option<Amount>, // None means use ALL
-}
-impl ShouldAddFactorToListEvaluation {
-    fn target_categories(&self) -> IndexSet<FactorSourceCategory> {
-        self.target_categories_with_kind_restrictions
-            .keys()
-            .cloned()
-            .collect()
-    }
-
-    fn with(
-        target_categories_with_kind_restrictions: IndexMap<
-            FactorSourceCategory,
-            IndexSet<FactorSourceKind>,
-        >,
-        target_amount: impl Into<Option<Amount>>,
-    ) -> Self {
-        target_categories_with_kind_restrictions
+        let mut factors_to_add = self
+            .remaining_available_factors
             .iter()
-            .for_each(|(k, v)| {
-                v.iter().for_each(|x| assert_eq!(x.category(), *k))
-            });
+            .filter(|&f| match selector {
+                FactorSelector::Category(category) => f.category() == category,
+                FactorSelector::Kind(kind) => f.factor_source_kind() == kind,
+            })
+            .map(|f| f.id())
+            .collect::<IndexSet<_>>();
 
-        Self {
-            target_categories_with_kind_restrictions,
-            target_amount: target_amount.into(),
-        }
-    }
-
-    fn new(
-        target_categories: impl IntoIterator<Item = FactorSourceCategory>,
-        target_amount: impl Into<Option<Amount>>,
-    ) -> Self {
-        Self::with(
-            target_categories
+        if let Some(quantity) = quantity_to_add.as_fixed() {
+            factors_to_add = factors_to_add
                 .into_iter()
-                .map(|c| (c, IndexSet::new()))
-                .collect::<IndexMap<_, _>>(),
-            target_amount,
-        )
-    }
+                .take(*quantity)
+                .collect::<IndexSet<_>>();
+        }
 
-    fn is_required(&self) -> bool {
-        let Some(target_amount) = &self.target_amount else {
-            return false;
+        let target_factors = match target_role {
+            Primary => &mut self.primary,
+            Recovery => &mut self.recovery,
+            Confirmation => &mut self.confirmation,
         };
-        target_amount.is_required
+
+        self.remaining_available_factors
+            .retain(|f| !factors_to_add.contains(&f.id()));
+
+        target_factors.extend(factors_to_add);
     }
 
-    fn assert_fulfilled(&self, actual: usize) -> Result<()> {
-        let Some(target_amount) = &self.target_amount else {
-            return Ok(());
-        };
-        target_amount.assert_fulfilled(actual)
+    fn factor_for_role(&self, role: RoleKind) -> &IndexSet<FactorSourceID> {
+        match role {
+            Primary => &self.primary,
+            Recovery => &self.recovery,
+            Confirmation => &self.confirmation,
+        }
     }
 
-    /// Nil means the requirement cannot be fulfilled by ADDING factors, since too
-    /// many are already present.
-    fn number_of_factors_of_category_to_add(
-        &self,
+    fn assign_factors_of_category(
+        &mut self,
+        to: RoleKind,
         category: FactorSourceCategory,
-        current_len_of_factor_list: usize,
-    ) -> Option<usize> {
-        let Some(target_amount) = &self.target_amount else {
-            return Some(usize::MAX); // Add "All"
-        };
-        if self.target_categories().contains(&category) {
-            target_amount.left_until_fulfilled(current_len_of_factor_list)
-        } else {
-            Some(0)
-        }
-    }
-}
-
-impl AutomaticShieldBuilder {
-    fn add_quantified_factors_of_categories_to_set_if_able(
-        &mut self,
-        to: &mut IndexSet<FactorSourceID>,
-        eval: ShouldAddFactorToListEvaluation,
-    ) -> Result<()> {
-        for category in eval.target_categories().iter() {
-            let factors_of_category = self.factors_of_category(*category);
-
-            let Some(q) =
-                eval.number_of_factors_of_category_to_add(*category, to.len())
-            else {
-                continue;
-            };
-
-            if q == 0 {
-                continue;
-            }
-
-            if factors_of_category.len() < q && eval.is_required() {
-                return Err(CommonError::AutomaticShieldBuildingFailure {
-                    underlying: format!(
-                        "Not enough factors of category {:?}",
-                        category
-                    ),
-                });
-            }
-
-            let quantified_factors = factors_of_category
-                .iter()
-                .take(q)
-                .cloned()
-                .collect::<IndexSet<_>>();
-
-            quantified_factors.into_iter().for_each(|factor| {
-                self.consume_factor_and_add_to(factor.id(), to);
-            });
-        }
-
-        eval.assert_fulfilled(to.len())
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct Amount {
-    is_required: bool,
-    quantity: RequestedQuantity,
-}
-
-impl Amount {
-    fn new(is_required: bool, quantity: RequestedQuantity) -> Self {
-        Self {
-            is_required,
-            quantity,
-        }
-    }
-
-    /// `None` means the requirement cannot be fulfilled by ADDING factors, since too
-    /// many are already present.
-    fn left_until_fulfilled(&self, actual: usize) -> Option<usize> {
-        let left = self.quantity.left_until_fulfilled(actual);
-        if left < 0 {
-            None
-        } else {
-            Some(left as usize)
-        }
-    }
-
-    fn is_fulfilled(&self, actual: usize) -> bool {
-        if let Some(remaining) = self.left_until_fulfilled(actual) {
-            remaining == 0
-        } else {
-            false
-        }
-    }
-
-    fn assert_fulfilled(&self, actual: usize) -> Result<()> {
-        if !self.is_required {
-            return Ok(());
-        }
-        if !self.is_fulfilled(actual) {
-            return Err(CommonError::AutomaticShieldBuildingFailure {
-                underlying: format!(
-                    "Quantity requirement not met: {:?} != {:?}",
-                    self, actual
-                ),
-            });
-        }
-        Ok(())
-    }
-}
-
-impl AutomaticShieldBuilder {
-    fn add_one_hardware_factor_to_set_if_able(
-        &mut self,
-        to: &mut IndexSet<FactorSourceID>,
-        target_amount: Amount,
-    ) -> Result<()> {
-        self.add_quantified_factors_of_categories_to_set_if_able(
+        quantity_to_add: Quantity,
+    ) {
+        self.assign_factors_matching_selector(
             to,
-            ShouldAddFactorToListEvaluation::new(
-                [FactorSourceCategory::Hardware],
-                target_amount,
-            ),
+            FactorSelector::Category(category),
+            quantity_to_add,
         )
     }
 
-    fn add_factors_to_role(
-        &self,
-        factors: &IndexSet<FactorSourceID>,
-        role: RoleKind,
+    fn assign_factors_of_kind(
+        &mut self,
+        to: RoleKind,
+        kind: FactorSourceKind,
+        quantity_to_add: Quantity,
     ) {
-        factors.into_iter().for_each(|&f| match role {
-            RoleKind::Primary => {
-                self.shield_builder
-                    .add_factor_source_to_primary_threshold(f);
-            }
-            RoleKind::Recovery => {
-                self.shield_builder
-                    .add_factor_source_to_recovery_override(f);
-            }
-            RoleKind::Confirmation => {
-                self.shield_builder
-                    .add_factor_source_to_confirmation_override(f);
-            }
-        });
+        self.assign_factors_matching_selector(
+            to,
+            FactorSelector::Kind(kind),
+            quantity_to_add,
+        )
     }
 
-    fn _build_shield(&mut self) -> Result<SecurityStructureOfFactorSourceIDs> {
-        // Primary
-        {
-            if self.picked_primary_role_factors.len() == 1 {
-                // if the user chose only 1 that factor cannot be used in the recovery or confirmation roles
-                self.remaining_available_factors
-                    .retain(|f| f.id() != self.picked_primary_role_factors[0]);
-            }
-            self.add_factors_to_role(
-                &self.picked_primary_role_factors,
-                RoleKind::Primary,
-            );
-            self.shield_builder
-                .set_threshold(self.picked_primary_role_factors.len() as u8);
-        }
+    fn assign_one_hardware_factor(&mut self, to: RoleKind) {
+        self.assign_factors_of_category(
+            to,
+            FactorSourceCategory::Hardware,
+            Quantity::one(),
+        )
+    }
 
-        let (recovery_factors, confirmation_factors) = {
-            let mut recovery_factors = self
-                .factors_of_category(FactorSourceCategory::Contact)
-                .iter()
-                .map(|f| f.id())
-                .collect::<IndexSet<_>>();
+    fn count_factors_for_role(&self, role_kind: RoleKind) -> u8 {
+        self.factor_for_role(role_kind).len() as u8
+    }
 
-            let mut confirmation_factors = self
-                .factors_of_category(FactorSourceCategory::Information)
-                .iter()
-                .map(|f| f.id())
-                .collect::<IndexSet<_>>();
+    fn assign_factors_of_category_to_primary(
+        &mut self,
+        category: FactorSourceCategory,
+        quantity_to_add: Quantity,
+    ) {
+        self.assign_factors_of_category(Primary, category, quantity_to_add);
+    }
 
-            self.add_one_hardware_factor_to_set_if_able(
-                &mut recovery_factors,
-                Amount::new(true, RequestedQuantity::at_least(1)),
-            )?;
+    fn assign_factors_of_category_to_recovery(
+        &mut self,
+        category: FactorSourceCategory,
+        quantity_to_add: Quantity,
+    ) {
+        self.assign_factors_of_category(Recovery, category, quantity_to_add)
+    }
 
-            self.add_quantified_factors_of_categories_to_set_if_able(
-                &mut recovery_factors,
-                ShouldAddFactorToListEvaluation::new(
-                    [FactorSourceCategory::Custodian],
-                    Amount::new(false, RequestedQuantity::at_least(1)),
-                ),
-            )?;
+    fn assign_factors_of_category_to_confirmation(
+        &mut self,
+        category: FactorSourceCategory,
+        quantity_to_add: Quantity,
+    ) {
+        self.assign_factors_of_category(Confirmation, category, quantity_to_add)
+    }
+}
 
-            self.add_one_hardware_factor_to_set_if_able(
-                &mut confirmation_factors,
-                Amount::new(true, RequestedQuantity::at_least(1)),
-            )?;
+impl AutomaticShieldBuilder {
+    fn _do_build_shield(&self) -> Result<SecurityStructureOfFactorSourceIds> {
+        let builder = &self.shield_builder;
+        builder.set_threshold(self.count_factors_for_role(Primary));
+        self.primary.iter().for_each(|&f| {
+            builder.add_factor_source_to_primary_threshold(f);
+        });
+        self.recovery.iter().for_each(|&f| {
+            builder.add_factor_source_to_recovery_override(f);
+        });
+        self.confirmation.iter().for_each(|&f| {
+            builder.add_factor_source_to_confirmation_override(f);
+        });
 
-            self.add_quantified_factors_of_categories_to_set_if_able(
-                &mut confirmation_factors,
-                ShouldAddFactorToListEvaluation::new(
-                    [FactorSourceCategory::Custodian],
-                    Amount::new(false, RequestedQuantity::at_least(1)),
-                ),
-            )?;
-
-            // "Distribute to try to get up to 2 RECOVERY and then 2 CONFIRM factors if possible"
-            {
-                self.add_one_hardware_factor_to_set_if_able(
-                    &mut recovery_factors,
-                    Amount::new(false, RequestedQuantity::exactly(2)),
-                )?;
-
-                self.add_one_hardware_factor_to_set_if_able(
-                    &mut confirmation_factors,
-                    Amount::new(false, RequestedQuantity::exactly(2)),
-                )?;
-            }
-
-            // "Add any (and all) remaining Hardware or Custodian factors in the list to RECOVERY."
-            self.add_quantified_factors_of_categories_to_set_if_able(
-                &mut recovery_factors,
-                ShouldAddFactorToListEvaluation::new(
-                    [
-                        FactorSourceCategory::Hardware,
-                        FactorSourceCategory::Custodian,
-                    ],
-                    None,
-                ),
-            )?;
-
-            // "Set all Biometrics/PIN factors to a role (they must be all in one role because they
-            // are unlocked by the same Biometrics/PIN check)":
-            let target_list =
-                if recovery_factors.len() > confirmation_factors.len() {
-                    // "If there are more RECOVERY factors than CONFIRM factors, add any (and all) Biometrics/PIN factors to CONFIRM"
-                    &mut confirmation_factors
-                } else {
-                    // "Else, add any (and all) Biometrics/PIN factors to RECOVERY."
-                    &mut recovery_factors
-                };
-
-            self.add_quantified_factors_of_categories_to_set_if_able(
-                target_list,
-                ShouldAddFactorToListEvaluation::with(
-                    IndexMap::kv(
-                        FactorSourceCategory::Identity,
-                        IndexSet::just(FactorSourceKind::Device),
-                    ),
-                    None,
-                ),
-            )?;
-
-            Ok((recovery_factors, confirmation_factors))
-        }?;
-
-        self.add_factors_to_role(&recovery_factors, RoleKind::Recovery);
-        self.add_factors_to_role(&confirmation_factors, RoleKind::Confirmation);
-
-        self.shield_builder.build().map_err(|e| {
+        builder.build().map_err(|e| {
             CommonError::AutomaticShieldBuildingFailure {
                 underlying: format!("{:?}", e),
             }
         })
+    }
+
+    fn _build_shield(&mut self) -> Result<SecurityStructureOfFactorSourceIds> {
+        // 📒 "If the user only chose 1 factor for PRIMARY, remove that factor from the list (it cannot be used elsewhere - otherwise it can)."
+        {
+            if self.count_factors_for_role(Primary) == 1
+                && let Some(only_primary_factor) = self.primary.iter().next()
+            {
+                self.remaining_available_factors
+                    .retain(|f| f.id() != *only_primary_factor);
+            }
+        }
+
+        // 📒 "Drop in the somewhat “special-use” factors first"
+        {
+            // 📒	"Add all Contact factors in the list to RECOVERY."
+            self.assign_factors_of_category_to_recovery(Contact, Quantity::All);
+
+            // 📒	"Add all Information factors in the list to CONFIRMATION."
+            self.assign_factors_of_category_to_confirmation(
+                Information,
+                Quantity::All,
+            );
+        }
+
+        let mut distribute_custodian_and_hardware_to_non_primary = || {
+            // 📒 "Add any Custodian.." 🙅‍♀️  Custodian FactorSources does not exist yet...
+
+            // 📒 "Add any Hardware factors in the list, starting with the most recently used, to RECOVERY
+            // until there is at least 1 factor source in RECOVERY."
+            // ❓ SHOULD WE ALWAYS DO THIS? OR ONLY IF count_factors_for_role(Recovery) < 1?
+            self.assign_one_hardware_factor(Recovery);
+            // ❓ WHAT TO DO IF THERE WAS NONE?
+
+            // 📒 "Add any Hardware (Ledger, Arculus, Yubikey) factors in the list, starting with the most recently used, to CONFIRMATION until there is at least 1 factor factors in CONFIRMATION."
+            // ❓ SHOULD WE ALWAYS DO THIS? OR ONLY IF count_factors_for_role(Confirmation) < 1?
+            self.assign_one_hardware_factor(Confirmation);
+            // ❓ WHAT TO DO IF THERE WAS NONE?
+        };
+
+        // 📒 "Distribute to try to get at least 1 RECOVERY and then 1 CONFIRMATION"
+        distribute_custodian_and_hardware_to_non_primary();
+
+        // 📒 "Distribute to try to get up to 2 RECOVERY and then 2 CONFIRMATION factors if possible"
+        distribute_custodian_and_hardware_to_non_primary();
+
+        // 📒 "Fill in any remaining other factors to increase reliability of being able to recover"
+        {
+            // 📒 "Add any (and all) remaining Hardware or Custodian factors in the list to RECOVERY."
+            self.assign_factors_of_category_to_primary(Hardware, Quantity::All);
+
+            // 📒 "Set all Biometrics/PIN factors to a role (they must be all in one role because they are unlocked by the same Biometrics/PIN check):"
+            {
+                self.assign_factors_of_kind(
+                    if self.count_factors_for_role(Recovery)
+                        > self.count_factors_for_role(Confirmation)
+                    {
+                        // 📒 "If there are more RECOVERY factors than CONFIRMATION factors, add any (and all) Biometrics/PIN factors to CONFIRMATION"
+                        Confirmation
+                    } else {
+                        // 📒 "Else, add any (and all) Biometrics/PIN factors to RECOVERY."
+                        Recovery
+                    },
+                    FactorSourceKind::Device,
+                    Quantity::All,
+                );
+            }
+        }
+
+        self._do_build_shield()
     }
 
     fn build_shield(self) -> Result<SecurityStructureOfFactorSourceIDs> {
@@ -481,11 +365,7 @@ impl AutomaticShieldBuilder {
                 underlying: "Prerequisites not met".to_string(),
             });
         }
-        let security_shield_builder = SecurityShieldBuilder::new();
-        let candidates = Self::find_primary_role_candidates(
-            &all_factors,
-            &security_shield_builder,
-        );
+        let candidates = Self::find_primary_role_candidates(&all_factors);
         let validated_picked: IndexSet<FactorSourceID> =
             pick_primary_role_factors(
                 candidates,
@@ -494,11 +374,7 @@ impl AutomaticShieldBuilder {
             .await
             .validated_picked;
 
-        let auto_builder = Self {
-            remaining_available_factors: all_factors.into_iter().collect(),
-            picked_primary_role_factors: validated_picked,
-            shield_builder: security_shield_builder,
-        };
+        let auto_builder = Self::new(all_factors, validated_picked);
         auto_builder.build_shield()
     }
 }
@@ -734,7 +610,7 @@ mod tests {
     }
 
     #[actix_rt::test]
-    async fn one_device_factor_source_and_two_ledger_is_not_ok_if_ledger_is_used_for_primary(
+    async fn one_device_factor_source_and_two_ledger_is_ok_when_primary_uses_one_ledger(
     ) {
         let res = SUT::build(
             IndexSet::from_iter([
@@ -752,226 +628,46 @@ mod tests {
         )
         .await;
 
-        println!("🔮 {:?}", res);
-        assert!(matches!(
-            res,
-            Err(CommonError::AutomaticShieldBuildingFailure { .. })
-        ));
+        let matrix = res.unwrap().matrix_of_factors;
+
+        pretty_assertions::assert_eq!(
+            matrix.primary(),
+            &PrimaryRoleWithFactorSourceIds::with_factors(
+                1,
+                [FactorSourceID::sample_ledger()],
+                []
+            )
+        );
+
+        pretty_assertions::assert_eq!(
+            matrix.recovery(),
+            &RecoveryRoleWithFactorSourceIds::override_only([
+                FactorSourceID::sample_ledger_other()
+            ],)
+        );
+
+        pretty_assertions::assert_eq!(
+            matrix.confirmation(),
+            &ConfirmationRoleWithFactorSourceIds::override_only([
+                FactorSourceID::sample_device()
+            ],)
+        );
     }
 }
 
-/*
+#[derive(Debug, Clone, Copy, PartialEq, Eq, EnumAsInner)]
 enum Quantity {
     All,
-    Fixed(u8)
-    pub fn one() -> Self {
+    Fixed(usize),
+}
+impl Quantity {
+    fn one() -> Self {
         Self::Fixed(1)
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum FactorSelector {
-    Category(FactorCategory),
-    Kind(FactorSourceKind)
+    Category(FactorSourceCategory),
+    Kind(FactorSourceKind),
 }
-
-pub struct AutoShieldBuilder {
-    shield_builder: SecurityShieldBuilder,
-    all_available_factors: IndexSet<FactorSource>
-}
-
-impl AutoShieldBuilder {
-
-    pub fn new(all_available_factors: IndexSet<FactorSource>, user_chosen) {
-        let candiates_for_primary_role = filter_out_valid_primary_role_factors_from(all_available_factors);
-        let user_chosen_primary_factors = wallet_ui.user_selects(candiates_for_primary_role).await;
-
-        // 📒 "If the user only chose 1 factor for ACCESS, remove that factor from the list (it cannot be used elsewhere - otherwise it can)."
-        if user_chosen_primary_factors.len() == 1 {
-            all_available_factors.remove_one(user_chosen_primary_factors.first())
-        }
-
-        shield_builder.set_threshold(user_chosen_primary_factors.len());
-    }
-
-    fn assign_factors_matching_selector(
-        &mut self,
-        to: &mut IndexSet<FactorSource>,
-        selector: FactorSelector,
-        quantity_to_add: Quantity
-    ) {
-        let all_filtered = self.all_available_factors.filter(selector)
-        let quantified_filtered = all_filtered.take(quantity);
-        target_factors.add_all(quantified_filtered)
-        self.all_available_factors.remove_all(quantified_filtered)
-    }
-
-
-    fn assign_factors_of_category(
-        &mut self,
-        to: &mut IndexSet<FactorSource>,
-        category: FactorCategory,
-        quantity_to_add: Quantity
-    ) {
-        self.assign_factors_matching_selector(
-            to: to,
-            selector: FactorSelector::Category(category),
-            quantity_to_add: quantity_to_add
-        )
-    }
-
-    fn assign_factors_of_kind(
-        &mut self,
-        to: &mut IndexSet<FactorSource>,
-        kind: FactorSourceKind,
-        quantity_to_add: Quantity
-    ) {
-        self.assign_factors_matching_selector(
-            to: to,
-            selector: FactorSelector::Kind(kind),
-            quantity_to_add: quantity_to_add
-        )
-    }
-
-
-    fn assign_one_hardware_factor(
-        &mut self,
-        to: &mut IndexSet<FactorSource>,
-    ) {
-        self.assign_factors_of_category(
-            to: to,
-            category: FactorCategory::Hardware,
-            quantity_to_add: Quantity::one()
-        )
-    }
-
-    fn assign_factors_of_category_to_primary(
-        &mut self,
-        category: FactorCategory,
-        quantity_to_add: Quantity
-    ) {
-        self.assign_factors_of_category(
-            to: primary,
-            category: category,
-            quantity_to_add: quantity_to_add
-        )
-        // For Primary role, dont forget to update threshold
-        shield_builder.set_threshold(primary.len());
-    }
-
-
-    fn assign_factors_of_category_to_recovery(
-        &mut self,
-        category: FactorCategory,
-        quantity_to_add: Quantity
-    ) {
-        self.assign_factors_of_category(
-            to: recovery,
-            category: category,
-            quantity_to_add: quantity_to_add
-        )
-    }
-
-
-    fn assign_factors_of_category_to_confirmation(
-        &mut self,
-        category: FactorCategory,
-        quantity_to_add: Quantity
-    ) {
-        self.assign_factors_of_category(
-            to: confirmation,
-            category: category,
-            quantity_to_add: quantity_to_add
-        )
-    }
-
-    pub fn auto_build_factors(&mut self) -> MatrixOfFactorSources {
-
-        let mut primary = self.user_chosen_primary_factors;
-        // Non user chosen factors, auto chosen by the heuristics laid out by Matt
-        // in: https://radixdlt.atlassian.net/wiki/spaces/AT/pages/3758063620/MFA+Rules+for+Factors+and+Security+Shields
-        let mut recovery: IndexSet<FactorSource>;
-        let mut confirmation: IndexSet<FactorSource>;
-
-
-        // 📒 "Drop in the somewhat “special-use” factors first"
-        {
-            // 📒	"Add all Contact factors in the list to START."
-            self.assign_factors_of_category_to_recovery(
-                category: FactorCategory::Contact,
-                quantity_to_add: Quantity::All
-            )
-
-            // 📒	"Add all Information factors in the list to CONFIRM."
-            self.assign_factors_of_category_to_confirmation(
-                category: FactorCategory::Information,
-                quantity_to_add: Quantity::All
-            )
-        }
-
-
-        // 📒 "Distribute to try to get at least 1 START and then 1 CONFIRM"
-        {
-            // 📒 "Add any Custodian.." 🙅‍♀️  Custodian FactorSources does not exist yet...
-
-            // 📒 "Add any Hardware factors in the list, starting with the most recently used, to START
-            // until there is at least 1 factor source in START."
-            self.assign_one_hardware_factor(
-                to: recovery
-            )
-            // ❓ WHAT TO DO IF THERE WAS NONE?
-
-
-            // 📒 "Add any Hardware (Ledger, Arculus, Yubikey) factors in the list, starting with the most recently used, to CONFIRM until there is at least 1 factor factors in CONFIRM."
-            self.assign_one_hardware_factor(
-                to: confirmation,
-            )
-            // ❓ WHAT TO DO IF THERE WAS NONE?
-        }
-
-
-
-        // 📒 "Distribute to try to get up to 2 START and then 2 CONFIRM factors if possible"
-        {
-            // 📒 "Add any Custodian.." 🙅‍♀️ Custodian FactorSources does not exist yet...
-
-            // 📒 "Add any Hardware (Ledger, Arculus, Yubikey) factors in the list, starting with the most recently used, to START until there are exactly 2 factors in START."
-            self.assign_one_hardware_factor(
-                to: recovery
-            )
-            // ❓ WHAT TO DO IF THERE WAS NONE?
-
-
-            // 📒 "Add any Hardware (Ledger, Arculus, Yubikey) factors in the list, starting with the most recently used, to CONFIRM until there are exactly 2 factors in CONFIRM."
-            self.assign_one_hardware_factor(
-                to: confirmation,
-            )
-            // ❓ WHAT TO DO IF THERE WAS NONE?
-        }
-
-        // 📒 "Fill in any remaining other factors to increase reliability of being able to recover"
-        {
-            // 📒 "Add any (and all) remaining Hardware or Custodian factors in the list to START."
-            self.assign_factors_of_category_to_primary(
-                category: FactorSourceKind::Hardware,
-                quantity: Quantity::All
-            )
-
-            // 📒 "Set all Biometrics/PIN factors to a role (they must be all in one role because they are unlocked by the same Biometrics/PIN check):"
-
-            let mut target_remaining_device_factors =  if recovery.len() > confirmation.len() {
-                // 📒 "If there are more START factors than CONFIRM factors, add any (and all) Biometrics/PIN factors to CONFIRM"
-                &mut confirmation
-            } else {
-                // 📒 "Else, add any (and all) Biometrics/PIN factors to START."
-                &mut recovery
-            };
-
-            self.assign_factors_of_kind(
-                to: target_remaining_device_factors,
-                kind: FactorSourceKind::Device,
-                quantity_to_add: Quantity::All
-            )
-        }
-    }
-}
-*/

--- a/crates/sargon/src/profile/mfa/security_structures/automatic_shield_builder.rs
+++ b/crates/sargon/src/profile/mfa/security_structures/automatic_shield_builder.rs
@@ -29,37 +29,26 @@ impl AutomaticShieldBuilder {
         let contact_factors = self
             .remaining_available_factors
             .iter()
-            .filter(|f| {
-                f.get_factor_source_category()
-                    == FactorSourceCategory::Contact
-            })
+            .filter(|f| f.category() == FactorSourceCategory::Contact)
             // .sorted_by_key(|x| x.)
             .cloned()
             .collect_vec();
 
-            let hardware = self
+        let hardware = self
             .remaining_available_factors
             .iter()
-            .filter(|f| {
-                f.get_factor_source_category()
-                    == FactorSourceCategory::Hardware
-            })
+            .filter(|f| f.category() == FactorSourceCategory::Hardware)
             .cloned()
             .collect_vec();
 
         todo!()
-
-
     }
 
     fn confirmation_role_factors(&mut self) -> Result<Vec<FactorSourceID>> {
         let information_factors = self
             .remaining_available_factors
             .iter()
-            .filter(|f| {
-                f.get_factor_source_category()
-                    == FactorSourceCategory::Information
-            })
+            .filter(|f| f.category() == FactorSourceCategory::Information)
             .cloned()
             .collect_vec();
         Ok(vec![])
@@ -130,11 +119,11 @@ impl SecurityShieldBuilder {
     ) -> SecurityShieldPrerequisitesStatus {
         let count_excluding_identity = factor_sources
             .iter()
-            .filter(|f| f.get_factor_source_category() != FactorSourceCategory::Identity)
+            .filter(|f| f.category() != FactorSourceCategory::Identity)
             .count();
         let count_hardware = factor_sources
             .iter()
-            .filter(|f| f.get_factor_source_category() == FactorSourceCategory::Hardware)
+            .filter(|f| f.category() == FactorSourceCategory::Hardware)
             .count();
         if count_hardware < 1 {
             SecurityShieldPrerequisitesStatus::HardwareRequired
@@ -168,9 +157,7 @@ impl AutomaticShieldBuilder {
         );
         let picked = pick_primary_role_factors(candidates).await;
         let auto_builder = Self {
-            remaining_available_factors: all_factors
-                .into_iter()
-                .collect(),
+            remaining_available_factors: all_factors.into_iter().collect(),
             picked_primary_role_factors: picked,
             shield_builder: security_shield_builder,
         };

--- a/crates/sargon/src/profile/mfa/security_structures/automatic_shield_builder.rs
+++ b/crates/sargon/src/profile/mfa/security_structures/automatic_shield_builder.rs
@@ -5,33 +5,172 @@ use crate::prelude::*;
 use super::security_shield_builder;
 
 pub struct AutomaticShieldBuilder {
-    all_factors: Vec<FactorSource>,
-    picked_primary_role_factors: Vec<FactorSource>,
+    remaining_available_factors: Vec<FactorSource>,
+    picked_primary_role_factors: Vec<FactorSourceID>,
     shield_builder: SecurityShieldBuilder,
 }
 
 impl AutomaticShieldBuilder {
-    fn find_primary_role_candidates(all: &[FactorSource]) -> Vec<FactorSource> {
+    fn find_primary_role_candidates(
+        all: &[FactorSource],
+        shield_builder: &SecurityShieldBuilder,
+    ) -> Vec<FactorSource> {
+        let factor_source_ids = all.iter().map(|f| f.id()).collect_vec();
+        shield_builder.validation_for_addition_of_factor_source_to_primary_threshold_for_each(factor_source_ids).into_iter().filter(|vs| match vs.validation {
+            Ok(_) => true,
+            Err(RoleBuilderValidation::NotYetValid(_)) => true,
+            Err(RoleBuilderValidation::BasicViolation(_)) |  Err(RoleBuilderValidation::ForeverInvalid(_)) => false,
+        }).filter_map(|vs| all.iter().find(|f| f.id() == vs.factor_source_id))
+        .cloned()
+        .collect_vec()
+    }
+
+    fn recovery_role_factors(&mut self) -> Result<Vec<FactorSourceID>> {
+        let contact_factors = self
+            .remaining_available_factors
+            .iter()
+            .filter(|f| {
+                f.get_factor_source_category()
+                    == FactorSourceCategory::Contact
+            })
+            // .sorted_by_key(|x| x.)
+            .cloned()
+            .collect_vec();
+
+            let hardware = self
+            .remaining_available_factors
+            .iter()
+            .filter(|f| {
+                f.get_factor_source_category()
+                    == FactorSourceCategory::Hardware
+            })
+            .cloned()
+            .collect_vec();
+
         todo!()
+
+
+    }
+
+    fn confirmation_role_factors(&mut self) -> Result<Vec<FactorSourceID>> {
+        let information_factors = self
+            .remaining_available_factors
+            .iter()
+            .filter(|f| {
+                f.get_factor_source_category()
+                    == FactorSourceCategory::Information
+            })
+            .cloned()
+            .collect_vec();
+        Ok(vec![])
+    }
+
+    fn add_factors_to_role(
+        &self,
+        factors: &Vec<FactorSourceID>,
+        role: RoleKind,
+    ) {
+        factors.into_iter().for_each(|&f| match role {
+            RoleKind::Primary => {
+                self.shield_builder
+                    .add_factor_source_to_primary_threshold(f);
+            }
+            RoleKind::Recovery => {
+                self.shield_builder
+                    .add_factor_source_to_recovery_override(f);
+            }
+            RoleKind::Confirmation => {
+                self.shield_builder
+                    .add_factor_source_to_confirmation_override(f);
+            }
+        });
+    }
+
+    fn _build_shield(&mut self) -> Result<SecurityStructureOfFactorSourceIDs> {
+        if self.picked_primary_role_factors.len() == 1 {
+            // if the user chose only 1 that factor cannot be used in the recovery or confirmation roles
+            self.remaining_available_factors
+                .retain(|f| f.id() != self.picked_primary_role_factors[0]);
+        }
+        self.add_factors_to_role(
+            &self.picked_primary_role_factors,
+            RoleKind::Primary,
+        );
+        self.shield_builder
+            .set_threshold(self.picked_primary_role_factors.len() as u8);
+
+        let recovery_factors = &self.recovery_role_factors()?;
+        self.add_factors_to_role(recovery_factors, RoleKind::Recovery);
+
+        let confirmation_factors = &self.confirmation_role_factors()?;
+        self.add_factors_to_role(confirmation_factors, RoleKind::Confirmation);
+
+        self.shield_builder.build().map_err(|e| {
+            CommonError::AutomaticShieldBuildingFailure {
+                underlying: format!("{:?}", e),
+            }
+        })
     }
 
     fn build_shield(self) -> Result<SecurityStructureOfFactorSourceIDs> {
-        todo!()
+        let mut _self = self;
+        _self._build_shield()
     }
 }
+
+impl SecurityShieldBuilder {
+    /// Returns the status of the prerequisites for building a Security Shield.
+    ///
+    /// According to [definition][doc], a Security Shield can be built if the user has, asides from
+    /// the Identity factor, "2 or more factors, one of which must be Hardware"
+    ///
+    /// [doc]: https://radixdlt.atlassian.net/wiki/spaces/AT/pages/3758063620/MFA+Rules+for+Factors+and+Security+Shields#Factor-Prerequisites
+    pub fn prerequisites_status(
+        factor_sources: &[FactorSource],
+    ) -> SecurityShieldPrerequisitesStatus {
+        let count_excluding_identity = factor_sources
+            .iter()
+            .filter(|f| f.get_factor_source_category() != FactorSourceCategory::Identity)
+            .count();
+        let count_hardware = factor_sources
+            .iter()
+            .filter(|f| f.get_factor_source_category() == FactorSourceCategory::Hardware)
+            .count();
+        if count_hardware < 1 {
+            SecurityShieldPrerequisitesStatus::HardwareRequired
+        } else if count_excluding_identity < 2 {
+            SecurityShieldPrerequisitesStatus::AnyRequired
+        } else {
+            SecurityShieldPrerequisitesStatus::Sufficient
+        }
+    }
+}
+
 impl AutomaticShieldBuilder {
     pub async fn build<Fut>(
         all_factors: Vec<FactorSource>,
         pick_primary_role_factors: impl Fn(Vec<FactorSource>) -> Fut,
     ) -> Result<SecurityStructureOfFactorSourceIDs>
     where
-        Fut: Future<Output = Vec<FactorSource>>,
+        Fut: Future<Output = Vec<FactorSourceID>>,
     {
-        let candidates = Self::find_primary_role_candidates(&all_factors);
-        let picked = pick_primary_role_factors(candidates).await;
+        if !SecurityShieldBuilder::prerequisites_status(&all_factors)
+            .is_sufficient()
+        {
+            return Err(CommonError::AutomaticShieldBuildingFailure {
+                underlying: "Prerequisites not met".to_string(),
+            });
+        }
         let security_shield_builder = SecurityShieldBuilder::new();
+        let candidates = Self::find_primary_role_candidates(
+            &all_factors,
+            &security_shield_builder,
+        );
+        let picked = pick_primary_role_factors(candidates).await;
         let auto_builder = Self {
-            all_factors,
+            remaining_available_factors: all_factors
+                .into_iter()
+                .collect(),
             picked_primary_role_factors: picked,
             shield_builder: security_shield_builder,
         };

--- a/crates/sargon/src/profile/mfa/security_structures/automatic_shield_builder.rs
+++ b/crates/sargon/src/profile/mfa/security_structures/automatic_shield_builder.rs
@@ -479,12 +479,33 @@ mod tests {
     }
 
     #[actix_rt::test]
-    async fn successful() {
+    async fn selection_of_primary_factor_first() {
         let built = SUT::test(|xs| {
             IndexSet::just(xs.iter().map(|x| x.id()).next().unwrap())
         })
         .await
         .unwrap();
-        assert_eq!(built.matrix_of_factors.primary_role.get_threshold(), 1);
+        assert_eq!(
+            built.matrix_of_factors.primary_role.get_threshold_factors(),
+            &vec![FactorSource::sample_all().first().unwrap().id()]
+        );
+    }
+
+    #[actix_rt::test]
+    async fn selection_of_primary_factor_last() {
+        let built = SUT::test(|xs| {
+            IndexSet::just(xs.iter().map(|x| x.id()).last().unwrap())
+        })
+        .await
+        .unwrap();
+        assert_eq!(
+            built.matrix_of_factors.primary_role.get_threshold_factors(),
+            &vec![FactorSource::sample_all()
+                .into_iter()
+                .filter(|f| f.category() == FactorSourceCategory::Identity)
+                .last()
+                .unwrap()
+                .id()]
+        );
     }
 }

--- a/crates/sargon/src/profile/mfa/security_structures/automatic_shield_builder/auto_build_outcome_for_testing.rs
+++ b/crates/sargon/src/profile/mfa/security_structures/automatic_shield_builder/auto_build_outcome_for_testing.rs
@@ -1,0 +1,38 @@
+use crate::prelude::*;
+
+/// For testing purposes
+/// We do not support Custodian FactorSource yet, but I wanted to write the
+/// heuristics being future proof, so instead of actually assigning any Custodian
+/// (which does not exist), we record the calls to assign Custodian using this
+/// small struct, so that we can assert correctness of the heuristics.
+///
+/// When we do add Custodian FactorSource, we can remove this struct and just
+/// assert the actual assignment of Custodian factors...
+#[derive(Default)]
+pub struct AutoBuildOutcomeForTesting {
+    pub(super) calls_to_assign_unsupported_factor:
+        Vec<CallsToAssignUnsupportedFactor>,
+}
+
+/// For testing purposes
+/// We do not support Custodian FactorSource yet, but I wanted to write the
+/// heuristics being future proof, so instead of actually assigning any Custodian
+/// (which does not exist), we record the calls to assign Custodian using this
+/// small struct, so that we can assert correctness of the heuristics.
+///
+/// When we do add Custodian FactorSource, we can remove this struct and just
+/// assert the actual assignment of Custodian factors...
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct CallsToAssignUnsupportedFactor {
+    /// The role.
+    pub(super) role: RoleKind,
+
+    /// FactorSelector
+    pub(super) unsupported: FactorSelector,
+
+    /// The number of factors in the role when `assign_custodian_and_hardware_to_role_if_less_than_limit_before_each_assignment` was called
+    pub(super) number_of_factors_for_role: u8,
+
+    /// The value of `limit` parameter passed to `assign_custodian_and_hardware_to_role_if_less_than_limit_before_each_assignment`
+    pub(super) limit: u8,
+}

--- a/crates/sargon/src/profile/mfa/security_structures/automatic_shield_builder/automatic_shield_builder.rs
+++ b/crates/sargon/src/profile/mfa/security_structures/automatic_shield_builder/automatic_shield_builder.rs
@@ -287,8 +287,8 @@ impl AutomaticShieldBuilder {
             }
 
             if !self.assign_factors_of_category(role, category, Quantity::One) {
-                // We did not manage to assign any hardware factor, meaning we
-                // it is meaningless to try to assign more factors of this category.
+                // We did not manage to assign any factor of this category, meaning we
+                // it is meaningless to try again.
                 return;
             }
         }

--- a/crates/sargon/src/profile/mfa/security_structures/automatic_shield_builder/automatic_shield_builder.rs
+++ b/crates/sargon/src/profile/mfa/security_structures/automatic_shield_builder/automatic_shield_builder.rs
@@ -67,6 +67,9 @@ impl SecurityShieldBuilder {
         }
 
         if !self.get_primary_override_factors().is_empty() {
+            // Can we update this auto assign heuristics to allow primary override factors?
+            // If we would allow it, we would need to remove all those factors in override
+            // from `all_factors_in_profile`.
             return Err(CommonError::AutomaticShieldBuildingFailure {
                 underlying: "Primary override factors not allowed when preselecting factors for Recovery and Confirmation".to_string(),
             });

--- a/crates/sargon/src/profile/mfa/security_structures/automatic_shield_builder/factor_selector.rs
+++ b/crates/sargon/src/profile/mfa/security_structures/automatic_shield_builder/factor_selector.rs
@@ -1,0 +1,9 @@
+use crate::prelude::*;
+
+/// A tiny enum to make it possible to filter FactorSources on either
+/// FactorSourceCategory or FactorSourceKind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FactorSelector {
+    Category(FactorSourceCategory),
+    Kind(FactorSourceKind),
+}

--- a/crates/sargon/src/profile/mfa/security_structures/automatic_shield_builder/mod.rs
+++ b/crates/sargon/src/profile/mfa/security_structures/automatic_shield_builder/mod.rs
@@ -1,0 +1,10 @@
+mod auto_build_outcome_for_testing;
+#[allow(clippy::module_inception)]
+mod automatic_shield_builder;
+mod factor_selector;
+mod proto_matrix;
+mod quantity;
+
+pub use auto_build_outcome_for_testing::*;
+pub(crate) use automatic_shield_builder::*;
+pub use factor_selector::*;

--- a/crates/sargon/src/profile/mfa/security_structures/automatic_shield_builder/proto_matrix.rs
+++ b/crates/sargon/src/profile/mfa/security_structures/automatic_shield_builder/proto_matrix.rs
@@ -1,0 +1,45 @@
+use crate::prelude::*;
+
+use RoleKind::*;
+
+/// A tiny holder of factors for each Role.
+/// Used by the AutomaticShieldBuilder to keep track of which factors are assigned to which role.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct ProtoMatrix {
+    pub(super) primary: IndexSet<FactorSourceID>,
+    pub(super) recovery: IndexSet<FactorSourceID>,
+    pub(super) confirmation: IndexSet<FactorSourceID>,
+}
+
+impl ProtoMatrix {
+    pub(super) fn new(primary: IndexSet<FactorSourceID>) -> Self {
+        Self {
+            primary,
+            recovery: IndexSet::new(),
+            confirmation: IndexSet::new(),
+        }
+    }
+
+    pub(super) fn factors_for_role(
+        &self,
+        role: RoleKind,
+    ) -> &IndexSet<FactorSourceID> {
+        match role {
+            Primary => &self.primary,
+            Recovery => &self.recovery,
+            Confirmation => &self.confirmation,
+        }
+    }
+
+    pub(super) fn add_factors_for_role(
+        &mut self,
+        role: RoleKind,
+        factors: IndexSet<FactorSourceID>,
+    ) {
+        match role {
+            Primary => self.primary.extend(factors),
+            Recovery => self.recovery.extend(factors),
+            Confirmation => self.confirmation.extend(factors),
+        }
+    }
+}

--- a/crates/sargon/src/profile/mfa/security_structures/automatic_shield_builder/quantity.rs
+++ b/crates/sargon/src/profile/mfa/security_structures/automatic_shield_builder/quantity.rs
@@ -1,0 +1,17 @@
+/// A tiny enum to make it possible to tell auto shield construction to
+/// either assign ALL FactorSource matching some `FactorSelector` or only   
+/// some fixed quantity (typically 1).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum Quantity {
+    All,
+    One,
+}
+
+impl Quantity {
+    pub(super) fn as_fixed(&self) -> Option<usize> {
+        match self {
+            Quantity::All => None,
+            Quantity::One => Some(1),
+        }
+    }
+}

--- a/crates/sargon/src/profile/mfa/security_structures/matrices/builder/matrix_builder.rs
+++ b/crates/sargon/src/profile/mfa/security_structures/matrices/builder/matrix_builder.rs
@@ -164,8 +164,9 @@ impl MatrixBuilder {
         Ok(())
     }
 
-
-    pub fn validate_primary_role_in_isolation(&self) -> MatrixBuilderMutateResult {
+    pub fn validate_primary_role_in_isolation(
+        &self,
+    ) -> MatrixBuilderMutateResult {
         self.validate_each_role_in_isolation()?;
         self.validate_combination()?;
         Ok(())

--- a/crates/sargon/src/profile/mfa/security_structures/matrices/builder/matrix_builder.rs
+++ b/crates/sargon/src/profile/mfa/security_structures/matrices/builder/matrix_builder.rs
@@ -196,6 +196,11 @@ impl MatrixBuilder {
         self.confirmation_role.reset();
     }
 
+    pub fn reset_factors_in_roles(&mut self) {
+        self.reset_recovery_and_confirmation_role_state();
+        self.primary_role.reset();
+    }
+
     /// Adds the factor source to the primary role override list.
     pub fn add_factor_source_to_primary_override(
         &mut self,

--- a/crates/sargon/src/profile/mfa/security_structures/matrices/builder/matrix_builder.rs
+++ b/crates/sargon/src/profile/mfa/security_structures/matrices/builder/matrix_builder.rs
@@ -164,6 +164,13 @@ impl MatrixBuilder {
         Ok(())
     }
 
+
+    pub fn validate_primary_role_in_isolation(&self) -> MatrixBuilderMutateResult {
+        self.validate_each_role_in_isolation()?;
+        self.validate_combination()?;
+        Ok(())
+    }
+
     pub fn validate(&self) -> MatrixBuilderMutateResult {
         self.validate_each_role_in_isolation()?;
         self.validate_combination()?;

--- a/crates/sargon/src/profile/mfa/security_structures/matrices/builder/matrix_builder_unit_tests.rs
+++ b/crates/sargon/src/profile/mfa/security_structures/matrices/builder/matrix_builder_unit_tests.rs
@@ -125,15 +125,15 @@ fn set_number_of_days_42() {
     pretty_assertions::assert_eq!(
         built,
         MatrixOfFactorSourceIds::with_roles_and_days(
-            RoleWithFactorSourceIds::primary_with_factors(
+            PrimaryRoleWithFactorSourceIds::with_factors(
                 1,
                 [FactorSourceID::sample_device(),],
                 [],
             ),
-            RoleWithFactorSourceIds::recovery_with_factors([
+            RecoveryRoleWithFactorSourceIds::override_only([
                 FactorSourceID::sample_ledger(),
             ],),
-            RoleWithFactorSourceIds::confirmation_with_factors([
+            ConfirmationRoleWithFactorSourceIds::override_only([
                 FactorSourceID::sample_password()
             ],),
             42,
@@ -172,15 +172,15 @@ fn set_number_of_days_if_not_set_uses_default() {
     pretty_assertions::assert_eq!(
         built,
         MatrixOfFactorSourceIds::with_roles_and_days(
-            RoleWithFactorSourceIds::primary_with_factors(
+            PrimaryRoleWithFactorSourceIds::with_factors(
                 1,
                 [FactorSourceID::sample_device(),],
                 [],
             ),
-            RoleWithFactorSourceIds::recovery_with_factors([
+            RecoveryRoleWithFactorSourceIds::override_only([
                 FactorSourceID::sample_ledger(),
             ],),
-            RoleWithFactorSourceIds::confirmation_with_factors([
+            ConfirmationRoleWithFactorSourceIds::override_only([
                 FactorSourceID::sample_password()
             ],),
             SUT::DEFAULT_NUMBER_OF_DAYS_UNTIL_AUTO_CONFIRM,
@@ -221,7 +221,7 @@ fn single_factor_in_primary_threshold_cannot_be_in_recovery() {
     let built = sut.build().unwrap();
     pretty_assertions::assert_eq!(
         built.primary(),
-        &RoleWithFactorSourceIds::primary_with_factors(
+        &PrimaryRoleWithFactorSourceIds::with_factors(
             1,
             [
                 FactorSourceID::sample_ledger(),
@@ -232,14 +232,14 @@ fn single_factor_in_primary_threshold_cannot_be_in_recovery() {
     );
     pretty_assertions::assert_eq!(
         built.recovery(),
-        &RoleWithFactorSourceIds::recovery_with_factors([
+        &RecoveryRoleWithFactorSourceIds::override_only([
             FactorSourceID::sample_ledger()
         ]),
     );
 
     pretty_assertions::assert_eq!(
         built.confirmation(),
-        &RoleWithFactorSourceIds::confirmation_with_factors([
+        &ConfirmationRoleWithFactorSourceIds::override_only([
             FactorSourceID::sample_arculus_other()
         ])
     )
@@ -1392,7 +1392,7 @@ mod shield_configs {
             pretty_assertions::assert_eq!(
                 built,
                 MatrixOfFactorSourceIds::with_roles(
-                    RoleWithFactorSourceIds::primary_with_factors(
+                    PrimaryRoleWithFactorSourceIds::with_factors(
                         2,
                         [
                             FactorSourceID::sample_device(),
@@ -1400,11 +1400,11 @@ mod shield_configs {
                         ],
                         [],
                     ),
-                    RoleWithFactorSourceIds::recovery_with_factors([
+                    RecoveryRoleWithFactorSourceIds::override_only([
                         FactorSourceID::sample_device(),
                         FactorSourceID::sample_ledger(),
                     ],),
-                    RoleWithFactorSourceIds::confirmation_with_factors([
+                    ConfirmationRoleWithFactorSourceIds::override_only([
                         FactorSourceID::sample_password()
                     ],),
                 )
@@ -1453,7 +1453,7 @@ mod shield_configs {
             pretty_assertions::assert_eq!(
                 built,
                 MatrixOfFactorSourceIds::with_roles(
-                    RoleWithFactorSourceIds::primary_with_factors(
+                    PrimaryRoleWithFactorSourceIds::with_factors(
                         2,
                         [
                             FactorSourceID::sample_ledger(),
@@ -1461,11 +1461,11 @@ mod shield_configs {
                         ],
                         [],
                     ),
-                    RoleWithFactorSourceIds::recovery_with_factors([
+                    RecoveryRoleWithFactorSourceIds::override_only([
                         FactorSourceID::sample_device(),
                         FactorSourceID::sample_ledger(),
                     ],),
-                    RoleWithFactorSourceIds::confirmation_with_factors([
+                    ConfirmationRoleWithFactorSourceIds::override_only([
                         FactorSourceID::sample_password()
                     ],),
                 )
@@ -1513,7 +1513,7 @@ mod shield_configs {
             pretty_assertions::assert_eq!(
                 built,
                 MatrixOfFactorSourceIds::with_roles(
-                    RoleWithFactorSourceIds::primary_with_factors(
+                    PrimaryRoleWithFactorSourceIds::with_factors(
                         2,
                         [
                             FactorSourceID::sample_device(),
@@ -1521,11 +1521,11 @@ mod shield_configs {
                         ],
                         [],
                     ),
-                    RoleWithFactorSourceIds::recovery_with_factors([
+                    RecoveryRoleWithFactorSourceIds::override_only([
                         FactorSourceID::sample_device(),
                         FactorSourceID::sample_ledger()
                     ],),
-                    RoleWithFactorSourceIds::confirmation_with_factors([
+                    ConfirmationRoleWithFactorSourceIds::override_only([
                         FactorSourceID::sample_password()
                     ],),
                 )
@@ -1565,15 +1565,15 @@ mod shield_configs {
             pretty_assertions::assert_eq!(
                 built,
                 MatrixOfFactorSourceIds::with_roles(
-                    RoleWithFactorSourceIds::primary_with_factors(
+                    PrimaryRoleWithFactorSourceIds::with_factors(
                         1,
                         [FactorSourceID::sample_device(),],
                         [],
                     ),
-                    RoleWithFactorSourceIds::recovery_with_factors([
+                    RecoveryRoleWithFactorSourceIds::override_only([
                         FactorSourceID::sample_ledger()
                     ],),
-                    RoleWithFactorSourceIds::confirmation_with_factors([
+                    ConfirmationRoleWithFactorSourceIds::override_only([
                         FactorSourceID::sample_password()
                     ],),
                 )
@@ -1614,15 +1614,15 @@ mod shield_configs {
             pretty_assertions::assert_eq!(
                 built,
                 MatrixOfFactorSourceIds::with_roles(
-                    RoleWithFactorSourceIds::primary_with_factors(
+                    PrimaryRoleWithFactorSourceIds::with_factors(
                         1,
                         [FactorSourceID::sample_ledger(),],
                         [],
                     ),
-                    RoleWithFactorSourceIds::recovery_with_factors([
+                    RecoveryRoleWithFactorSourceIds::override_only([
                         FactorSourceID::sample_device()
                     ],),
-                    RoleWithFactorSourceIds::confirmation_with_factors([
+                    ConfirmationRoleWithFactorSourceIds::override_only([
                         FactorSourceID::sample_password()
                     ],),
                 )
@@ -1671,7 +1671,7 @@ mod shield_configs {
             pretty_assertions::assert_eq!(
                 built,
                 MatrixOfFactorSourceIds::with_roles(
-                    RoleWithFactorSourceIds::primary_with_factors(
+                    PrimaryRoleWithFactorSourceIds::with_factors(
                         2,
                         [
                             FactorSourceID::sample_device(),
@@ -1679,11 +1679,11 @@ mod shield_configs {
                         ],
                         [],
                     ),
-                    RoleWithFactorSourceIds::recovery_with_factors([
+                    RecoveryRoleWithFactorSourceIds::override_only([
                         FactorSourceID::sample_ledger(),
                         FactorSourceID::sample_ledger_other(),
                     ],),
-                    RoleWithFactorSourceIds::confirmation_with_factors([
+                    ConfirmationRoleWithFactorSourceIds::override_only([
                         FactorSourceID::sample_device()
                     ],),
                 )
@@ -1732,7 +1732,7 @@ mod shield_configs {
             pretty_assertions::assert_eq!(
                 built,
                 MatrixOfFactorSourceIds::with_roles(
-                    RoleWithFactorSourceIds::primary_with_factors(
+                    PrimaryRoleWithFactorSourceIds::with_factors(
                         2,
                         [
                             FactorSourceID::sample_ledger(),
@@ -1740,11 +1740,11 @@ mod shield_configs {
                         ],
                         [],
                     ),
-                    RoleWithFactorSourceIds::recovery_with_factors([
+                    RecoveryRoleWithFactorSourceIds::override_only([
                         FactorSourceID::sample_ledger(),
                         FactorSourceID::sample_ledger_other(),
                     ],),
-                    RoleWithFactorSourceIds::confirmation_with_factors([
+                    ConfirmationRoleWithFactorSourceIds::override_only([
                         FactorSourceID::sample_device()
                     ],),
                 )
@@ -1785,15 +1785,15 @@ mod shield_configs {
             pretty_assertions::assert_eq!(
                 built,
                 MatrixOfFactorSourceIds::with_roles(
-                    RoleWithFactorSourceIds::primary_with_factors(
+                    PrimaryRoleWithFactorSourceIds::with_factors(
                         1,
                         [FactorSourceID::sample_ledger(),],
                         [],
                     ),
-                    RoleWithFactorSourceIds::recovery_with_factors([
+                    RecoveryRoleWithFactorSourceIds::override_only([
                         FactorSourceID::sample_ledger_other(),
                     ],),
-                    RoleWithFactorSourceIds::confirmation_with_factors([
+                    ConfirmationRoleWithFactorSourceIds::override_only([
                         FactorSourceID::sample_device()
                     ],),
                 )
@@ -1834,15 +1834,15 @@ mod shield_configs {
             pretty_assertions::assert_eq!(
                 built,
                 MatrixOfFactorSourceIds::with_roles(
-                    RoleWithFactorSourceIds::primary_with_factors(
+                    PrimaryRoleWithFactorSourceIds::with_factors(
                         1,
                         [FactorSourceID::sample_device(),],
                         [],
                     ),
-                    RoleWithFactorSourceIds::recovery_with_factors([
+                    RecoveryRoleWithFactorSourceIds::override_only([
                         FactorSourceID::sample_ledger(),
                     ],),
-                    RoleWithFactorSourceIds::confirmation_with_factors([
+                    ConfirmationRoleWithFactorSourceIds::override_only([
                         FactorSourceID::sample_ledger_other()
                     ],),
                 )
@@ -1895,7 +1895,7 @@ mod shield_configs {
             pretty_assertions::assert_eq!(
                 built,
                 MatrixOfFactorSourceIds::with_roles(
-                    RoleWithFactorSourceIds::primary_with_factors(
+                    PrimaryRoleWithFactorSourceIds::with_factors(
                         2,
                         [
                             FactorSourceID::sample_device(),
@@ -1903,11 +1903,11 @@ mod shield_configs {
                         ],
                         [],
                     ),
-                    RoleWithFactorSourceIds::recovery_with_factors([
+                    RecoveryRoleWithFactorSourceIds::override_only([
                         FactorSourceID::sample_ledger(),
                         FactorSourceID::sample_ledger_other(),
                     ],),
-                    RoleWithFactorSourceIds::confirmation_with_factors([
+                    ConfirmationRoleWithFactorSourceIds::override_only([
                         FactorSourceID::sample_device(),
                         FactorSourceID::sample_password()
                     ],),
@@ -1965,7 +1965,7 @@ mod shield_configs {
             pretty_assertions::assert_eq!(
                 built,
                 MatrixOfFactorSourceIds::with_roles(
-                    RoleWithFactorSourceIds::primary_with_factors(
+                    PrimaryRoleWithFactorSourceIds::with_factors(
                         2,
                         [
                             FactorSourceID::sample_device(),
@@ -1973,11 +1973,11 @@ mod shield_configs {
                         ],
                         [],
                     ),
-                    RoleWithFactorSourceIds::recovery_with_factors([
+                    RecoveryRoleWithFactorSourceIds::override_only([
                         FactorSourceID::sample_device(),
                         FactorSourceID::sample_ledger(),
                     ],),
-                    RoleWithFactorSourceIds::confirmation_with_factors([
+                    ConfirmationRoleWithFactorSourceIds::override_only([
                         FactorSourceID::sample_password(),
                         FactorSourceID::sample_password_other(),
                         FactorSourceID::sample_off_device()

--- a/crates/sargon/src/profile/mfa/security_structures/mod.rs
+++ b/crates/sargon/src/profile/mfa/security_structures/mod.rs
@@ -7,7 +7,9 @@ mod security_shield_prerequisites_status;
 mod security_structure_id;
 mod security_structure_metadata;
 mod security_structure_of_factors;
+mod automatic_shield_builder;
 
+pub use automatic_shield_builder::*;
 pub use has_role_kind::*;
 pub use matrices::*;
 pub use roles::*;

--- a/crates/sargon/src/profile/mfa/security_structures/mod.rs
+++ b/crates/sargon/src/profile/mfa/security_structures/mod.rs
@@ -1,3 +1,4 @@
+mod automatic_shield_builder;
 mod has_role_kind;
 mod matrices;
 mod roles;
@@ -7,7 +8,6 @@ mod security_shield_prerequisites_status;
 mod security_structure_id;
 mod security_structure_metadata;
 mod security_structure_of_factors;
-mod automatic_shield_builder;
 
 pub use automatic_shield_builder::*;
 pub use has_role_kind::*;

--- a/crates/sargon/src/profile/mfa/security_structures/roles/abstract_role_builder_or_built.rs
+++ b/crates/sargon/src/profile/mfa/security_structures/roles/abstract_role_builder_or_built.rs
@@ -44,20 +44,6 @@ pub struct AbstractRoleBuilderOrBuilt<const ROLE: u8, const MODE: u8, FACTOR> {
     override_factors: Vec<FACTOR>,
 }
 
-impl<const ROLE: u8> RoleBuilder<ROLE>
-where
-    Assert<{ ROLE > ROLE_PRIMARY }>: IsTrue,
-{
-    /// Removes all override factors from this role
-    pub fn reset(&mut self) {
-        self.override_factors.clear();
-
-        // This is not necessary, but why not...
-        self.threshold_factors.clear();
-        self.threshold = 0;
-    }
-}
-
 pub(crate) type AbstractBuiltRoleWithFactor<const ROLE: u8, FACTOR> =
     AbstractRoleBuilderOrBuilt<ROLE, IS_BUILT_ROLE, FACTOR>;
 
@@ -67,6 +53,13 @@ pub(crate) type RoleBuilder<const ROLE: u8> =
 impl<const ROLE: u8, const MODE: u8, FACTOR: IsMaybeKeySpaceAware>
     AbstractRoleBuilderOrBuilt<ROLE, MODE, FACTOR>
 {
+    /// Removes all factors from this role and set threshold to 0.
+    pub fn reset(&mut self) {
+        self.threshold_factors.clear();
+        self.threshold = 0;
+        self.override_factors.clear();
+    }
+
     pub fn role(&self) -> RoleKind {
         RoleKind::from_u8(ROLE).expect("RoleKind should be valid")
     }

--- a/crates/sargon/src/profile/mfa/security_structures/roles/builder/confirmation_roles_builder_unit_tests.rs
+++ b/crates/sargon/src/profile/mfa/security_structures/roles/builder/confirmation_roles_builder_unit_tests.rs
@@ -87,7 +87,7 @@ mod device_in_isolation {
         // Assert
         assert_eq!(
             sut.build().unwrap(),
-            RoleWithFactorSourceIds::confirmation_with_factors([sample()])
+            ConfirmationRoleWithFactorSourceIds::override_only([sample()])
         );
     }
 
@@ -105,7 +105,7 @@ mod device_in_isolation {
         assert!(built.get_threshold_factors().is_empty());
         assert_eq!(
             built,
-            RoleWithFactorSourceIds::confirmation_with_factors([
+            ConfirmationRoleWithFactorSourceIds::override_only([
                 sample(),
                 sample_other()
             ])
@@ -135,7 +135,7 @@ mod ledger_in_isolation {
         // Assert
         assert_eq!(
             sut.build().unwrap(),
-            RoleWithFactorSourceIds::confirmation_with_factors([sample(),])
+            ConfirmationRoleWithFactorSourceIds::override_only([sample(),])
         );
     }
 
@@ -151,7 +151,7 @@ mod ledger_in_isolation {
         // Assert
         assert_eq!(
             sut.build().unwrap(),
-            RoleWithFactorSourceIds::confirmation_with_factors([
+            ConfirmationRoleWithFactorSourceIds::override_only([
                 sample(),
                 sample_other()
             ])
@@ -181,7 +181,7 @@ mod arculus_in_isolation {
         // Assert
         assert_eq!(
             sut.build().unwrap(),
-            RoleWithFactorSourceIds::confirmation_with_factors([sample(),])
+            ConfirmationRoleWithFactorSourceIds::override_only([sample(),])
         );
     }
 
@@ -197,7 +197,7 @@ mod arculus_in_isolation {
         // Assert
         assert_eq!(
             sut.build().unwrap(),
-            RoleWithFactorSourceIds::confirmation_with_factors([
+            ConfirmationRoleWithFactorSourceIds::override_only([
                 sample(),
                 sample_other()
             ])
@@ -227,7 +227,7 @@ mod off_device_mnemonic_in_isolation {
         // Assert
         assert_eq!(
             sut.build().unwrap(),
-            RoleWithFactorSourceIds::confirmation_with_factors([sample(),])
+            ConfirmationRoleWithFactorSourceIds::override_only([sample(),])
         );
     }
 
@@ -243,7 +243,7 @@ mod off_device_mnemonic_in_isolation {
         // Assert
         assert_eq!(
             sut.build().unwrap(),
-            RoleWithFactorSourceIds::confirmation_with_factors([
+            ConfirmationRoleWithFactorSourceIds::override_only([
                 sample(),
                 sample_other()
             ])
@@ -320,7 +320,7 @@ mod password_in_isolation {
         // Assert
         assert_eq!(
             sut.build().unwrap(),
-            RoleWithFactorSourceIds::confirmation_with_factors([sample(),])
+            ConfirmationRoleWithFactorSourceIds::override_only([sample(),])
         );
     }
 
@@ -336,7 +336,7 @@ mod password_in_isolation {
         // Assert
         assert_eq!(
             sut.build().unwrap(),
-            RoleWithFactorSourceIds::confirmation_with_factors([
+            ConfirmationRoleWithFactorSourceIds::override_only([
                 sample(),
                 sample_other()
             ])

--- a/crates/sargon/src/profile/mfa/security_structures/roles/builder/primary_roles_builder_unit_tests.rs
+++ b/crates/sargon/src/profile/mfa/security_structures/roles/builder/primary_roles_builder_unit_tests.rs
@@ -219,7 +219,7 @@ mod threshold_suite {
         sut.set_threshold(1).unwrap();
 
         // Assert
-        let expected = RoleWithFactorSourceIds::primary_with_factors(
+        let expected = PrimaryRoleWithFactorSourceIds::with_factors(
             1,
             [sample_other()],
             [],
@@ -243,7 +243,7 @@ mod threshold_suite {
         sut.add_factor_source_to_threshold(sample_other()).unwrap();
 
         // Assert
-        let expected = RoleWithFactorSourceIds::primary_with_factors(
+        let expected = PrimaryRoleWithFactorSourceIds::with_factors(
             1,
             [sample_other()],
             [],
@@ -269,7 +269,7 @@ mod threshold_suite {
         sut.add_factor_source_to_threshold(sample_other()).unwrap();
 
         // Assert
-        let expected = RoleWithFactorSourceIds::primary_with_factors(
+        let expected = PrimaryRoleWithFactorSourceIds::with_factors(
             2,
             [sample(), sample_other()],
             [],
@@ -289,7 +289,7 @@ mod threshold_suite {
         assert_eq!(sut.set_threshold(2), Ok(()));
 
         // Assert
-        let expected = RoleWithFactorSourceIds::primary_with_factors(
+        let expected = PrimaryRoleWithFactorSourceIds::with_factors(
             2,
             [sample(), sample_other()],
             [],
@@ -317,7 +317,7 @@ mod threshold_suite {
         sut.add_factor_source_to_threshold(sample_third()).unwrap();
 
         // Assert
-        let expected = RoleWithFactorSourceIds::primary_with_factors(
+        let expected = PrimaryRoleWithFactorSourceIds::with_factors(
             3,
             [sample(), sample_other(), sample_third()],
             [],
@@ -335,7 +335,7 @@ mod threshold_suite {
         sut.set_threshold(1).unwrap();
 
         // Assert
-        let expected = RoleWithFactorSourceIds::primary_with_factors(
+        let expected = PrimaryRoleWithFactorSourceIds::with_factors(
             1,
             [sample_other()],
             [],
@@ -651,11 +651,8 @@ mod ledger {
             sut.set_threshold(1).unwrap();
 
             // Assert
-            let expected = RoleWithFactorSourceIds::primary_with_factors(
-                1,
-                [sample()],
-                [],
-            );
+            let expected =
+                PrimaryRoleWithFactorSourceIds::with_factors(1, [sample()], []);
             assert_eq!(sut.build().unwrap(), expected);
         }
 
@@ -689,7 +686,7 @@ mod ledger {
             sut.set_threshold(2).unwrap();
 
             // Assert
-            let expected = RoleWithFactorSourceIds::primary_with_factors(
+            let expected = PrimaryRoleWithFactorSourceIds::with_factors(
                 2,
                 [sample(), sample_other()],
                 [],
@@ -718,11 +715,8 @@ mod ledger {
             sut.add_factor_source_to_override(sample()).unwrap();
 
             // Assert
-            let expected = RoleWithFactorSourceIds::primary_with_factors(
-                0,
-                [],
-                [sample()],
-            );
+            let expected =
+                PrimaryRoleWithFactorSourceIds::with_factors(0, [], [sample()]);
             assert_eq!(sut.build().unwrap(), expected);
         }
 
@@ -736,7 +730,7 @@ mod ledger {
             sut.add_factor_source_to_override(sample_other()).unwrap();
 
             // Assert
-            let expected = RoleWithFactorSourceIds::primary_with_factors(
+            let expected = PrimaryRoleWithFactorSourceIds::with_factors(
                 0,
                 [],
                 [sample(), sample_other()],
@@ -786,11 +780,8 @@ mod arculus {
             sut.set_threshold(1).unwrap();
 
             // Assert
-            let expected = RoleWithFactorSourceIds::primary_with_factors(
-                1,
-                [sample()],
-                [],
-            );
+            let expected =
+                PrimaryRoleWithFactorSourceIds::with_factors(1, [sample()], []);
             assert_eq!(sut.build().unwrap(), expected);
         }
 
@@ -805,7 +796,7 @@ mod arculus {
             sut.set_threshold(1).unwrap();
 
             // Assert
-            let expected = RoleWithFactorSourceIds::primary_with_factors(
+            let expected = PrimaryRoleWithFactorSourceIds::with_factors(
                 1,
                 [sample(), sample_other()],
                 [],
@@ -834,11 +825,8 @@ mod arculus {
             sut.add_factor_source_to_override(sample()).unwrap();
 
             // Assert
-            let expected = RoleWithFactorSourceIds::primary_with_factors(
-                0,
-                [],
-                [sample()],
-            );
+            let expected =
+                PrimaryRoleWithFactorSourceIds::with_factors(0, [], [sample()]);
             assert_eq!(sut.build().unwrap(), expected);
         }
 
@@ -852,7 +840,7 @@ mod arculus {
             sut.add_factor_source_to_override(sample_other()).unwrap();
 
             // Assert
-            let expected = RoleWithFactorSourceIds::primary_with_factors(
+            let expected = PrimaryRoleWithFactorSourceIds::with_factors(
                 0,
                 [],
                 [sample(), sample_other()],
@@ -904,11 +892,8 @@ mod device_factor_source {
             sut.set_threshold(1).unwrap();
 
             // Assert
-            let expected = RoleWithFactorSourceIds::primary_with_factors(
-                1,
-                [sample()],
-                [],
-            );
+            let expected =
+                PrimaryRoleWithFactorSourceIds::with_factors(1, [sample()], []);
             assert_eq!(sut.build().unwrap(), expected);
         }
 
@@ -954,11 +939,8 @@ mod device_factor_source {
             sut.add_factor_source_to_override(sample()).unwrap();
 
             // Assert
-            let expected = RoleWithFactorSourceIds::primary_with_factors(
-                0,
-                [],
-                [sample()],
-            );
+            let expected =
+                PrimaryRoleWithFactorSourceIds::with_factors(0, [], [sample()]);
             assert_eq!(sut.build().unwrap(), expected);
         }
     }

--- a/crates/sargon/src/profile/mfa/security_structures/roles/builder/recovery_roles_builder_unit_tests.rs
+++ b/crates/sargon/src/profile/mfa/security_structures/roles/builder/recovery_roles_builder_unit_tests.rs
@@ -85,7 +85,7 @@ mod device_in_isolation {
         // Assert
         assert_eq!(
             sut.build().unwrap(),
-            RoleWithFactorSourceIds::recovery_with_factors([sample()])
+            RecoveryRoleWithFactorSourceIds::override_only([sample()])
         );
     }
 
@@ -101,7 +101,7 @@ mod device_in_isolation {
         // Assert
         assert_eq!(
             sut.build().unwrap(),
-            RoleWithFactorSourceIds::recovery_with_factors([
+            RecoveryRoleWithFactorSourceIds::override_only([
                 sample(),
                 sample_other()
             ],)
@@ -153,7 +153,7 @@ mod ledger_in_isolation {
         // Assert
         assert_eq!(
             sut.build().unwrap(),
-            RoleWithFactorSourceIds::recovery_with_factors([sample()],)
+            RecoveryRoleWithFactorSourceIds::override_only([sample()],)
         );
     }
 
@@ -169,7 +169,7 @@ mod ledger_in_isolation {
         // Assert
         assert_eq!(
             sut.build().unwrap(),
-            RoleWithFactorSourceIds::recovery_with_factors([
+            RecoveryRoleWithFactorSourceIds::override_only([
                 sample(),
                 sample_other()
             ])
@@ -199,7 +199,7 @@ mod arculus_in_isolation {
         // Assert
         assert_eq!(
             sut.build().unwrap(),
-            RoleWithFactorSourceIds::recovery_with_factors([sample(),])
+            RecoveryRoleWithFactorSourceIds::override_only([sample(),])
         );
     }
 
@@ -215,7 +215,7 @@ mod arculus_in_isolation {
         // Assert
         assert_eq!(
             sut.build().unwrap(),
-            RoleWithFactorSourceIds::recovery_with_factors([
+            RecoveryRoleWithFactorSourceIds::override_only([
                 sample(),
                 sample_other()
             ])
@@ -245,7 +245,7 @@ mod off_device_mnemonic_in_isolation {
         // Assert
         assert_eq!(
             sut.build().unwrap(),
-            RoleWithFactorSourceIds::recovery_with_factors([sample()])
+            RecoveryRoleWithFactorSourceIds::override_only([sample()])
         );
     }
 
@@ -261,7 +261,7 @@ mod off_device_mnemonic_in_isolation {
         // Assert
         assert_eq!(
             sut.build().unwrap(),
-            RoleWithFactorSourceIds::recovery_with_factors([
+            RecoveryRoleWithFactorSourceIds::override_only([
                 sample(),
                 sample_other()
             ])
@@ -291,7 +291,7 @@ mod trusted_contact_in_isolation {
         // Assert
         assert_eq!(
             sut.build().unwrap(),
-            RoleWithFactorSourceIds::recovery_with_factors([sample(),])
+            RecoveryRoleWithFactorSourceIds::override_only([sample(),])
         );
     }
 
@@ -307,7 +307,7 @@ mod trusted_contact_in_isolation {
         // Assert
         assert_eq!(
             sut.build().unwrap(),
-            RoleWithFactorSourceIds::recovery_with_factors([
+            RecoveryRoleWithFactorSourceIds::override_only([
                 sample(),
                 sample_other()
             ])
@@ -412,7 +412,7 @@ mod security_questions_in_isolation {
         // so we can build and `sample` is not present in the built result.
         assert_eq!(
             sut.build(),
-            Ok(RoleWithFactorSourceIds::recovery_with_factors([
+            Ok(RecoveryRoleWithFactorSourceIds::override_only([
                 FactorSourceID::sample_ledger(),
                 FactorSourceID::sample_arculus()
             ]))

--- a/crates/sargon/src/profile/mfa/security_structures/roles/builder/roles_builder.rs
+++ b/crates/sargon/src/profile/mfa/security_structures/roles/builder/roles_builder.rs
@@ -7,19 +7,8 @@ pub type RecoveryRoleBuilder = RoleBuilder<{ ROLE_RECOVERY }>;
 pub type ConfirmationRoleBuilder = RoleBuilder<{ ROLE_CONFIRMATION }>;
 
 #[cfg(test)]
-impl PrimaryRoleWithFactorSourceIds {
-    pub(crate) fn primary_with_factors(
-        threshold: u8,
-        threshold_factors: impl IntoIterator<Item = FactorSourceID>,
-        override_factors: impl IntoIterator<Item = FactorSourceID>,
-    ) -> Self {
-        Self::with_factors(threshold, threshold_factors, override_factors)
-    }
-}
-
-#[cfg(test)]
 impl RecoveryRoleWithFactorSourceIds {
-    pub(crate) fn recovery_with_factors(
+    pub(crate) fn override_only(
         override_factors: impl IntoIterator<Item = FactorSourceID>,
     ) -> Self {
         Self::with_factors(0, vec![], override_factors)
@@ -28,7 +17,7 @@ impl RecoveryRoleWithFactorSourceIds {
 
 #[cfg(test)]
 impl ConfirmationRoleWithFactorSourceIds {
-    pub(crate) fn confirmation_with_factors(
+    pub(crate) fn override_only(
         override_factors: impl IntoIterator<Item = FactorSourceID>,
     ) -> Self {
         Self::with_factors(0, vec![], override_factors)

--- a/crates/sargon/src/profile/mfa/security_structures/security_shield_builder.rs
+++ b/crates/sargon/src/profile/mfa/security_structures/security_shield_builder.rs
@@ -226,6 +226,12 @@ impl SecurityShieldBuilder {
             builder.reset_recovery_and_confirmation_role_state();
         })
     }
+
+    pub(crate) fn reset_factors_in_roles(&self) -> &Self {
+        self.set(|builder| {
+            builder.reset_factors_in_roles();
+        })
+    }
 }
 
 impl SecurityShieldBuilder {

--- a/crates/sargon/src/profile/mfa/security_structures/security_shield_builder.rs
+++ b/crates/sargon/src/profile/mfa/security_structures/security_shield_builder.rs
@@ -1113,6 +1113,31 @@ mod test_invalid {
     }
 
     #[test]
+    fn two_different_password_only_not_valid_for_primary() {
+        let sut = SUT::new();
+
+        sut.add_factor_source_to_recovery_override(
+            FactorSourceID::sample_ledger(),
+        );
+        sut.add_factor_source_to_confirmation_override(
+            FactorSourceID::sample_arculus(),
+        );
+
+        sut.set_threshold(2);
+        sut.add_factor_source_to_primary_threshold(
+            FactorSourceID::sample_password(),
+        );
+        sut.add_factor_source_to_primary_threshold(
+            FactorSourceID::sample_password_other(),
+        );
+
+        assert_eq!(
+            sut.validate().unwrap(),
+            SecurityShieldBuilderInvalidReason::PrimaryRoleWithPasswordInThresholdListMustHaveAnotherFactor
+        );
+    }
+
+    #[test]
     fn primary_role_with_password_in_override_does_not_get_added() {
         let sut = SUT::new();
 

--- a/crates/sargon/src/profile/mfa/security_structures/security_shield_builder.rs
+++ b/crates/sargon/src/profile/mfa/security_structures/security_shield_builder.rs
@@ -421,6 +421,19 @@ impl SecurityShieldBuilder {
         })
     }
 
+    /// Validates **just** the primary role **in isolation**.
+    pub fn validate_primary_role(
+        &self,
+    ) -> Option<SecurityShieldBuilderInvalidReason> {
+        self.get(|builder| {
+            builder
+                .primary_role
+                .validate()
+                .into_matrix_err(RoleKind::Primary)
+                .as_shield_validation()
+        })
+    }
+
     pub fn build(
         &self,
     ) -> Result<

--- a/crates/sargon/src/profile/mfa/security_structures/security_shield_prerequisites_status.rs
+++ b/crates/sargon/src/profile/mfa/security_structures/security_shield_prerequisites_status.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 
 /// An enum representing the status of the prerequisites for building a Security Shield.
 /// This is, whether the user has the necessary factor sources to build a Security Shield.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, EnumAsInner)]
 pub enum SecurityShieldPrerequisitesStatus {
     /// A Security Shield can be built with the current Factor Sources available.
     Sufficient,

--- a/crates/sargon/src/profile/mfa/security_structures/security_structure_of_factors/security_structure_of_factor_source_ids.rs
+++ b/crates/sargon/src/profile/mfa/security_structures/security_structure_of_factors/security_structure_of_factor_source_ids.rs
@@ -3,6 +3,9 @@ use crate::prelude::*;
 pub type SecurityStructureOfFactorSourceIds =
     AbstractSecurityStructure<FactorSourceID>;
 
+pub type SecurityStructureOfFactorSourceIDs =
+    SecurityStructureOfFactorSourceIds;
+
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
 #[serde(rename_all = "camelCase")]
 pub struct SecurityStructureOfFactorInstances {

--- a/crates/sargon/src/profile/v100/app_preferences/security.rs
+++ b/crates/sargon/src/profile/v100/app_preferences/security.rs
@@ -1,8 +1,5 @@
 use crate::prelude::*;
 
-pub type SecurityStructureOfFactorSourceIDs =
-    SecurityStructureOfFactorSourceIds;
-
 decl_identified_vec_of!(
     /// A collection of [`SecurityStructureOfFactorSourceIDs`]
     SecurityStructuresOfFactorSourceIDs,

--- a/crates/sargon/src/profile/v100/factors/factor_source_category.rs
+++ b/crates/sargon/src/profile/v100/factors/factor_source_category.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 
 /// An enum representing the **category** of a `FactorSource`/`FactorSourceKind`.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum FactorSourceCategory {
     /// Something I am.
     Identity,

--- a/crates/sargon/src/profile/v100/factors/factor_source_category.rs
+++ b/crates/sargon/src/profile/v100/factors/factor_source_category.rs
@@ -12,6 +12,9 @@ pub enum FactorSourceCategory {
     /// Something I know.
     Information,
 
-    /// Someone I trust.
+    /// Some person I trust.
     Contact,
+
+    /// Some institution I trust.
+    Custodian,
 }

--- a/crates/sargon/src/profile/v100/factors/factor_source_id.rs
+++ b/crates/sargon/src/profile/v100/factors/factor_source_id.rs
@@ -34,6 +34,12 @@ pub enum FactorSourceID {
     },
 }
 
+impl FactorSourceID {
+    pub fn category(&self) -> FactorSourceCategory {
+        self.get_factor_source_kind().category()
+    }
+}
+
 /// A bit hacky... but used to make it possible for us to validate FactorSourceID
 /// in RoleWithFactor...
 impl IsMaybeKeySpaceAware for FactorSourceID {

--- a/crates/sargon/src/profile/v100/networks/network/authorized_dapp/shared_with_dapp.rs
+++ b/crates/sargon/src/profile/v100/networks/network/authorized_dapp/shared_with_dapp.rs
@@ -42,7 +42,7 @@ macro_rules! declare_shared_with_dapp {
             ///
             /// # Panics
             /// Panics if `ids` does not fulfill `request`, for more information
-            /// see [`RequestedQuantity::is_fulfilled_by_ids`]
+            /// see [`RequestedQuantity::is_fulfilled_by_quantity`]
             pub fn new(
                 request: RequestedQuantity,
                 ids: impl IntoIterator<Item = $id>,
@@ -50,7 +50,7 @@ macro_rules! declare_shared_with_dapp {
                 let ids = IdentifiedVecOf::from_iter(ids.into_iter());
                 let len = ids.len();
                 assert!(
-                    request.is_fulfilled_by_ids(len),
+                    request.is_fulfilled_by_quantity(len),
                     "ids does not fulfill request, got: #{}, but requested: {}",
                     len,
                     request

--- a/crates/sargon/src/system/sargon_os/sargon_os_signing.rs
+++ b/crates/sargon/src/system/sargon_os/sargon_os_signing.rs
@@ -121,8 +121,8 @@ mod test {
             .unwrap();
 
         let signature_with_public_key = SignatureWithPublicKey::from((
-            signed.public_key.as_ed25519().unwrap().clone(),
-            signed.signature.as_ed25519().unwrap().clone(),
+            *signed.public_key.as_ed25519().unwrap(),
+            *signed.signature.as_ed25519().unwrap(),
         ));
 
         assert!(signature_with_public_key


### PR DESCRIPTION
Implementation of ["Automatic Security Shield Construction"][doc].

> [!TIP]
> The name "Automatic Security Shield Construction" is slightly misleading since it is actually just pre-selection of factors for `Recovery` and `Confirmation` roles **after already having selected factors for `Primary** role

> [!TIP]
> Hosts can call `auto_assign_factors_to_recovery_and_confirmation_based_on_primary` on `SecurityShieldBuilder` after having set the Primary role factors, and providing a list of **ALL** FactorSources in Profile (including those assigned to Primary).
> The `SecurityShieldBuilder` will then internally dispatch to `AutomaticShieldBuilder` which is an internal
> type which will assign the factors to the Recovery and Confirmation roles.

I did not really understand the instruction:
> Distribute to try to get up to 2 START and then 2 CONFIRM factors if possible
>
> Add any Custodian factors in the list, starting with the most recently used, to START until there are exactly 2 factors in START.
> 
> Add any Hardware (Ledger, Arculus, Yubikey) factors in the list, starting with the most recently used, to START until there are exactly 2 factors in START.

Or rather, I think there are two both reasonable, interpretations of this, and I've implemented the first and then the second and current head is using the second:
1. [`interpretation if < limit; add` (hash: `45be07f`)](https://github.com/radixdlt/sargon/pull/299/commits/45be07face748481ad91c87c8a8cbba43c1eefb6). 
2. [`interpretation while < limit; add` (hash: `de17433`)](https://github.com/radixdlt/sargon/pull/299/commits/de17433e6077853e4ebe2a16536423e30043d898)

The difference is the interpretation of "Add any .. until there are exactly 2 factors" - the phrasing "Add any" make it sound like we ought to add *one*. The phrasing "until" make it sound like we **loop**, i.e. add potentially two.

[doc]: https://radixdlt.atlassian.net/wiki/spaces/AT/pages/3758063620/MFA+Rules+for+Factors+and+Security+Shields#Automatic-Security-Shield-Construction