### PR TITLE
Transform UniFFI SecurityShieldBuilder to value type semantics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2761,7 +2761,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.1.96"
+version = "1.1.97"
 dependencies = [
  "actix-rt",
  "aes-gcm",
@@ -2816,7 +2816,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-uniffi"
-version = "1.1.96"
+version = "1.1.97"
 dependencies = [
  "actix-rt",
  "assert-json-diff",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2761,7 +2761,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.1.92"
+version = "1.1.93"
 dependencies = [
  "actix-rt",
  "aes-gcm",
@@ -2816,7 +2816,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-uniffi"
-version = "1.1.92"
+version = "1.1.93"
 dependencies = [
  "actix-rt",
  "assert-json-diff",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2761,7 +2761,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.1.95"
+version = "1.1.96"
 dependencies = [
  "actix-rt",
  "aes-gcm",
@@ -2816,7 +2816,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-uniffi"
-version = "1.1.95"
+version = "1.1.96"
 dependencies = [
  "actix-rt",
  "assert-json-diff",

--- a/apple/Sources/Sargon/Extensions/Swiftified/Profile/MFA/SecurityShieldBuilder+Swifified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Profile/MFA/SecurityShieldBuilder+Swifified.swift
@@ -13,8 +13,7 @@ extension SecurityShieldBuilder {
 	}
 
 	public var threshold: UInt8 {
-		get { getPrimaryThreshold() }
-		set { setThreshold(threshold: newValue) }
+		getPrimaryThreshold()
 	}
 
 	public var primaryRoleThresholdFactors: [Factor] {
@@ -35,11 +34,6 @@ extension SecurityShieldBuilder {
 
 	/// Name of the shield
 	public var name: String {
-		get {
-			getName()
-		}
-		set {
-			setName(name: newValue)
-		}
+		getName()
 	}
 }

--- a/apple/Sources/Sargon/Extensions/Swiftified/Profile/MFA/SecurityShieldBuilder+Swifified.swift
+++ b/apple/Sources/Sargon/Extensions/Swiftified/Profile/MFA/SecurityShieldBuilder+Swifified.swift
@@ -5,11 +5,7 @@ extension SecurityShieldBuilder {
 
 	/// Confirmation Role
 	public var numberOfDaysUntilAutoConfirm: UInt16 {
-		get { getNumberOfDaysUntilAutoConfirm() }
-		set {
-			precondition(newValue > 0, "Number of days until auto confirm must be greater than zero.")
-			setNumberOfDaysUntilAutoConfirm(numberOfDays: UInt16(newValue))
-		}
+		getNumberOfDaysUntilAutoConfirm()
 	}
 
 	public var threshold: UInt8 {

--- a/apple/Tests/TestCases/Profile/MFA/SecurityShieldsBuilderTests.swift
+++ b/apple/Tests/TestCases/Profile/MFA/SecurityShieldsBuilderTests.swift
@@ -151,7 +151,7 @@ struct ShieldTests {
 			.addFactorSourceToPrimaryOverride(factorSourceId: factor)
 			.addFactorSourceToPrimaryThreshold(factorSourceId: other)
 		#expect(builder.primaryRoleThresholdFactors == [other])
-		#expect(builder.primaryRoleOverrideFactors == [factor])
+		#expect(builder.primaryRoleOverrideFactors == [other, factor])
 
 		// But when validated/built is err
 		#expect(builder.validate() != nil)

--- a/apple/Tests/TestCases/Profile/MFA/SecurityShieldsBuilderTests.swift
+++ b/apple/Tests/TestCases/Profile/MFA/SecurityShieldsBuilderTests.swift
@@ -9,25 +9,25 @@ import Testing
 struct ShieldTests {
 	@Test("name")
 	func name() {
-		let builder = SecurityShieldBuilder()
+		var builder = SecurityShieldBuilder()
 		#expect(builder.name == "My Shield")
-		builder.name = "S.H.I.E.L.D"
+		builder = builder.setName(name: "S.H.I.E.L.D")
 		#expect(builder.name == "S.H.I.E.L.D")
 	}
 
 	@Test("threshold")
 	func threshold() {
-		let builder = SecurityShieldBuilder()
+		var builder = SecurityShieldBuilder()
 		#expect(builder.threshold == 0)
-		builder.setThreshold(threshold: 42)
+		builder = builder.setThreshold(threshold: 42)
 		#expect(builder.threshold == 42)
 	}
 
 	@Test("days")
 	func days() {
-		let builder = SecurityShieldBuilder()
+		var builder = SecurityShieldBuilder()
 		#expect(builder.numberOfDaysUntilAutoConfirm == 14)
-		builder.setNumberOfDaysUntilAutoConfirm(numberOfDays: 237)
+		builder = builder.setNumberOfDaysUntilAutoConfirm(numberOfDays: 237)
 		#expect(builder.numberOfDaysUntilAutoConfirm == 237)
 	}
 
@@ -63,73 +63,69 @@ struct ShieldTests {
 
 	@Test("Auto lowering of threshold upon deletion")
 	func deleteFactorSourceFromPrimaryLowersThreshold() {
-		let builder = SecurityShieldBuilder()
 		let x: FactorSourceID = .sampleDevice
 		let y: FactorSourceID = .sampleLedger
 		let z: FactorSourceID = .sampleArculus
-		builder.addFactorSourceToPrimaryThreshold(factorSourceId: x)
-		builder.addFactorSourceToPrimaryThreshold(factorSourceId: y)
-		builder.addFactorSourceToPrimaryThreshold(factorSourceId: z)
-		builder.threshold = 3
-
-		builder.addFactorSourceToRecoveryOverride(factorSourceId: y)
+		var builder = SecurityShieldBuilder()
+			.addFactorSourceToPrimaryThreshold(factorSourceId: x)
+			.addFactorSourceToPrimaryThreshold(factorSourceId: y)
+			.addFactorSourceToPrimaryThreshold(factorSourceId: z)
+			.setThreshold(threshold: 3)
+			.addFactorSourceToRecoveryOverride(factorSourceId: y)
 		#expect(builder.recoveryRoleFactors == [y])
 
 		#expect(builder.threshold == 3)
 
-		builder.removeFactorFromPrimary(factorSourceId: x)
+		builder = builder.removeFactorFromPrimary(factorSourceId: x)
 		#expect(builder.threshold == 2)
 
-		builder.removeFactorFromAllRoles(factorSourceId: y)
+		builder = builder.removeFactorFromAllRoles(factorSourceId: y)
 		#expect(builder.recoveryRoleFactors == []) // assert `y` is removed from Recovery and Primary
 		#expect(builder.threshold == 1)
 
-		builder.removeFactorFromPrimary(factorSourceId: z)
+		builder = builder.removeFactorFromPrimary(factorSourceId: z)
 		#expect(builder.threshold == 0)
 		#expect(builder.primaryRoleThresholdFactors == [])
 	}
 
 	@Test("basic validation")
 	func basicValidation() throws {
-		let builder = SecurityShieldBuilder()
+		var builder = SecurityShieldBuilder()
 		#expect(builder.validate() == .PrimaryRoleMustHaveAtLeastOneFactor)
-		builder.addFactorSourceToPrimaryThreshold(factorSourceId: .sampleDevice)
-		builder.addFactorSourceToPrimaryThreshold(factorSourceId: .sampleDevice) // did not get added, duplicates are not allowed
+		builder = builder.addFactorSourceToPrimaryThreshold(factorSourceId: .sampleDevice)
+			.addFactorSourceToPrimaryThreshold(factorSourceId: .sampleDevice) // did not get added, duplicates are not allowed
 		#expect(builder.primaryRoleThresholdFactors == [.sampleDevice])
-		builder.addFactorSourceToPrimaryThreshold(factorSourceId: .sampleDeviceOther)
+		builder = builder.addFactorSourceToPrimaryThreshold(factorSourceId: .sampleDeviceOther)
 
 		#expect(builder.validate() == .RecoveryRoleMustHaveAtLeastOneFactor)
-		builder.removeFactorFromPrimary(factorSourceId: .sampleDeviceOther)
-		builder.addFactorSourceToRecoveryOverride(factorSourceId: .sampleLedger)
+		builder = builder.removeFactorFromPrimary(factorSourceId: .sampleDeviceOther)
+			.addFactorSourceToRecoveryOverride(factorSourceId: .sampleLedger)
 
 		#expect(builder.validate() == .ConfirmationRoleMustHaveAtLeastOneFactor)
-		builder.addFactorSourceToConfirmationOverride(factorSourceId: .sampleArculus)
+		builder = builder.addFactorSourceToConfirmationOverride(factorSourceId: .sampleArculus)
 		#expect(builder.validate() == nil)
 		#expect((try? builder.build()) != nil)
 	}
 
 	@Test("primary role with threshold factors cannot have a threshold value of zero")
 	func primaryRoleWithThresholdFactorsCannotHaveAThresholdValueOfZero() throws {
-		let builder = SecurityShieldBuilder()
-		builder.addFactorSourceToPrimaryThreshold(factorSourceId: .sampleLedger)
-		builder.threshold = 0
+		var builder = SecurityShieldBuilder()
+			.addFactorSourceToPrimaryThreshold(factorSourceId: .sampleLedger)
+			.setThreshold(threshold: 0)
 		#expect(builder.validate() == .PrimaryRoleWithThresholdFactorsCannotHaveAThresholdValueOfZero)
 	}
 
 	@Test("cannot add forbidden FactorSourceKinds")
 	func preventAddOfForbiddenFactorSourceKinds() throws {
-		let builder = SecurityShieldBuilder()
-
-		// Primary
-		builder.addFactorSourceToPrimaryThreshold(factorSourceId: .sampleTrustedContact) // Verboten
-		builder.addFactorSourceToPrimaryThreshold(factorSourceId: .sampleSecurityQuestions) // Verboten
-
-		// Recovery
-		builder.addFactorSourceToRecoveryOverride(factorSourceId: .sampleSecurityQuestions) // Verboten
-		builder.addFactorSourceToRecoveryOverride(factorSourceId: .samplePassword) // Verboten
-
-		// Confirmation
-		builder.addFactorSourceToConfirmationOverride(factorSourceId: .sampleTrustedContact) // Verboten
+		var builder = SecurityShieldBuilder()
+			// Primary
+			.addFactorSourceToPrimaryThreshold(factorSourceId: .sampleTrustedContact) // Verboten
+			.addFactorSourceToPrimaryThreshold(factorSourceId: .sampleSecurityQuestions) // Verboten
+			// Recovery
+			.addFactorSourceToRecoveryOverride(factorSourceId: .sampleSecurityQuestions) // Verboten
+			.addFactorSourceToRecoveryOverride(factorSourceId: .samplePassword) // Verboten
+			// Confirmation
+			.addFactorSourceToConfirmationOverride(factorSourceId: .sampleTrustedContact) // Verboten
 
 		#expect(builder.primaryRoleThresholdFactors.isEmpty)
 		#expect(builder.recoveryRoleFactors.isEmpty)
@@ -138,40 +134,39 @@ struct ShieldTests {
 
 	@Test("Primary can only contain one DeviceFactorSource")
 	func primaryCanOnlyContainOneDeviceFactorSourceThreshold() throws {
-		let builder = SecurityShieldBuilder()
 		let factor = FactorSourceId.sampleDevice
 		let other = FactorSourceId.sampleDeviceOther
-		builder.addFactorSourceToPrimaryThreshold(factorSourceId: factor)
-		builder.addFactorSourceToPrimaryOverride(factorSourceId: other)
+		var builder = SecurityShieldBuilder()
+			.addFactorSourceToPrimaryThreshold(factorSourceId: factor)
+			.addFactorSourceToPrimaryOverride(factorSourceId: other)
 		#expect(builder.primaryRoleThresholdFactors == [factor])
 		#expect(builder.primaryRoleOverrideFactors == [])
 
-		builder.removeFactorFromPrimary(factorSourceId: factor)
-
-		builder.addFactorSourceToPrimaryOverride(factorSourceId: factor)
-		builder.addFactorSourceToPrimaryThreshold(factorSourceId: other)
+		builder = builder.removeFactorFromPrimary(factorSourceId: factor)
+			.addFactorSourceToPrimaryOverride(factorSourceId: factor)
+			.addFactorSourceToPrimaryThreshold(factorSourceId: other)
 		#expect(builder.primaryRoleThresholdFactors == [])
 		#expect(builder.primaryRoleOverrideFactors == [factor])
 	}
 
 	@Test("Primary password never alone")
 	func primaryPasswordNeverAlone() {
-		let builder = SecurityShieldBuilder()
-		builder.addFactorSourceToPrimaryOverride(factorSourceId: .samplePassword) // not allowed
+		var builder = SecurityShieldBuilder()
+			.addFactorSourceToPrimaryOverride(factorSourceId: .samplePassword) // not allowed
 		#expect(builder.primaryRoleOverrideFactors.isEmpty)
 
-		builder.addFactorSourceToPrimaryThreshold(factorSourceId: .samplePassword)
+		builder = builder.addFactorSourceToPrimaryThreshold(factorSourceId: .samplePassword)
 		#expect(builder.validate() == .PrimaryRoleWithThresholdFactorsCannotHaveAThresholdValueOfZero)
-		builder.threshold = 0
+		builder = builder.setThreshold(threshold: 0)
 		#expect(builder.validate() == .PrimaryRoleWithThresholdFactorsCannotHaveAThresholdValueOfZero)
-		builder.threshold = 1
+		builder = builder.setThreshold(threshold: 1)
 		#expect(builder.validate() == .PrimaryRoleWithPasswordInThresholdListMustHaveAnotherFactor)
-		builder.addFactorSourceToPrimaryThreshold(factorSourceId: .sampleLedger)
+		builder = builder.addFactorSourceToPrimaryThreshold(factorSourceId: .sampleLedger)
 		#expect(builder.validate() == .PrimaryRoleWithPasswordInThresholdListMustThresholdGreaterThanOne)
-		builder.threshold = 2
+		builder = builder.setThreshold(threshold: 2)
 
-		builder.addFactorSourceToRecoveryOverride(factorSourceId: .sampleArculus)
-		builder.addFactorSourceToConfirmationOverride(factorSourceId: .sampleArculusOther)
+		builder = builder.addFactorSourceToRecoveryOverride(factorSourceId: .sampleArculus)
+			.addFactorSourceToConfirmationOverride(factorSourceId: .sampleArculusOther)
 
 		let shield = try! builder.build()
 
@@ -182,28 +177,26 @@ struct ShieldTests {
 
 	@Test("Build")
 	func build() throws {
-		let builder = SecurityShieldBuilder()
-		builder.setName(name: "S.H.I.E.L.D.")
-		builder.numberOfDaysUntilAutoConfirm = 42
+		var builder = SecurityShieldBuilder()
+			.setName(name: "S.H.I.E.L.D.")
+			.setNumberOfDaysUntilAutoConfirm(numberOfDays: 42)
 
 		#expect(builder.validate() == .PrimaryRoleMustHaveAtLeastOneFactor)
 
 		// Primary
 		#expect(builder.threshold == 0)
-		builder.addFactorSourceToPrimaryThreshold(factorSourceId: .sampleDevice) // bumps threshold
+		builder = builder.addFactorSourceToPrimaryThreshold(factorSourceId: .sampleDevice) // bumps threshold
 		#expect(builder.threshold == 1)
-		builder.addFactorSourceToPrimaryOverride(factorSourceId: .sampleArculus)
-		builder.addFactorSourceToPrimaryOverride(factorSourceId: .sampleArculusOther)
-
-		// Recovery
-		builder.addFactorSourceToRecoveryOverride(factorSourceId: .sampleLedger)
-		builder.addFactorSourceToRecoveryOverride(factorSourceId: .sampleLedgerOther)
-
-		// Confirmation
-		builder.addFactorSourceToConfirmationOverride(factorSourceId: .sampleDevice)
-
-		builder.removeFactorFromPrimary(factorSourceId: .sampleArculusOther)
-		builder.removeFactorFromRecovery(factorSourceId: .sampleLedgerOther)
+		builder = builder.addFactorSourceToPrimaryOverride(factorSourceId: .sampleArculus)
+			.addFactorSourceToPrimaryOverride(factorSourceId: .sampleArculusOther)
+			// Recovery
+			.addFactorSourceToRecoveryOverride(factorSourceId: .sampleLedger)
+			.addFactorSourceToRecoveryOverride(factorSourceId: .sampleLedgerOther)
+			// Confirmation
+			.addFactorSourceToConfirmationOverride(factorSourceId: .sampleDevice)
+			// Remove
+			.removeFactorFromPrimary(factorSourceId: .sampleArculusOther)
+			.removeFactorFromRecovery(factorSourceId: .sampleLedgerOther)
 
 		// Validate
 		#expect(builder.validate() == nil)
@@ -227,9 +220,9 @@ struct ShieldTests {
 
 	@Test("selected factor sources for role status")
 	func selectedFactorSourcesForRoleStatus() {
-		let builder = SecurityShieldBuilder()
-		builder.addFactorSourceToPrimaryThreshold(factorSourceId: .samplePassword)
-		builder.addFactorSourceToRecoveryOverride(factorSourceId: .sampleLedger)
+		var builder = SecurityShieldBuilder()
+			.addFactorSourceToPrimaryThreshold(factorSourceId: .samplePassword)
+			.addFactorSourceToRecoveryOverride(factorSourceId: .sampleLedger)
 
 		#expect(builder.selectedFactorSourcesForRoleStatus(role: .primary) == .invalid)
 		#expect(builder.selectedFactorSourcesForRoleStatus(role: .recovery) == .optimal)

--- a/crates/sargon-uniffi/Cargo.toml
+++ b/crates/sargon-uniffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sargon-uniffi"
 # Don't forget to update version in crates/sargon/Cargo.toml
-version = "1.1.92"
+version = "1.1.93"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/sargon-uniffi/Cargo.toml
+++ b/crates/sargon-uniffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sargon-uniffi"
 # Don't forget to update version in crates/sargon/Cargo.toml
-version = "1.1.96"
+version = "1.1.97"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/sargon-uniffi/Cargo.toml
+++ b/crates/sargon-uniffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sargon-uniffi"
 # Don't forget to update version in crates/sargon/Cargo.toml
-version = "1.1.95"
+version = "1.1.96"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/sargon-uniffi/src/core/utils/builder_arc_map.rs
+++ b/crates/sargon-uniffi/src/core/utils/builder_arc_map.rs
@@ -1,0 +1,11 @@
+use crate::prelude::*;
+
+pub(crate) fn builder_arc_map<T, F>(arc: Arc<T>, callback: F) -> Arc<T>
+where
+    T: Clone,
+    F: FnOnce(&mut T),
+{
+    let mut this = Arc::try_unwrap(arc).unwrap_or_else(|x| (*x).clone());
+    callback(&mut this);
+    Arc::new(this)
+}

--- a/crates/sargon-uniffi/src/core/utils/mod.rs
+++ b/crates/sargon-uniffi/src/core/utils/mod.rs
@@ -1,8 +1,10 @@
+mod builder_arc_map;
 mod constants;
 mod conversion_tests_macro;
 mod delegate_debug_display_impl;
 mod image_url_utils_uniffi_fn;
 
+pub use builder_arc_map::*;
 pub use conversion_tests_macro::*;
 pub use delegate_debug_display_impl::*;
 pub use image_url_utils_uniffi_fn::*;

--- a/crates/sargon/Cargo.toml
+++ b/crates/sargon/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sargon"
 # Don't forget to update version in crates/sargon-uniffi/Cargo.toml
-version = "1.1.92"
+version = "1.1.93"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/sargon/Cargo.toml
+++ b/crates/sargon/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sargon"
 # Don't forget to update version in crates/sargon-uniffi/Cargo.toml
-version = "1.1.96"
+version = "1.1.97"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/sargon/Cargo.toml
+++ b/crates/sargon/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sargon"
 # Don't forget to update version in crates/sargon-uniffi/Cargo.toml
-version = "1.1.95"
+version = "1.1.96"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/sargon/src/profile/mfa/security_structures/security_shield_builder.rs
+++ b/crates/sargon/src/profile/mfa/security_structures/security_shield_builder.rs
@@ -51,6 +51,8 @@ impl PartialEq for SecurityShieldBuilder {
     }
 }
 
+impl Eq for SecurityShieldBuilder {}
+
 impl Clone for SecurityShieldBuilder {
     fn clone(&self) -> Self {
         Self {
@@ -734,6 +736,20 @@ mod tests {
     #[test]
     fn inequality() {
         assert_ne!(SUT::sample(), SUT::sample_other());
+    }
+
+    #[test]
+    fn hash() {
+        assert_eq!(
+            radix_rust::hashset![
+                SUT::sample(),
+                SUT::sample(),
+                SUT::sample_other(),
+                SUT::sample_other(),
+            ]
+            .len(),
+            2
+        )
     }
 
     #[test]

--- a/crates/sargon/src/profile/mfa/security_structures/security_shield_builder.rs
+++ b/crates/sargon/src/profile/mfa/security_structures/security_shield_builder.rs
@@ -18,6 +18,62 @@ impl Default for SecurityShieldBuilder {
     }
 }
 
+impl PartialEq for SecurityShieldBuilder {
+    fn eq(&self, other: &Self) -> bool {
+        let (matrix, name) = (
+            self.matrix_builder
+                .read()
+                .expect("Failed to read matrix_builder"),
+            self.name.read().expect("Failed to read name"),
+        );
+        let (other_matrix, other_name) = (
+            other
+                .matrix_builder
+                .read()
+                .expect("Failed to read other matrix_builder"),
+            other.name.read().expect("Failed to read other name"),
+        );
+
+        *matrix == *other_matrix
+            && *name == *other_name
+            && self.shield_id == other.shield_id
+            && self.created_on == other.created_on
+    }
+}
+
+impl Clone for SecurityShieldBuilder {
+    fn clone(&self) -> Self {
+        Self {
+            matrix_builder: RwLock::new(
+                self.matrix_builder
+                    .read()
+                    .expect("Failed to read matrix_builder")
+                    .clone(),
+            ),
+            name: RwLock::new(
+                self.name.read().expect("Failed to read name").clone(),
+            ),
+            shield_id: self.shield_id,
+            created_on: self.created_on,
+        }
+    }
+}
+
+impl std::hash::Hash for SecurityShieldBuilder {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        let (matrix, name) = (
+            self.matrix_builder
+                .read()
+                .expect("Failed to read matrix_builder"),
+            self.name.read().expect("Failed to read name"),
+        );
+        matrix.hash(state);
+        name.hash(state);
+        self.shield_id.hash(state);
+        self.created_on.hash(state);
+    }
+}
+
 impl SecurityShieldBuilder {
     pub fn new() -> Self {
         let matrix_builder = MatrixBuilder::new();

--- a/crates/sargon/src/profile/mfa/security_structures/security_shield_builder.rs
+++ b/crates/sargon/src/profile/mfa/security_structures/security_shield_builder.rs
@@ -85,6 +85,44 @@ impl SecurityShieldBuilder {
             created_on: now(),
         }
     }
+
+    pub fn with_details(
+        matrix_builder: RwLock<MatrixBuilder>,
+        name: RwLock<String>,
+        shield_id: SecurityStructureID,
+        created_on: Timestamp,
+    ) -> Self {
+        Self {
+            matrix_builder,
+            name,
+            shield_id,
+            created_on,
+        }
+    }
+}
+
+impl HasSampleValues for SecurityShieldBuilder {
+    fn sample() -> Self {
+        let matrix_builder = MatrixBuilder::new();
+        let name = RwLock::new("My Shield".to_owned());
+        Self::with_details(
+            RwLock::new(matrix_builder),
+            name,
+            SecurityStructureID::sample(),
+            Timestamp::sample(),
+        )
+    }
+
+    fn sample_other() -> Self {
+        let matrix_builder = MatrixBuilder::new();
+        let name = RwLock::new("My Shield Other".to_owned());
+        Self::with_details(
+            RwLock::new(matrix_builder),
+            name,
+            SecurityStructureID::sample_other(),
+            Timestamp::sample_other(),
+        )
+    }
 }
 
 impl SecurityShieldBuilder {
@@ -598,6 +636,23 @@ mod tests {
 
     #[allow(clippy::upper_case_acronyms)]
     type SUT = SecurityShieldBuilder;
+
+    #[test]
+    fn equality() {
+        assert_eq!(SUT::sample(), SUT::sample());
+        assert_eq!(SUT::sample_other(), SUT::sample_other());
+    }
+
+    #[test]
+    fn inequality() {
+        assert_ne!(SUT::sample(), SUT::sample_other());
+    }
+
+    #[test]
+    fn clone() {
+        assert_eq!(SUT::sample(), SUT::sample().clone());
+        assert_eq!(SUT::sample_other(), SUT::sample_other().clone());
+    }
 
     #[test]
     fn add_factor_to_primary_threshold_does_not_change_already_set_threshold() {


### PR DESCRIPTION
To improve the handling of TCA state in the iOS host, we need to transform the UniFFI `SecurityShieldBuilder` to use value type semantics, similar to how the [TransactionBuilder is implemented in radix-engine-toolkit](https://github.com/radixdlt/radix-engine-toolkit/blob/2ab5b35a6cb96c9faeb98ed8df67b870336e6873/crates/radix-engine-toolkit-uniffi/src/builder/manifest_builder/builder_v1.rs#L24).

This change means that every mutating function will return a new instance of `SecurityShieldBuilder`.