### PR TITLE
Allow setting name of FactorSources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2761,7 +2761,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.1.86"
+version = "1.1.87"
 dependencies = [
  "actix-rt",
  "aes-gcm",
@@ -2816,7 +2816,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-uniffi"
-version = "1.1.86"
+version = "1.1.87"
 dependencies = [
  "actix-rt",
  "assert-json-diff",

--- a/apple/Sources/Sargon/Extensions/Methods/Profile/Factor/FactorSource+Wrap+Functions.swift
+++ b/apple/Sources/Sargon/Extensions/Methods/Profile/Factor/FactorSource+Wrap+Functions.swift
@@ -17,4 +17,8 @@ extension FactorSource {
 	public var name: String {
 		factorSourceName(factorSource: self)
 	}
+
+	public mutating func setName(_ updated: String) {
+		self = factorSourceSetName(factorSource: self, updated: updated)
+	}
 }

--- a/apple/Tests/TestCases/Profile/Factor/FactorSourceTests.swift
+++ b/apple/Tests/TestCases/Profile/Factor/FactorSourceTests.swift
@@ -27,6 +27,9 @@ final class FactorSourceTests: FactorSourceTest<FactorSource> {
 	}
 
 	func test_name() {
-		XCTAssertEqual(SUT.sample.name, "My Phone")
+		var sut = SUT.sample
+		XCTAssertEqual(sut.name, "My Phone")
+		sut.setName("Updated name")
+		XCTAssertEqual(sut.name, "Updated name")
 	}
 }

--- a/crates/sargon-uniffi/Cargo.toml
+++ b/crates/sargon-uniffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sargon-uniffi"
 # Don't forget to update version in crates/sargon/Cargo.toml
-version = "1.1.86"
+version = "1.1.87"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/sargon-uniffi/src/profile/v100/factors/factor_source.rs
+++ b/crates/sargon-uniffi/src/profile/v100/factors/factor_source.rs
@@ -59,6 +59,16 @@ pub fn factor_source_name(factor_source: &FactorSource) -> String {
 }
 
 #[uniffi::export]
+pub fn factor_source_set_name(
+    factor_source: FactorSource,
+    updated: String,
+) -> FactorSource {
+    let mut factor_source = factor_source.into_internal();
+    factor_source.set_name(updated);
+    factor_source.into()
+}
+
+#[uniffi::export]
 pub fn new_factor_source_sample() -> FactorSource {
     InternalFactorSource::sample().into()
 }

--- a/crates/sargon/Cargo.toml
+++ b/crates/sargon/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sargon"
 # Don't forget to update version in crates/sargon-uniffi/Cargo.toml
-version = "1.1.86"
+version = "1.1.87"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/sargon/src/profile/mfa/mfa_factor_sources/arculus_card_factor_source/arculus_card_factor_source.rs
+++ b/crates/sargon/src/profile/mfa/mfa_factor_sources/arculus_card_factor_source/arculus_card_factor_source.rs
@@ -112,6 +112,10 @@ impl BaseBaseIsFactorSource for ArculusCardFactorSource {
     fn name(&self) -> String {
         self.hint.label.clone()
     }
+
+    fn set_name(&mut self, updated: String) {
+        self.hint.label = updated;
+    }
 }
 
 #[cfg(test)]
@@ -195,6 +199,9 @@ mod tests {
 
     #[test]
     fn name() {
-        assert_eq!(SUT::sample().name(), "Silver");
+        let mut sut = SUT::sample();
+        assert_eq!(sut.name(), "Silver");
+        sut.set_name("Black".to_string());
+        assert_eq!(sut.name(), "Black");
     }
 }

--- a/crates/sargon/src/profile/mfa/mfa_factor_sources/off_device_mnemonic_factor_source/off_device_mnemonic_factor_source.rs
+++ b/crates/sargon/src/profile/mfa/mfa_factor_sources/off_device_mnemonic_factor_source/off_device_mnemonic_factor_source.rs
@@ -112,6 +112,10 @@ impl BaseBaseIsFactorSource for OffDeviceMnemonicFactorSource {
     fn name(&self) -> String {
         self.hint.label.value.clone()
     }
+
+    fn set_name(&mut self, updated: String) {
+        self.hint.label.value = updated;
+    }
 }
 
 #[cfg(test)]
@@ -158,6 +162,9 @@ mod tests {
 
     #[test]
     fn name() {
-        assert_eq!(SUT::sample().name(), "Story about a horse");
+        let mut sut = SUT::sample();
+        assert_eq!(sut.name(), "Story about a horse");
+        sut.set_name("Thrilled with a shark".to_string());
+        assert_eq!(sut.name(), "Thrilled with a shark");
     }
 }

--- a/crates/sargon/src/profile/mfa/mfa_factor_sources/password_factor_source/password_factor_source.rs
+++ b/crates/sargon/src/profile/mfa/mfa_factor_sources/password_factor_source/password_factor_source.rs
@@ -114,6 +114,10 @@ impl BaseBaseIsFactorSource for PasswordFactorSource {
     fn name(&self) -> String {
         self.hint.label.clone()
     }
+
+    fn set_name(&mut self, updated: String) {
+        self.hint.label = updated;
+    }
 }
 
 #[cfg(test)]
@@ -196,6 +200,9 @@ mod tests {
 
     #[test]
     fn name() {
-        assert_eq!(SUT::sample().name(), "Password 1");
+        let mut sut = SUT::sample();
+        assert_eq!(sut.name(), "Password 1");
+        sut.set_name("Password 2".to_string());
+        assert_eq!(sut.name(), "Password 2");
     }
 }

--- a/crates/sargon/src/profile/mfa/mfa_factor_sources/security_questions_factor_source/security_questions_factor_source.rs
+++ b/crates/sargon/src/profile/mfa/mfa_factor_sources/security_questions_factor_source/security_questions_factor_source.rs
@@ -291,6 +291,10 @@ impl BaseBaseIsFactorSource
             .join(", ");
         format!("Questions: {}", ids)
     }
