### PR TITLE
Expose ManifestSummary classification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1942,17 +1942,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
-name = "num-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.85",
-]
-
-[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2251,8 +2240,8 @@ dependencies = [
 
 [[package]]
 name = "radix-blueprint-schema-init"
-version = "1.3.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=423e26abcfbb631d8e7f64ae748cab6f57151bb3#423e26abcfbb631d8e7f64ae748cab6f57151bb3"
+version = "1.3.0"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=v1.3.0#57309755e1fe81ba802e0bf92bbcaf4f116b9b62"
 dependencies = [
  "bitflags 1.3.2",
  "radix-common",
@@ -2262,8 +2251,8 @@ dependencies = [
 
 [[package]]
 name = "radix-common"
-version = "1.3.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=423e26abcfbb631d8e7f64ae748cab6f57151bb3#423e26abcfbb631d8e7f64ae748cab6f57151bb3"
+version = "1.3.0"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=v1.3.0#57309755e1fe81ba802e0bf92bbcaf4f116b9b62"
 dependencies = [
  "bech32",
  "blake2",
@@ -2288,8 +2277,8 @@ dependencies = [
 
 [[package]]
 name = "radix-common-derive"
-version = "1.3.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=423e26abcfbb631d8e7f64ae748cab6f57151bb3#423e26abcfbb631d8e7f64ae748cab6f57151bb3"
+version = "1.3.0"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=v1.3.0#57309755e1fe81ba802e0bf92bbcaf4f116b9b62"
 dependencies = [
  "paste 1.0.15",
  "proc-macro2",
@@ -2300,8 +2289,8 @@ dependencies = [
 
 [[package]]
 name = "radix-engine"
-version = "1.3.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=423e26abcfbb631d8e7f64ae748cab6f57151bb3#423e26abcfbb631d8e7f64ae748cab6f57151bb3"
+version = "1.3.0"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=v1.3.0#57309755e1fe81ba802e0bf92bbcaf4f116b9b62"
 dependencies = [
  "bitflags 1.3.2",
  "colored",
@@ -2331,8 +2320,8 @@ dependencies = [
 
 [[package]]
 name = "radix-engine-interface"
-version = "1.3.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=423e26abcfbb631d8e7f64ae748cab6f57151bb3#423e26abcfbb631d8e7f64ae748cab6f57151bb3"
+version = "1.3.0"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=v1.3.0#57309755e1fe81ba802e0bf92bbcaf4f116b9b62"
 dependencies = [
  "bitflags 1.3.2",
  "const-sha1",
@@ -2352,16 +2341,16 @@ dependencies = [
 
 [[package]]
 name = "radix-engine-profiling"
-version = "1.3.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=423e26abcfbb631d8e7f64ae748cab6f57151bb3#423e26abcfbb631d8e7f64ae748cab6f57151bb3"
+version = "1.3.0"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=v1.3.0#57309755e1fe81ba802e0bf92bbcaf4f116b9b62"
 dependencies = [
  "fixedstr",
 ]
 
 [[package]]
 name = "radix-engine-profiling-derive"
-version = "1.3.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=423e26abcfbb631d8e7f64ae748cab6f57151bb3#423e26abcfbb631d8e7f64ae748cab6f57151bb3"
+version = "1.3.0"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=v1.3.0#57309755e1fe81ba802e0bf92bbcaf4f116b9b62"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2372,7 +2361,7 @@ dependencies = [
 [[package]]
 name = "radix-engine-toolkit"
 version = "2.2.0-dev2"
-source = "git+https://github.com/radixdlt/radix-engine-toolkit?rev=9f58ddfc6e0edb06cb35f8422044522bc0387d14#9f58ddfc6e0edb06cb35f8422044522bc0387d14"
+source = "git+https://github.com/radixdlt/radix-engine-toolkit?rev=2ab5b35a6cb96c9faeb98ed8df67b870336e6873#2ab5b35a6cb96c9faeb98ed8df67b870336e6873"
 dependencies = [
  "bech32",
  "cargo_toml 0.15.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2397,8 +2386,8 @@ dependencies = [
 
 [[package]]
 name = "radix-engine-toolkit-common"
-version = "1.3.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=423e26abcfbb631d8e7f64ae748cab6f57151bb3#423e26abcfbb631d8e7f64ae748cab6f57151bb3"
+version = "1.3.0"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=v1.3.0#57309755e1fe81ba802e0bf92bbcaf4f116b9b62"
 dependencies = [
  "radix-common",
  "radix-engine",
@@ -2411,8 +2400,8 @@ dependencies = [
 
 [[package]]
 name = "radix-native-sdk"
-version = "1.3.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=423e26abcfbb631d8e7f64ae748cab6f57151bb3#423e26abcfbb631d8e7f64ae748cab6f57151bb3"
+version = "1.3.0"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=v1.3.0#57309755e1fe81ba802e0bf92bbcaf4f116b9b62"
 dependencies = [
  "radix-common",
  "radix-engine-interface",
@@ -2422,8 +2411,8 @@ dependencies = [
 
 [[package]]
 name = "radix-rust"
-version = "1.3.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=423e26abcfbb631d8e7f64ae748cab6f57151bb3#423e26abcfbb631d8e7f64ae748cab6f57151bb3"
+version = "1.3.0"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=v1.3.0#57309755e1fe81ba802e0bf92bbcaf4f116b9b62"
 dependencies = [
  "indexmap 2.6.0",
  "serde",
@@ -2431,8 +2420,8 @@ dependencies = [
 
 [[package]]
 name = "radix-sbor-derive"
-version = "1.3.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=423e26abcfbb631d8e7f64ae748cab6f57151bb3#423e26abcfbb631d8e7f64ae748cab6f57151bb3"
+version = "1.3.0"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=v1.3.0#57309755e1fe81ba802e0bf92bbcaf4f116b9b62"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2442,8 +2431,8 @@ dependencies = [
 
 [[package]]
 name = "radix-substate-store-impls"
-version = "1.3.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=423e26abcfbb631d8e7f64ae748cab6f57151bb3#423e26abcfbb631d8e7f64ae748cab6f57151bb3"
+version = "1.3.0"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=v1.3.0#57309755e1fe81ba802e0bf92bbcaf4f116b9b62"
 dependencies = [
  "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.10.5",
@@ -2455,8 +2444,8 @@ dependencies = [
 
 [[package]]
 name = "radix-substate-store-interface"
-version = "1.3.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=423e26abcfbb631d8e7f64ae748cab6f57151bb3#423e26abcfbb631d8e7f64ae748cab6f57151bb3"
+version = "1.3.0"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=v1.3.0#57309755e1fe81ba802e0bf92bbcaf4f116b9b62"
 dependencies = [
  "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.10.5",
@@ -2467,8 +2456,8 @@ dependencies = [
 
 [[package]]
 name = "radix-substate-store-queries"
-version = "1.3.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=423e26abcfbb631d8e7f64ae748cab6f57151bb3#423e26abcfbb631d8e7f64ae748cab6f57151bb3"
+version = "1.3.0"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=v1.3.0#57309755e1fe81ba802e0bf92bbcaf4f116b9b62"
 dependencies = [
  "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.10.5",
@@ -2484,8 +2473,8 @@ dependencies = [
 
 [[package]]
 name = "radix-transactions"
-version = "1.3.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=423e26abcfbb631d8e7f64ae748cab6f57151bb3#423e26abcfbb631d8e7f64ae748cab6f57151bb3"
+version = "1.3.0"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=v1.3.0#57309755e1fe81ba802e0bf92bbcaf4f116b9b62"
 dependencies = [
  "annotate-snippets",
  "bech32",
@@ -2874,8 +2863,8 @@ dependencies = [
 
 [[package]]
 name = "sbor"
-version = "1.3.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=423e26abcfbb631d8e7f64ae748cab6f57151bb3#423e26abcfbb631d8e7f64ae748cab6f57151bb3"
+version = "1.3.0"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=v1.3.0#57309755e1fe81ba802e0bf92bbcaf4f116b9b62"
 dependencies = [
  "const-sha1",
  "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2888,8 +2877,8 @@ dependencies = [
 
 [[package]]
 name = "sbor-derive"
-version = "1.3.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=423e26abcfbb631d8e7f64ae748cab6f57151bb3#423e26abcfbb631d8e7f64ae748cab6f57151bb3"
+version = "1.3.0"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=v1.3.0#57309755e1fe81ba802e0bf92bbcaf4f116b9b62"
 dependencies = [
  "proc-macro2",
  "sbor-derive-common",
@@ -2898,8 +2887,8 @@ dependencies = [
 
 [[package]]
 name = "sbor-derive-common"
-version = "1.3.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=423e26abcfbb631d8e7f64ae748cab6f57151bb3#423e26abcfbb631d8e7f64ae748cab6f57151bb3"
+version = "1.3.0"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=v1.3.0#57309755e1fe81ba802e0bf92bbcaf4f116b9b62"
 dependencies = [
  "const-sha1",
  "indexmap 2.6.0",
@@ -2912,7 +2901,7 @@ dependencies = [
 [[package]]
 name = "sbor-json"
 version = "2.2.0-dev2"
-source = "git+https://github.com/radixdlt/radix-engine-toolkit?rev=9f58ddfc6e0edb06cb35f8422044522bc0387d14#9f58ddfc6e0edb06cb35f8422044522bc0387d14"
+source = "git+https://github.com/radixdlt/radix-engine-toolkit?rev=2ab5b35a6cb96c9faeb98ed8df67b870336e6873#2ab5b35a6cb96c9faeb98ed8df67b870336e6873"
 dependencies = [
  "bech32",
  "radix-common",
@@ -2970,8 +2959,8 @@ dependencies = [
 
 [[package]]
 name = "scrypto"
-version = "1.3.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=423e26abcfbb631d8e7f64ae748cab6f57151bb3#423e26abcfbb631d8e7f64ae748cab6f57151bb3"
+version = "1.3.0"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=v1.3.0#57309755e1fe81ba802e0bf92bbcaf4f116b9b62"
 dependencies = [
  "bech32",
  "const-sha1",
@@ -2991,8 +2980,8 @@ dependencies = [
 
 [[package]]
 name = "scrypto-derive"
-version = "1.3.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=423e26abcfbb631d8e7f64ae748cab6f57151bb3#423e26abcfbb631d8e7f64ae748cab6f57151bb3"
+version = "1.3.0"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=v1.3.0#57309755e1fe81ba802e0bf92bbcaf4f116b9b62"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3983,42 +3972,46 @@ dependencies = [
 
 [[package]]
 name = "wasmi"
-version = "0.35.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbaac6e702fa7b52258e5ac90d6e20a40afb37a1fbe7c645d0903ee42c5f85f4"
+checksum = "fc7a1acc721dd73e4fff2dc3796cc3efda6e008369e859a20fdbe058bddeebc3"
 dependencies = [
  "arrayvec",
  "multi-stash",
- "num-derive",
- "num-traits",
  "smallvec",
  "spin",
  "wasmi_collections",
  "wasmi_core",
+ "wasmi_ir",
  "wasmparser-nostd",
 ]
 
 [[package]]
 name = "wasmi_collections"
-version = "0.35.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ff59e30e550a509cc689ec638e5042be4d78ec9f6dd8a71fd02ee28776a74fd"
+checksum = "142fda775f9cda587681ff0ec63c7a7e5679dc95da75f3f9b7e3979ce3506a5b"
 dependencies = [
- "ahash",
- "hashbrown 0.14.5",
  "string-interner",
 ]
 
 [[package]]
 name = "wasmi_core"
-version = "0.35.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e10c674add0f92f47bf8ad57c55ee3ac1762a0d9baf07535e27e22b758a916"
+checksum = "281a49ca3c12c8efa052cb67758454fc861d80ab5a03def352e04eb08c20beb2"
 dependencies = [
  "downcast-rs",
  "libm",
- "num-traits",
- "paste 1.0.15",
+]
+
+[[package]]
+name = "wasmi_ir"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bbadcf529808086a74bacd3ce8aedece444a847292198a56dcde920d1fb213c"
+dependencies = [
+ "wasmi_core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2761,7 +2761,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.1.85"
+version = "1.1.86"
 dependencies = [
  "actix-rt",
  "aes-gcm",
@@ -2816,7 +2816,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-uniffi"
-version = "1.1.85"
+version = "1.1.86"
 dependencies = [
  "actix-rt",
  "assert-json-diff",

--- a/crates/sargon-uniffi/Cargo.toml
+++ b/crates/sargon-uniffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sargon-uniffi"
 # Don't forget to update version in crates/sargon/Cargo.toml
-version = "1.1.85"
+version = "1.1.86"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/sargon-uniffi/Cargo.toml
+++ b/crates/sargon-uniffi/Cargo.toml
@@ -21,7 +21,7 @@ required-features = ["build-binary"]
 sargon = { path = "../sargon" }
 sargon-uniffi-conversion-macros = { path = "../sargon-uniffi-conversion-macros" }
 
-radix-engine-toolkit = { git = "https://github.com/radixdlt/radix-engine-toolkit", rev = "9f58ddfc6e0edb06cb35f8422044522bc0387d14" }
+radix-engine-toolkit = { git = "https://github.com/radixdlt/radix-engine-toolkit", rev = "2ab5b35a6cb96c9faeb98ed8df67b870336e6873" }
 
 # zeroize = "1.7.0"
 zeroize = { git = "https://github.com/RustCrypto/utils", rev = "df6d2f48a5e8afe8eef04ba32e2af55bacb41375", features = [

--- a/crates/sargon-uniffi/src/wrapped_radix_engine_toolkit/low_level/execution_summary/reserved_instruction.rs
+++ b/crates/sargon-uniffi/src/wrapped_radix_engine_toolkit/low_level/execution_summary/reserved_instruction.rs
@@ -9,4 +9,8 @@ pub enum ReservedInstruction {
     AccountSecurify,
     IdentitySecurify,
     AccessControllerMethod,
+    AccountLockOwnerKeysMetadataField,
+    AccountUpdateOwnerKeysMetadataField,
+    IdentityLockOwnerKeysMetadataField,
+    IdentityUpdateOwnerKeysMetadataField,
 }

--- a/crates/sargon-uniffi/src/wrapped_radix_engine_toolkit/low_level/manifest_summary/manifest_summary.rs
+++ b/crates/sargon-uniffi/src/wrapped_radix_engine_toolkit/low_level/manifest_summary/manifest_summary.rs
@@ -39,4 +39,43 @@ pub struct ManifestSummary {
     /// The set of instructions encountered in the manifest that are reserved
     /// and can only be included in the manifest by the wallet itself.
     pub reserved_instructions: Vec<ReservedInstruction>,
+
+    /// The various classifications that this manifest matched against. Note
+    /// that an empty set means that the manifest is non-conforming.
+    pub classification: Vec<ManifestClass>,
+}
+
+use sargon::RetManifestClass as InternalManifestClass;
+
+/// The classification process classifies manifests into classes. The following
+/// are the classes that the Radix Engine Toolkit supports.
+#[derive(Clone, PartialEq, Eq, InternalConversion, uniffi::Enum)]
+pub enum ManifestClass {
+    /// A subintent manifest which satisfies the general rules allowed for in
+    /// general transactions and that includes a [`YieldToParent`] instruction.
+    ///
+    /// [`YieldToParent`]: radix_transactions::manifest::YieldToParent
+    GeneralSubintent,
+    /// A general manifest that involves any amount of arbitrary components
+    /// and packages where nothing more concrete can be said about the manifest
+    /// and its nature.
+    General,
+    /// A manifest of a 1-to-1 transfer to a one-to-many transfer of resources.
+    Transfer,
+    /// A manifest that contributed some amount of resources to a liquidity
+    /// pool that can be a one-resource pool, two-resource pool, or a
+    /// multi-resource pool.
+    PoolContribution,
+    /// A manifest that redeemed resources from a liquidity pool. Similar to
+    /// contributions, this can be any of the three pool blueprints available
+    /// in the pool package.
+    PoolRedemption,
+    /// A manifest where XRD is staked to one or more validators.
+    ValidatorStake,
+    /// A manifest where XRD is unstaked from one or more validators.
+    ValidatorUnstake,
+    /// A manifest where XRD is claimed from one or more validators.
+    ValidatorClaim,
+    /// A manifest that updated the deposit settings of the account.
+    AccountDepositSettingsUpdate,
 }

--- a/crates/sargon/Cargo.toml
+++ b/crates/sargon/Cargo.toml
@@ -74,22 +74,22 @@ strum = { git = "https://github.com/Peternator7/strum/", rev = "f746c3699acf1501
   "derive",
 ] }
 
-sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "423e26abcfbb631d8e7f64ae748cab6f57151bb3" }
-radix-rust = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "423e26abcfbb631d8e7f64ae748cab6f57151bb3", features = [
+sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v1.3.0" }
+radix-rust = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v1.3.0", features = [
   "serde",
 ] }
-radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "423e26abcfbb631d8e7f64ae748cab6f57151bb3" }
-radix-common = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "423e26abcfbb631d8e7f64ae748cab6f57151bb3", features = [
+radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v1.3.0" }
+radix-common = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v1.3.0", features = [
   "serde",
   "secp256k1_sign_and_validate",
 ] }
-radix-common-derive = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "423e26abcfbb631d8e7f64ae748cab6f57151bb3" }
-radix-engine-interface = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "423e26abcfbb631d8e7f64ae748cab6f57151bb3" }
-radix-engine-toolkit-common = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "423e26abcfbb631d8e7f64ae748cab6f57151bb3" }
+radix-common-derive = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v1.3.0" }
+radix-engine-interface = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v1.3.0" }
+radix-engine-toolkit-common = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v1.3.0" }
 
-radix-transactions = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "423e26abcfbb631d8e7f64ae748cab6f57151bb3" }
+radix-transactions = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v1.3.0" }
 
-radix-engine-toolkit = { git = "https://github.com/radixdlt/radix-engine-toolkit", rev = "9f58ddfc6e0edb06cb35f8422044522bc0387d14" }
+radix-engine-toolkit = { git = "https://github.com/radixdlt/radix-engine-toolkit", rev = "2ab5b35a6cb96c9faeb98ed8df67b870336e6873" }
 
 # enum-iterator = "1.4.1"
 enum-iterator = { git = "https://github.com/stephaneyfx/enum-iterator/", rev = "9d472a1237cfd03b1c7657fdcba74c8070bfb4ea" }

--- a/crates/sargon/Cargo.toml
+++ b/crates/sargon/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sargon"
 # Don't forget to update version in crates/sargon-uniffi/Cargo.toml
-version = "1.1.85"
+version = "1.1.86"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/sargon/src/core/has_sample_values.rs
+++ b/crates/sargon/src/core/has_sample_values.rs
@@ -88,6 +88,23 @@ where
     }
 }
 
+impl<T> HasSampleValues for IndexSet<T>
+where
+    T: HasSampleValues + Eq + std::hash::Hash,
+{
+    fn sample() -> Self {
+        let mut set = Self::new();
+        set.insert(T::sample());
+        set
+    }
+
+    fn sample_other() -> Self {
+        let mut set = Self::new();
+        set.insert(T::sample_other());
+        set
+    }
+}
+
 impl<T> HasSampleValues for Option<T>
 where
     T: HasSampleValues,

--- a/crates/sargon/src/lib.rs
+++ b/crates/sargon/src/lib.rs
@@ -331,7 +331,7 @@ pub mod prelude {
             DetailedManifestClass as RetDetailedManifestClass,
             DynamicAnalysis as RetDynamicAnalysis, FeeSummary as RetFeeSummary,
             FungibleResourceIndicator as RetFungibleResourceIndicator,
-            NewEntities as RetNewEntities,
+            ManifestClass as RetManifestClass, NewEntities as RetNewEntities,
             NonFungibleResourceIndicator as RetNonFungibleResourceIndicator,
             Operation as RetOperation, Predicted as RetPredicted,
             ReservedInstruction as RetReservedInstruction,

--- a/crates/sargon/src/system/sargon_os/transactions/sargon_os_transaction_analysis.rs
+++ b/crates/sargon/src/system/sargon_os/transactions/sargon_os_transaction_analysis.rs
@@ -648,7 +648,9 @@ mod transaction_preview_analysis_tests {
         assert_eq!(
             result,
             Err(CommonError::ReservedInstructionsNotAllowedInManifest {
-                reserved_instructions: "AccountLockFee".to_string()
+                reserved_instructions:
+                    "AccountLockFeeAccountUpdateOwnerKeysMetadataField"
+                        .to_string()
             })
         )
     }
@@ -707,7 +709,7 @@ mod transaction_preview_analysis_tests {
             )
             .await;
 
-        assert_eq!(
+        pretty_assertions::assert_eq!(
             result,
             Ok(TransactionToReview {
                 transaction_manifest: manifest,
@@ -717,7 +719,7 @@ mod transaction_preview_analysis_tests {
                     [acc],
                     [],
                     [],
-                    [ReservedInstruction::AccountLockFee],
+                    [ReservedInstruction::AccountLockFee, ReservedInstruction::AccountUpdateOwnerKeysMetadataField],
                     [],
                     [],
                     [],

--- a/crates/sargon/src/wrapped_radix_engine_toolkit/low_level/execution_summary/reserved_instruction.rs
+++ b/crates/sargon/src/wrapped_radix_engine_toolkit/low_level/execution_summary/reserved_instruction.rs
@@ -8,6 +8,10 @@ pub enum ReservedInstruction {
     AccountSecurify,
     IdentitySecurify,
     AccessControllerMethod,
+    AccountLockOwnerKeysMetadataField,
+    AccountUpdateOwnerKeysMetadataField,
+    IdentityLockOwnerKeysMetadataField,
+    IdentityUpdateOwnerKeysMetadataField,
 }
 
 impl From<RetReservedInstruction> for ReservedInstruction {
@@ -18,6 +22,18 @@ impl From<RetReservedInstruction> for ReservedInstruction {
             RetReservedInstruction::IdentitySecurify => Self::IdentitySecurify,
             RetReservedInstruction::AccessControllerMethod => {
                 Self::AccessControllerMethod
+            }
+            RetReservedInstruction::AccountLockOwnerKeysMetadataField => {
+                Self::AccountLockOwnerKeysMetadataField
+            }
+            RetReservedInstruction::AccountUpdateOwnerKeysMetadataField => {
+                Self::AccountUpdateOwnerKeysMetadataField
+            }
+            RetReservedInstruction::IdentityLockOwnerKeysMetadataField => {
+                Self::IdentityLockOwnerKeysMetadataField
+            }
+            RetReservedInstruction::IdentityUpdateOwnerKeysMetadataField => {
+                Self::IdentityUpdateOwnerKeysMetadataField
             }
         }
     }

--- a/crates/sargon/src/wrapped_radix_engine_toolkit/low_level/manifest_summary/manifest_summary.rs
+++ b/crates/sargon/src/wrapped_radix_engine_toolkit/low_level/manifest_summary/manifest_summary.rs
@@ -38,6 +38,10 @@ pub struct ManifestSummary {
     /// The set of instructions encountered in the manifest that are reserved
     /// and can only be included in the manifest by the wallet itself.
     pub reserved_instructions: Vec<ReservedInstruction>,
+
+    /// The various classifications that this manifest matched against. Note
+    /// that an empty set means that the manifest is non-conforming.
+    pub classification: IndexSet<RetManifestClass>,
 }
 
 impl ManifestSummary {
@@ -54,6 +58,7 @@ impl ManifestSummary {
         accounts_requiring_auth: impl IntoIterator<Item = AccountAddress>,
         personas_requiring_auth: impl IntoIterator<Item = IdentityAddress>,
         reserved_instructions: impl IntoIterator<Item = ReservedInstruction>,
+        classification: impl IntoIterator<Item = RetManifestClass>,
     ) -> Self {
         Self {
             account_withdrawals: account_withdraws.into(),
@@ -85,6 +90,7 @@ impl ManifestSummary {
                 .into_iter()
                 .collect_vec(),
             reserved_instructions: reserved_instructions.into_iter().collect(),
+            classification: classification.into_iter().collect::<IndexSet<_>>(),
         }
     }
 }
@@ -176,7 +182,18 @@ impl From<(RetStaticAnalysisWithResourceMovements, NetworkID)>
             addresses_of_accounts_requiring_auth,
             addresses_of_personas_requiring_auth,
             reserved_instructions,
+            ret.classification,
         )
+    }
+}
+
+impl HasSampleValues for RetManifestClass {
+    fn sample() -> Self {
+        RetManifestClass::GeneralSubintent
+    }
+
+    fn sample_other() -> Self {
+        RetManifestClass::Transfer
     }
 }
 
@@ -192,6 +209,7 @@ impl HasSampleValues for ManifestSummary {
             addresses_of_accounts_requiring_auth: Vec::<_>::sample(),
             addresses_of_personas_requiring_auth: Vec::<_>::sample(),
             reserved_instructions: Vec::<_>::sample(),
+            classification: IndexSet::<_>::sample(),
         }
     }
 
@@ -206,6 +224,7 @@ impl HasSampleValues for ManifestSummary {
             addresses_of_accounts_requiring_auth: Vec::<_>::sample_other(),
             addresses_of_personas_requiring_auth: Vec::<_>::sample_other(),
             reserved_instructions: Vec::<_>::sample_other(),
+            classification: IndexSet::<_>::sample_other(),
         }
     }
 }
@@ -232,6 +251,7 @@ mod tests {
             Vec::default(),
             Vec::default(),
             Vec::default(),
+            Vec::default(),
         );
         assert_eq!(sut.addresses_of_accounts_withdrawn_from.len(), 1);
     }
@@ -247,6 +267,7 @@ mod tests {
             Vec::default(),
             Vec::default(),
             duplicates,
+            Vec::default(),
             Vec::default(),
             Vec::default(),
             Vec::default(),

--- a/crates/sargon/src/wrapped_radix_engine_toolkit/low_level/v1/transaction_manifest/transaction_manifest.rs
+++ b/crates/sargon/src/wrapped_radix_engine_toolkit/low_level/v1/transaction_manifest/transaction_manifest.rs
@@ -474,6 +474,7 @@ BURN_RESOURCE
                 [AccountAddress::sample()],
                 [],
                 Vec::<_>::sample(),
+                [RetManifestClass::Transfer, RetManifestClass::General],
             )
         );
     }
@@ -522,6 +523,7 @@ BURN_RESOURCE
                 [a],
                 [],
                 Vec::<_>::sample(),
+                [RetManifestClass::Transfer, RetManifestClass::General],
             )
         );
     }

--- a/crates/sargon/src/wrapped_radix_engine_toolkit/low_level/v2/transaction_manifest_v2/subintent_manifest.rs
+++ b/crates/sargon/src/wrapped_radix_engine_toolkit/low_level/v2/transaction_manifest_v2/subintent_manifest.rs
@@ -517,6 +517,7 @@ DROP_AUTH_ZONE_PROOFS;
                 [AccountAddress::sample()],
                 [],
                 Vec::<_>::sample(),
+                [RetManifestClass::GeneralSubintent],
             )
         );
     }
@@ -565,6 +566,7 @@ DROP_AUTH_ZONE_PROOFS;
                 [a],
                 [],
                 Vec::<_>::sample(),
+                [RetManifestClass::GeneralSubintent],
             )
         );
     }

--- a/crates/sargon/src/wrapped_radix_engine_toolkit/low_level/v2/transaction_manifest_v2/transaction_manifest_v2.rs
+++ b/crates/sargon/src/wrapped_radix_engine_toolkit/low_level/v2/transaction_manifest_v2/transaction_manifest_v2.rs
@@ -470,6 +470,7 @@ DROP_AUTH_ZONE_PROOFS;
                 [AccountAddress::sample()],
                 [],
                 Vec::<_>::sample(),
+                [RetManifestClass::Transfer, RetManifestClass::General],
             )
         );
     }
@@ -518,6 +519,7 @@ DROP_AUTH_ZONE_PROOFS;
                 [a],
                 [],
                 Vec::<_>::sample(),
+                [RetManifestClass::Transfer, RetManifestClass::General],
             )
         );
     }


### PR DESCRIPTION
- Updates RET to bring in GeneralSubintent manifest classification.
- Exposed ManifestSummary classification so it can be used in hosts to determine the classification of the open Pre-Auth.
- The main intent is to display the proper UI only for GeneralSubintent, and raw manifest for other classifications.

Context - https://rdxworks.slack.com/archives/C031A0V1A1W/p1734031336038489