### PR TITLE
Keep HostId in memory

### DIFF
--- a/crates/sargon-uniffi/src/system/sargon_os/sargon_os.rs
+++ b/crates/sargon-uniffi/src/system/sargon_os/sargon_os.rs
@@ -75,8 +75,8 @@ impl SargonOS {
         self.wrapped.delete_wallet().await.into_result()
     }
 
-    pub async fn resolve_host_id(&self) -> Result<HostId> {
-        self.wrapped.resolve_host_id().await.into_result()
+    pub fn resolve_host_id(&self) -> HostId {
+        self.wrapped.host_id().into()
     }
 
     pub async fn resolve_host_info(&self) -> HostInfo {

--- a/crates/sargon/src/system/sargon_os/sargon_os.rs
+++ b/crates/sargon/src/system/sargon_os/sargon_os.rs
@@ -345,12 +345,13 @@ impl SargonOS {
             Ok(Some(loaded_host_id)) => {
                 debug!("Found saved host id: {:?}", &loaded_host_id);
                 loaded_host_id
-            },
+            }
             Ok(None) => {
                 debug!("Found no saved host id, creating new.");
                 let new_host_id = HostId::generate_new();
                 debug!("Created new host id: {:?}", &new_host_id);
-                let save_result = secure_storage.save_host_id(&new_host_id).await;
+                let save_result =
+                    secure_storage.save_host_id(&new_host_id).await;
                 if let Err(error) = save_result {
                     debug!("Failed to save new host id {:?}", error);
                 } else {
@@ -763,10 +764,7 @@ mod tests {
     async fn test_resolve_host_id() {
         let os = SUT::fast_boot().await;
 
-        assert_eq!(
-            SargonOS::get_host_id(&os.clients).await,
-            os.host_id()
-        )
+        assert_eq!(SargonOS::get_host_id(&os.clients).await, os.host_id())
     }
 
     #[actix_rt::test]

--- a/crates/sargon/src/system/sargon_os/sargon_os.rs
+++ b/crates/sargon/src/system/sargon_os/sargon_os.rs
@@ -14,6 +14,7 @@ pub struct SargonOS {
     pub(crate) profile_state_holder: ProfileStateHolder,
     pub(crate) clients: Clients,
     pub(crate) interactors: Interactors,
+    pub(crate) host_id: HostId,
 }
 
 /// So that we do not have to go through `self.clients`,
@@ -68,12 +69,14 @@ impl SargonOS {
             profile_state = ProfileState::None;
         }
 
+        let host_id = Self::get_host_id(&clients).await;
         let os = Arc::new(Self {
             clients,
             profile_state_holder: ProfileStateHolder::new(
                 profile_state.clone(),
             ),
             interactors,
+            host_id,
         });
         os.clients
             .profile_state_change
@@ -227,12 +230,11 @@ impl SargonOS {
             .save_private_hd_factor_source(&hd_factor_source)
             .await?;
 
-        let host_id = self.host_id().await?;
         let host_info = self.host_info().await;
 
         let profile = Profile::from_device_factor_source(
             hd_factor_source.factor_source,
-            host_id,
+            self.host_id,
             host_info,
             Some(accounts),
         );
@@ -281,8 +283,8 @@ impl SargonOS {
             as Arc<dyn AuthenticationSigningInteractor>
     }
 
-    pub async fn resolve_host_id(&self) -> Result<HostId> {
-        self.host_id().await
+    pub fn host_id(&self) -> HostId {
+        self.host_id
     }
 
     pub async fn resolve_host_info(&self) -> HostInfo {
@@ -297,7 +299,6 @@ impl SargonOS {
     ) -> Result<(Profile, PrivateHierarchicalDeterministicFactorSource)> {
         debug!("Creating new Profile and BDFS");
 
-        let host_id = self.host_id().await?;
         let host_info = self.host_info().await;
 
         let is_main = true;
@@ -325,7 +326,7 @@ impl SargonOS {
 
         debug!("Creating new Profile...");
         let profile = Profile::with(
-            Header::new(DeviceInfo::new_from_info(&host_id, &host_info)),
+            Header::new(DeviceInfo::new_from_info(&self.host_id, &host_info)),
             FactorSources::with_bdfs(private_bdfs.factor_source.clone()),
             AppPreferences::default(),
             ProfileNetworks::default(),
@@ -334,26 +335,32 @@ impl SargonOS {
         Ok((profile, private_bdfs))
     }
 
-    pub(crate) async fn host_id(&self) -> Result<HostId> {
-        Self::get_host_id(&self.clients).await
-    }
-
-    pub(crate) async fn get_host_id(clients: &Clients) -> Result<HostId> {
+    pub(crate) async fn get_host_id(clients: &Clients) -> HostId {
         debug!("Get Host ID");
         let secure_storage = &clients.secure_storage;
+        let stored_host_id = secure_storage.load_host_id().await;
+        let new_host_id = HostId::generate_new();
 
-        match secure_storage.load_host_id().await? {
-            Some(loaded_host_id) => {
+        match stored_host_id {
+            Ok(Some(loaded_host_id)) => {
                 debug!("Found saved host id: {:?}", &loaded_host_id);
-                Ok(loaded_host_id)
-            }
-            None => {
+                loaded_host_id
+            },
+            Ok(None) => {
                 debug!("Found no saved host id, creating new.");
                 let new_host_id = HostId::generate_new();
                 debug!("Created new host id: {:?}", &new_host_id);
-                secure_storage.save_host_id(&new_host_id).await?;
-                debug!("Saved new host id");
-                Ok(new_host_id)
+                let save_result = secure_storage.save_host_id(&new_host_id).await;
+                if let Err(error) = save_result {
+                    debug!("Failed to save new host id {:?}", error);
+                } else {
+                    debug!("Saved new host id");
+                }
+                new_host_id
+            }
+            Err(error) => {
+                debug!("Failed to load the host id {:?}", error);
+                new_host_id
             }
         }
     }
@@ -757,8 +764,8 @@ mod tests {
         let os = SUT::fast_boot().await;
 
         assert_eq!(
-            os.resolve_host_id().await.unwrap(),
-            os.host_id().await.unwrap()
+            SargonOS::get_host_id(&os.clients).await,
+            os.host_id()
         )
     }
 

--- a/crates/sargon/src/system/sargon_os/sargon_os_profile.rs
+++ b/crates/sargon/src/system/sargon_os/sargon_os_profile.rs
@@ -21,10 +21,9 @@ impl SargonOS {
     /// header
     pub async fn claim_profile(&self, profile: &mut Profile) -> Result<()> {
         debug!("Claiming profile, id: {}", &profile.id());
-        let host_id = self.host_id().await?;
         let host_info = self.host_info().await;
         let claiming_device_info =
-            DeviceInfo::new_from_info(&host_id, &host_info);
+            DeviceInfo::new_from_info(&self.host_id, &host_info);
 
         Self::claim_provided_profile(profile, claiming_device_info);
         info!(
@@ -345,7 +344,7 @@ mod tests {
             .unwrap();
 
         // ASSERT
-        let host_id = os.host_id().await.unwrap();
+        let host_id = os.host_id;
         let host_info = os.host_info().await;
         assert_eq!(
             os.profile().unwrap().header.last_used_on_device,


### PR DESCRIPTION
This is part of fixing the issue with user seeing Claim Profile prompt on iOS.

The root cause of the issue is that the iOS Wallet fails to resolve the host id and [then we do consider that profile needs to be claimed](https://github.com/radixdlt/babylon-wallet-ios/blob/c209586b2753539384be656f291a4cafb0be8bce/RadixWallet/Clients/ProfileStore/ProfileStore.swift#L66). While this might be wrong assumption, just changing that to true is not the most correct fix.

The iOS wallet will fail to resolve the host id when the app is in background, as the access to the keychain is not allowed while the app is in background. We will try to resolve the host id every 15 minutes, which is the interval we do check for profile claim.
So this bug happens in a very specific scenario - when user moves the app to background somewhere at 13-14 minute - and when at 15 minute mark the wallet tries to resolve the host id, the following error is thrown by the secure storage:

> OSStatus error:[-25308] User interaction is not allowed.

The fix, is to resolve the host id at boot time and then just read it from memory throughout the app lifecycle. Additionally, failing to resolve the host id is not considered a breaking error - even more, it is highly unlikely that the app will fail to perform secure storage operations at boot time.