+
+    fn set_name(&mut self, _updated: String) {
+        unreachable!("SecurityQuestions cannot be renamed");
+    }
 }
 
 #[cfg(test)]
@@ -497,5 +501,11 @@ mod tests {
     #[test]
     fn name() {
         assert_eq!(SUT::sample().name(), "Questions: #0, #1, #2, #3, #4, #5");
+    }
+
+    #[should_panic(expected = "SecurityQuestions cannot be renamed")]
+    #[test]
+    fn set_name() {
+        SUT::sample().set_name("whatever".to_string())
     }
 }

--- a/crates/sargon/src/profile/mfa/mfa_factor_sources/trusted_contact_factor_source/trusted_contact_factor_source.rs
+++ b/crates/sargon/src/profile/mfa/mfa_factor_sources/trusted_contact_factor_source/trusted_contact_factor_source.rs
@@ -91,6 +91,10 @@ impl BaseBaseIsFactorSource for TrustedContactFactorSource {
     fn name(&self) -> String {
         self.contact.name.value.clone()
     }
+
+    fn set_name(&mut self, updated: String) {
+        self.contact.name.value = updated;
+    }
 }
 impl TrustedContactFactorSource {
     fn new_sample(name: &str, email: &str, address: AccountAddress) -> Self {
@@ -215,6 +219,9 @@ mod tests {
 
     #[test]
     fn name() {
-        assert_eq!(SUT::sample().name(), "Spending Account");
+        let mut sut = SUT::sample();
+        assert_eq!(sut.name(), "Spending Account");
+        sut.set_name("Savings Account".to_string());
+        assert_eq!(sut.name(), "Savings Account");
     }
 }

--- a/crates/sargon/src/profile/v100/factors/factor_source.rs
+++ b/crates/sargon/src/profile/v100/factors/factor_source.rs
@@ -116,6 +116,10 @@ impl BaseBaseIsFactorSource for FactorSource {
     fn name(&self) -> String {
         self.map_get(|v| v.name())
     }
+
+    fn set_name(&mut self, updated: String) {
+        self.map_set(|v| v.set_name(updated.clone()));
+    }
 }
 
 impl Identifiable for FactorSource {
@@ -396,6 +400,13 @@ mod tests {
             SUT::sample_other().name(),
             LedgerHardwareWalletFactorSource::sample().name()
         )
+    }
+
+    #[test]
+    fn set_name() {
+        let mut sut = SUT::sample();
+        sut.set_name("new name".to_string());
+        assert_eq!(sut.name(), "new name");
     }
 
     #[test]

--- a/crates/sargon/src/profile/v100/factors/factor_sources/device_factor_source/device_factor_source.rs
+++ b/crates/sargon/src/profile/v100/factors/factor_sources/device_factor_source/device_factor_source.rs
@@ -66,6 +66,10 @@ impl BaseBaseIsFactorSource for DeviceFactorSource {
     fn name(&self) -> String {
         self.hint.label.clone()
     }
+
+    fn set_name(&mut self, updated: String) {
+        self.hint.label = updated;
+    }
 }
 
 impl DeviceFactorSource {
@@ -317,6 +321,9 @@ mod tests {
 
     #[test]
     fn name() {
-        assert_eq!(SUT::sample().name(), "My Phone");
+        let mut sut = SUT::sample();
+        assert_eq!(sut.name(), "My Phone");
+        sut.set_name("My Old Phone".to_string());
+        assert_eq!(sut.name(), "My Old Phone");
     }
 }

--- a/crates/sargon/src/profile/v100/factors/factor_sources/ledger_hardware_wallet_factor_source/ledger_hardware_wallet_factor_source.rs
+++ b/crates/sargon/src/profile/v100/factors/factor_sources/ledger_hardware_wallet_factor_source/ledger_hardware_wallet_factor_source.rs
@@ -102,6 +102,10 @@ impl BaseBaseIsFactorSource for LedgerHardwareWalletFactorSource {
     fn name(&self) -> String {
         self.hint.label.clone()
     }
+
+    fn set_name(&mut self, updated: String) {
+        self.hint.label = updated
+    }
 }
 
 #[cfg(test)]
@@ -185,6 +189,9 @@ mod tests {
 
     #[test]
     fn name() {
-        assert_eq!(SUT::sample().name(), "Orange, scratched");
+        let mut sut = SUT::sample();
+        assert_eq!(sut.name(), "Orange, scratched");
+        sut.set_name("Old cracked".to_string());
+        assert_eq!(sut.name(), "Old cracked");
     }
 }

--- a/crates/sargon/src/profile/v100/factors/is_factor_source.rs
+++ b/crates/sargon/src/profile/v100/factors/is_factor_source.rs
@@ -19,6 +19,7 @@ pub trait BaseBaseIsFactorSource {
     }
 
     fn name(&self) -> String;
+    fn set_name(&mut self, updated: String);
 
     fn category(&self) -> FactorSourceCategory {
         self.factor_source_kind().category()


### PR DESCRIPTION
Exports a UniFFI function that allows setting name of any FactorSource.