### PR TITLE
Transaction Analysis allow unknown accounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2761,7 +2761,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.1.90"
+version = "1.1.89"
 dependencies = [
  "actix-rt",
  "aes-gcm",
@@ -2816,7 +2816,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-uniffi"
-version = "1.1.90"
+version = "1.1.89"
 dependencies = [
  "actix-rt",
  "assert-json-diff",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2761,7 +2761,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.1.88"
+version = "1.1.89"
 dependencies = [
  "actix-rt",
  "aes-gcm",
@@ -2816,7 +2816,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-uniffi"
-version = "1.1.88"
+version = "1.1.89"
 dependencies = [
  "actix-rt",
  "assert-json-diff",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2761,7 +2761,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.1.89"
+version = "1.1.90"
 dependencies = [
  "actix-rt",
  "aes-gcm",
@@ -2816,7 +2816,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-uniffi"
-version = "1.1.89"
+version = "1.1.90"
 dependencies = [
  "actix-rt",
  "assert-json-diff",

--- a/crates/sargon-uniffi/Cargo.toml
+++ b/crates/sargon-uniffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sargon-uniffi"
 # Don't forget to update version in crates/sargon/Cargo.toml
-version = "1.1.90"
+version = "1.1.89"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/sargon-uniffi/Cargo.toml
+++ b/crates/sargon-uniffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sargon-uniffi"
 # Don't forget to update version in crates/sargon/Cargo.toml
-version = "1.1.89"
+version = "1.1.90"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/sargon-uniffi/Cargo.toml
+++ b/crates/sargon-uniffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sargon-uniffi"
 # Don't forget to update version in crates/sargon/Cargo.toml
-version = "1.1.88"
+version = "1.1.89"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/sargon/Cargo.toml
+++ b/crates/sargon/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sargon"
 # Don't forget to update version in crates/sargon-uniffi/Cargo.toml
-version = "1.1.89"
+version = "1.1.90"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/sargon/Cargo.toml
+++ b/crates/sargon/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sargon"
 # Don't forget to update version in crates/sargon-uniffi/Cargo.toml
-version = "1.1.90"
+version = "1.1.89"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/sargon/Cargo.toml
+++ b/crates/sargon/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sargon"
 # Don't forget to update version in crates/sargon-uniffi/Cargo.toml
-version = "1.1.88"
+version = "1.1.89"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/sargon/src/signing/collector/extractor_of_instances_required_to_sign_transactions.rs
+++ b/crates/sargon/src/signing/collector/extractor_of_instances_required_to_sign_transactions.rs
@@ -47,13 +47,19 @@ mod tests {
 
     #[test]
     fn preprocessor_init_fail() {
+        let intent_with_invalid_persona =
+            TransactionIntent::sample_entity_addresses_requiring_auth(
+                vec![],
+                vec![Persona::sample_mainnet().address],
+            );
+
         let result = ExtractorOfInstancesRequiredToSignTransactions::extract(
             &Profile::sample_other(),
-            vec![TransactionIntent::sample()],
+            vec![intent_with_invalid_persona],
             RoleKind::Primary,
         );
 
-        assert!(matches!(result, Err(CommonError::UnknownAccount)));
+        assert!(matches!(result, Err(CommonError::UnknownPersona)));
     }
 
     #[test]

--- a/crates/sargon/src/signing/collector/signatures_collector.rs
+++ b/crates/sargon/src/signing/collector/signatures_collector.rs
@@ -435,7 +435,7 @@ mod tests {
     }
 
     #[test]
-    fn invalid_profile_unknown_account() {
+    fn profile_with_unknown_account() {
         let res = SignaturesCollector::new(
             SigningFinishEarlyStrategy::default(),
             [TransactionIntent::sample_entities_requiring_auth(
@@ -446,7 +446,7 @@ mod tests {
             &Profile::sample_from(IndexSet::new(), [], []),
             RoleKind::Primary,
         );
-        assert!(matches!(res, Err(CommonError::UnknownAccount)));
+        assert!(res.is_ok());
     }
 
     #[test]

--- a/crates/sargon/src/signing/extractor_of_entities_requiring_auth.rs
+++ b/crates/sargon/src/signing/extractor_of_entities_requiring_auth.rs
@@ -5,7 +5,7 @@ pub struct ExtractorOfEntitiesRequiringAuth;
 impl ExtractorOfEntitiesRequiringAuth {
     /// Matches entities requiring auth from a manifest summary with the entities in the given profile.
     /// Returns a set of `AccountOrPersona` or empty if the manifest summary does not require auth.
-    /// Returns an error if an account or persona is unknown.
+    /// Returns an error if persona is unknown.
     pub fn extract(
         profile: &Profile,
         summary: ManifestSummary,
@@ -17,7 +17,8 @@ impl ExtractorOfEntitiesRequiringAuth {
             .addresses_of_accounts_requiring_auth
             .iter()
             .map(|a| profile.account_by_address(*a))
-            .collect::<Result<Vec<_>>>()?;
+            .filter_map(|a| a.ok())
+            .collect::<Vec<_>>();
 
         entities_requiring_auth.extend(
             accounts
@@ -45,6 +46,7 @@ impl ExtractorOfEntitiesRequiringAuth {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indexmap::IndexSet;
     use radix_transactions::prelude::ManifestBuilder;
 
     #[test]
@@ -67,7 +69,7 @@ mod tests {
             manifest_summary,
         );
 
-        assert!(matches!(result, Err(CommonError::UnknownAccount)));
+        assert_eq!(result, Ok(IndexSet::new()));
     }
 
     #[test]

--- a/crates/sargon/src/system/sargon_os/transactions/sargon_os_transaction_analysis.rs
+++ b/crates/sargon/src/system/sargon_os/transactions/sargon_os_transaction_analysis.rs
@@ -582,7 +582,11 @@ mod transaction_preview_analysis_tests {
             )
             .await;
 
-        assert_eq!(result, Err(CommonError::UnknownAccount))
+        // Just asserts that the execution path reached GW preview call
+        assert!(matches!(
+            result,
+            Err(CommonError::ExecutionSummaryFail { .. })
+        ))
     }
 
     #[actix_rt::test]

--- a/crates/sargon/src/system/sargon_os/transactions/sargon_os_transaction_analysis.rs
+++ b/crates/sargon/src/system/sargon_os/transactions/sargon_os_transaction_analysis.rs
@@ -545,51 +545,6 @@ mod transaction_preview_analysis_tests {
     }
 
     #[actix_rt::test]
-    async fn signer_entities_not_found() {
-        let responses = prepare_responses(
-            LedgerState {
-                network: "".to_string(),
-                state_version: 0,
-                proposer_round_timestamp: "".to_string(),
-                epoch: 0,
-                round: 0,
-            },
-            TransactionPreviewResponse {
-                encoded_receipt: "".to_string(),
-                radix_engine_toolkit_receipt: Some(
-                    ScryptoSerializableToolkitTransactionReceipt::Reject {
-                        reason: "Test".to_string(),
-                    },
-                ),
-                logs: vec![],
-                receipt: TransactionReceipt {
-                    status: TransactionReceiptStatus::Succeeded,
-                    error_message: None,
-                },
-            },
-        );
-        let os =
-            prepare_os(MockNetworkingDriver::new_with_bodies(200, responses))
-                .await;
-
-        let result = os
-            .analyse_transaction_preview(
-                TransactionManifest::sample().instructions_string(),
-                Blobs::sample(),
-                true,
-                Nonce::sample(),
-                PublicKey::sample(),
-            )
-            .await;
-
-        // Just asserts that the execution path reached GW preview call
-        assert!(matches!(
-            result,
-            Err(CommonError::ExecutionSummaryFail { .. })
-        ))
-    }
-
-    #[actix_rt::test]
     async fn execution_summary_parse_error() {
         let responses = prepare_responses(
             LedgerState {
@@ -733,6 +688,51 @@ mod transaction_preview_analysis_tests {
                 )
             })
         )
+    }
+
+    #[actix_rt::test]
+    async fn signer_entities_not_found() {
+        let responses = prepare_responses(
+            LedgerState {
+                network: "".to_string(),
+                state_version: 0,
+                proposer_round_timestamp: "".to_string(),
+                epoch: 0,
+                round: 0,
+            },
+            TransactionPreviewResponse {
+                encoded_receipt: "".to_string(),
+                radix_engine_toolkit_receipt: Some(
+                    ScryptoSerializableToolkitTransactionReceipt::Reject {
+                        reason: "Test".to_string(),
+                    },
+                ),
+                logs: vec![],
+                receipt: TransactionReceipt {
+                    status: TransactionReceiptStatus::Succeeded,
+                    error_message: None,
+                },
+            },
+        );
+        let os =
+            prepare_os(MockNetworkingDriver::new_with_bodies(200, responses))
+                .await;
+
+        let result = os
+            .analyse_transaction_preview(
+                TransactionManifest::sample().instructions_string(),
+                Blobs::sample(),
+                true,
+                Nonce::sample(),
+                PublicKey::sample(),
+            )
+            .await;
+
+        // Just asserts that the execution path reached GW preview call
+        assert!(matches!(
+            result,
+            Err(CommonError::ExecutionSummaryFail { .. })
+        ))
     }
 
     #[actix_rt::test]


### PR DESCRIPTION
Allow transaction manifests which contain unknown accounts which to require signatures. The Wallet should not reject such transactions.

References:
- https://rdxworks.slack.com/archives/C031A0V1A1W/p1734036514557019?thread_ts=1733976138.385129&cid=C031A0V1A1W
- https://rdxworks.slack.com/archives/C031A0V1A1W/p1734356845160559

The new behaviour was introduced with Sargon, and we reject the manifest at the moment we try to extract the public keys to be sent to the GW. Old implementation, did allow for unknown accounts, [see iOS for reference](https://github.com/radixdlt/babylon-wallet-ios/blob/4b0738caf583521751a5c03f3c6410ab956c68a3/RadixWallet/Clients/TransactionClient/TransactionClient%2BLive.swift#L50).