### PR TITLE
Remove special handling for virtual accounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2772,7 +2772,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.1.79"
+version = "1.1.81"
 dependencies = [
  "actix-rt",
  "aes-gcm",
@@ -2827,7 +2827,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-uniffi"
-version = "1.1.79"
+version = "1.1.81"
 dependencies = [
  "actix-rt",
  "assert-json-diff",

--- a/crates/sargon-uniffi/Cargo.toml
+++ b/crates/sargon-uniffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sargon-uniffi"
 # Don't forget to update version in crates/sargon/Cargo.toml
-version = "1.1.79"
+version = "1.1.81"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/sargon/Cargo.toml
+++ b/crates/sargon/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sargon"
 # Don't forget to update version in crates/sargon-uniffi/Cargo.toml
-version = "1.1.79"
+version = "1.1.81"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/sargon/src/gateway_api/methods/state_methods.rs
+++ b/crates/sargon/src/gateway_api/methods/state_methods.rs
@@ -172,31 +172,20 @@ impl GatewayClient {
         account_address: AccountAddress,
         ledger_state_selector: LedgerStateSelector,
     ) -> Result<Vec<AccountResourcePreference>> {
-        let result = self
-            .load_all_pages(
-                None,
-                ledger_state_selector,
-                |cursor, ledger_state_selector| {
-                    let request = AccountPageResourcePreferencesRequest::new(
-                        account_address,
-                        ledger_state_selector,
-                        cursor,
-                        GATEWAY_PAGE_REQUEST_LIMIT,
-                    );
-                    self.account_page_resource_preferences(request)
-                },
-            )
-            .await;
-        match result {
-            Ok(response) => Ok(response),
-            Err(CommonError::NetworkResponseBadCode { code: 404 }) => {
-                // The GW is currently returning a 404 when this endpoint is called with a virtual account.
-                // This is a temporary workaround until the GW is fixed.
-                // More info on thread: https://rdxworks.slack.com/archives/C06EBEA0SGY/p1731686360114749
-                Ok(vec![])
-            }
-            Err(e) => Err(e),
-        }
+        self.load_all_pages(
+            None,
+            ledger_state_selector,
+            |cursor, ledger_state_selector| {
+                let request = AccountPageResourcePreferencesRequest::new(
+                    account_address,
+                    ledger_state_selector,
+                    cursor,
+                    GATEWAY_PAGE_REQUEST_LIMIT,
+                );
+                self.account_page_resource_preferences(request)
+            },
+        )
+        .await
     }
 
     /// Fetches all the account's authorized depositors.
@@ -205,31 +194,20 @@ impl GatewayClient {
         account_address: AccountAddress,
         ledger_state_selector: LedgerStateSelector,
     ) -> Result<Vec<AccountAuthorizedDepositor>> {
-        let result = self
-            .load_all_pages(
-                None,
-                ledger_state_selector,
-                |cursor, ledger_state_selector| {
-                    let request = AccountPageAuthorizedDepositorsRequest::new(
-                        account_address,
-                        ledger_state_selector,
-                        cursor,
-                        GATEWAY_PAGE_REQUEST_LIMIT,
-                    );
-                    self.account_page_authorized_depositors(request)
-                },
-            )
-            .await;
-        match result {
-            Ok(response) => Ok(response),
-            Err(CommonError::NetworkResponseBadCode { code: 404 }) => {
-                // The GW is currently returning a 404 when this endpoint is called with a virtual account.
-                // This is a temporary workaround until the GW is fixed.
-                // More info on thread: https://rdxworks.slack.com/archives/C06EBEA0SGY/p1731686360114749
-                Ok(vec![])
-            }
-            Err(e) => Err(e),
-        }
+        self.load_all_pages(
+            None,
+            ledger_state_selector,
+            |cursor, ledger_state_selector| {
+                let request = AccountPageAuthorizedDepositorsRequest::new(
+                    account_address,
+                    ledger_state_selector,
+                    cursor,
+                    GATEWAY_PAGE_REQUEST_LIMIT,
+                );
+                self.account_page_authorized_depositors(request)
+            },
+        )
+        .await
     }
 }
 

--- a/crates/sargon/src/system/sargon_os/sargon_os_signing.rs
+++ b/crates/sargon/src/system/sargon_os/sargon_os_signing.rs
@@ -121,8 +121,8 @@ mod test {
             .unwrap();
 
         let signature_with_public_key = SignatureWithPublicKey::from((
-            signed.public_key.as_ed25519().unwrap().clone(),
-            signed.signature.as_ed25519().unwrap().clone(),
+            *signed.public_key.as_ed25519().unwrap(),
+            *signed.signature.as_ed25519().unwrap(),
         ));
 
         assert!(signature_with_public_key


### PR DESCRIPTION
## Changelog
When implementing the delete account feature, we need to add in https://github.com/radixdlt/sargon/pull/268 special handling for 2 methods (`fetch_all_account_resource_preferences` & `fetch_all_account_authorized_depositors`) since their respective endpoints would return a `404` for virtual accounts. 

This was fixed by the Gateway team, so such handling is no longer necessary. This [integration test](https://github.com/radixdlt/sargon/blob/main/crates/sargon/src/system/sargon_os/delete_account/sargon_os_delete_account.rs#L373-L390) confirms it still works fine after the changes 🙂 