### PR TITLE
Remove save identifier from backup result

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,22 +43,3 @@ repos:
         types: [file, rust]
         entry: cargo test --lib
         pass_filenames: false
-
-  - repo: https://github.com/phylum-dev/phylum-ci
-    rev: main
-    hooks:
-      - id: phylum
-        stages: [pre-push]
-        # Optional: Specify the dependency file pattern for your repository
-        files: |
-            (?x)^(
-                Cargo\.lock|
-            )$
-        # Optional: Specify additional arguments to be passed to `phylum-ci`
-        args:
-          - -vv
-          - --depfile=Cargo.lock
-          - --audit
-          - --force-analysis
-          - --all-deps
-        verbose: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2772,7 +2772,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.1.79"
+version = "1.1.80"
 dependencies = [
  "actix-rt",
  "aes-gcm",
@@ -2827,7 +2827,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-uniffi"
-version = "1.1.79"
+version = "1.1.80"
 dependencies = [
  "actix-rt",
  "assert-json-diff",

--- a/crates/sargon-uniffi/Cargo.toml
+++ b/crates/sargon-uniffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sargon-uniffi"
 # Don't forget to update version in crates/sargon/Cargo.toml
-version = "1.1.79"
+version = "1.1.80"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/sargon-uniffi/src/security_center/support/backup_result.rs
+++ b/crates/sargon-uniffi/src/security_center/support/backup_result.rs
@@ -8,9 +8,6 @@ use sargon::IsBackupResultFailed;
 /// Reference for iOS: it is a combination of `BackupStatus` and `BackupResult` (all in one).
 #[derive(Clone, PartialEq, Eq, uniffi::Record)]
 pub struct BackupResult {
-    /// The identifier of the backup.
-    pub save_identifier: String,
-
     /// Whether this backup matches the one on Profile.
     pub is_current: bool,
 
@@ -21,7 +18,6 @@ pub struct BackupResult {
 impl From<InternalBackupResult> for BackupResult {
     fn from(internal: InternalBackupResult) -> Self {
         Self {
-            save_identifier: internal.save_identifier,
             is_current: internal.is_current.0,
             is_failed: internal.is_failed.0,
         }
@@ -31,7 +27,6 @@ impl From<InternalBackupResult> for BackupResult {
 impl From<BackupResult> for InternalBackupResult {
     fn from(backup_result: BackupResult) -> Self {
         InternalBackupResult {
-            save_identifier: backup_result.save_identifier,
             is_current: IsBackupResultCurrent(backup_result.is_current),
             is_failed: IsBackupResultFailed(backup_result.is_failed),
         }

--- a/crates/sargon/Cargo.toml
+++ b/crates/sargon/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sargon"
 # Don't forget to update version in crates/sargon-uniffi/Cargo.toml
-version = "1.1.79"
+version = "1.1.80"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/sargon/src/security_center/client.rs
+++ b/crates/sargon/src/security_center/client.rs
@@ -112,12 +112,10 @@ mod tests {
     #[test]
     fn problem_5() {
         let failed_backup = BackupResult::new(
-            "f",
             IsBackupResultCurrent(true),
             IsBackupResultFailed(true),
         );
         let success_backup = BackupResult::new(
-            "s",
             IsBackupResultCurrent(true),
             IsBackupResultFailed(false),
         );
@@ -225,12 +223,10 @@ mod tests {
     #[test]
     fn problem_7() {
         let current_backup = BackupResult::new(
-            "c",
             IsBackupResultCurrent(true),
             IsBackupResultFailed(false),
         );
         let outdated_backup = BackupResult::new(
-            "o",
             IsBackupResultCurrent(false),
             IsBackupResultFailed(false),
         );

--- a/crates/sargon/src/security_center/support/backup_result.rs
+++ b/crates/sargon/src/security_center/support/backup_result.rs
@@ -5,9 +5,6 @@ use crate::prelude::*;
 /// Reference for iOS: it is a combination of `BackupStatus` and `BackupResult` (all in one).
 #[derive(Debug, Clone, PartialEq)]
 pub struct BackupResult {
-    /// The identifier of the backup.
-    pub save_identifier: String,
-
     /// Whether this backup matches the one on Profile.
     pub is_current: IsBackupResultCurrent,
 
@@ -20,12 +17,10 @@ decl_bool_type!(IsBackupResultFailed, false);
 
 impl BackupResult {
     pub fn new(
-        save_identifier: impl AsRef<str>,
         is_current: IsBackupResultCurrent,
         is_failed: IsBackupResultFailed,
     ) -> Self {
         Self {
-            save_identifier: save_identifier.as_ref().to_owned(),
             is_current,
             is_failed,
         }
@@ -34,19 +29,11 @@ impl BackupResult {
 
 impl HasSampleValues for BackupResult {
     fn sample() -> Self {
-        Self::new(
-            String::sample(),
-            IsBackupResultCurrent(true),
-            IsBackupResultFailed(false),
-        )
+        Self::new(IsBackupResultCurrent(true), IsBackupResultFailed(false))
     }
 
     fn sample_other() -> Self {
-        Self::new(
-            String::sample_other(),
-            IsBackupResultCurrent(false),
-            IsBackupResultFailed(true),
-        )
+        Self::new(IsBackupResultCurrent(false), IsBackupResultFailed(true))
     }
 }
 


### PR DESCRIPTION
In this PR the unused `save_identifier` is removed from `BackupResult`. Related thread [here](https://rdxworks.slack.com/archives/C031A0V1A1W/p1733816964734079).

⚠️  This PR also removes the phylum from per-commit.