### PR TITLE
Propagate compile diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2761,7 +2761,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.1.95"
+version = "1.1.96"
 dependencies = [
  "actix-rt",
  "aes-gcm",
@@ -2816,7 +2816,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-uniffi"
-version = "1.1.95"
+version = "1.1.96"
 dependencies = [
  "actix-rt",
  "assert-json-diff",

--- a/crates/sargon-uniffi/Cargo.toml
+++ b/crates/sargon-uniffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sargon-uniffi"
 # Don't forget to update version in crates/sargon/Cargo.toml
-version = "1.1.95"
+version = "1.1.96"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/sargon/Cargo.toml
+++ b/crates/sargon/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sargon"
 # Don't forget to update version in crates/sargon-uniffi/Cargo.toml
-version = "1.1.95"
+version = "1.1.96"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/sargon/src/lib.rs
+++ b/crates/sargon/src/lib.rs
@@ -199,6 +199,7 @@ pub mod prelude {
         },
         manifest::{
             compile as scrypto_compile,
+            compile_error_diagnostics as scrypto_compile_error_diagnostics,
             compile_manifest as scrypto_compile_manifest,
             decompile as scrypto_decompile,
             generator::{GeneratorError, GeneratorErrorKind},
@@ -214,6 +215,7 @@ pub mod prelude {
             },
             token::{Position, Span},
             CompileError as ScryptoCompileError,
+            CompileErrorDiagnosticsStyle as ScryptoCompileErrorDiagnosticsStyle,
             KnownManifestObjectNames as ScryptoKnownManifestObjectNames,
             ManifestObjectNames as ScryptoManifestObjectNames,
             MockBlobProvider as ScryptoMockBlobProvider,

--- a/crates/sargon/src/wrapped_radix_engine_toolkit/low_level/v1/transaction_manifest/instructions/instructions.rs
+++ b/crates/sargon/src/wrapped_radix_engine_toolkit/low_level/v1/transaction_manifest/instructions/instructions.rs
@@ -72,7 +72,13 @@ impl Instructions {
             &network_definition,
             blob_provider,
         )
-        .map_err(|e| CommonError::from_scrypto_compile_error(e, network_id))
+        .map_err(|e| {
+            CommonError::from_scrypto_compile_error(
+                instructions_string.as_ref(),
+                e,
+                network_id,
+            )
+        })
         .and_then(|manifest| {
             Self::try_from((manifest.instructions.as_ref(), network_id))
         })

--- a/crates/sargon/src/wrapped_radix_engine_toolkit/low_level/v1/transaction_manifest/instructions/instructions.rs
+++ b/crates/sargon/src/wrapped_radix_engine_toolkit/low_level/v1/transaction_manifest/instructions/instructions.rs
@@ -261,7 +261,8 @@ mod tests {
         assert_eq!(
             CommonError::from_address_error(
                 "foo".to_owned(),
-                NetworkID::Simulator
+                NetworkID::Simulator,
+                "fallback".to_owned()
             ),
             CommonError::InvalidInstructionsString {
                 underlying: "Failed to get NetworkID from address".to_owned()
@@ -272,8 +273,8 @@ mod tests {
     fn extract_error_from_addr_uses_invalid_instructions_string_if_same_network(
     ) {
         assert_eq!(
-            CommonError::from_address_error("account_rdx128y6j78mt0aqv6372evz28hrxp8mn06ccddkr7xppc88hyvynvjdwr".to_owned(), NetworkID::Mainnet),
-            CommonError::InvalidInstructionsString { underlying: "Failed to determine why an address was invalid".to_owned() }
+            CommonError::from_address_error("account_rdx128y6j78mt0aqv6372evz28hrxp8mn06ccddkr7xppc88hyvynvjdwr".to_owned(), NetworkID::Mainnet, "fallback".to_owned()),
+            CommonError::InvalidInstructionsString { underlying: "fallback".to_owned() }
         );
     }
 
@@ -281,6 +282,7 @@ mod tests {
     fn extract_error_from_error_non_gen_err() {
         assert_eq!(
             CommonError::from_scrypto_compile_error(
+                "invalid_manifest",
                 ScryptoCompileError::LexerError(LexerError {
                     error_kind: LexerErrorKind::UnexpectedEof,
                     span: Span {
@@ -299,7 +301,7 @@ mod tests {
                 NetworkID::Simulator
             ),
             CommonError::InvalidInstructionsString {
-                underlying: "LexerError(LexerError { error_kind: UnexpectedEof, span: Span { start: Position { full_index: 0, line_idx: 0, line_char_index: 0 }, end: Position { full_index: 0, line_idx: 0, line_char_index: 0 } } })".to_owned()
+                underlying: "error: unexpected end of file\n  |\n1 | invalid_manifest\n  | ^ unexpected end of file\n  |".to_owned()
             }
         );
     }
@@ -326,6 +328,7 @@ mod tests {
     fn extract_error_from_error_gen_non_addr_err() {
         assert_eq!(
             CommonError::from_scrypto_compile_error(
+                "invalid_manifest",
                 ScryptoCompileError::GeneratorError(GeneratorError {
                     error_kind: GeneratorErrorKind::BlobNotFound(
                         "dead".to_owned()
@@ -346,7 +349,7 @@ mod tests {
                 NetworkID::Simulator
             ),
             CommonError::InvalidInstructionsString {
-                underlying: "GeneratorError: BlobNotFound(\"dead\")".to_owned()
+                underlying: "error: blob with hash 'dead' not found\n  |\n1 | invalid_manifest\n  | ^ blob not found\n  |".to_owned()
             }
         );
     }
@@ -355,6 +358,7 @@ mod tests {
     fn extract_error_from_error_gen_err_package_addr() {
         assert_eq!(
             CommonError::from_scrypto_compile_error(
+                "invalid_manifest",
                 ScryptoCompileError::GeneratorError(GeneratorError {
                     error_kind: GeneratorErrorKind::InvalidPackageAddress(
                         PackageAddress::sample().to_string()
@@ -385,6 +389,7 @@ mod tests {
     fn extract_error_from_error_gen_err_resource_addr() {
         assert_eq!(
             CommonError::from_scrypto_compile_error(
+                "invalid_manifest",
                 ScryptoCompileError::GeneratorError(GeneratorError {
                     error_kind: GeneratorErrorKind::InvalidResourceAddress(
                         ResourceAddress::sample().to_string()

--- a/crates/sargon/src/wrapped_radix_engine_toolkit/low_level/v2/transaction_manifest_v2/instructions_v2/instructions_v2.rs
+++ b/crates/sargon/src/wrapped_radix_engine_toolkit/low_level/v2/transaction_manifest_v2/instructions_v2/instructions_v2.rs
@@ -275,7 +275,8 @@ mod tests {
         assert_eq!(
             CommonError::from_address_error(
                 "foo".to_owned(),
-                NetworkID::Simulator
+                NetworkID::Simulator,
+                "fallback".to_owned(),
             ),
             CommonError::InvalidInstructionsString {
                 underlying: "Failed to get NetworkID from address".to_owned()
@@ -286,8 +287,8 @@ mod tests {
     fn extract_error_from_addr_uses_invalid_instructions_string_if_same_network(
     ) {
         assert_eq!(
-            CommonError::from_address_error("account_rdx128y6j78mt0aqv6372evz28hrxp8mn06ccddkr7xppc88hyvynvjdwr".to_owned(), NetworkID::Mainnet),
-            CommonError::InvalidInstructionsString { underlying: "Failed to determine why an address was invalid".to_owned() }
+            CommonError::from_address_error("account_rdx128y6j78mt0aqv6372evz28hrxp8mn06ccddkr7xppc88hyvynvjdwr".to_owned(), NetworkID::Mainnet, "fallback".to_owned()),
+            CommonError::InvalidInstructionsString { underlying: "fallback".to_owned() }
         );
     }
 
@@ -295,6 +296,7 @@ mod tests {
     fn extract_error_from_error_non_gen_err() {
         assert_eq!(
             CommonError::from_scrypto_compile_error(
+                "invalid_manifest",
                 ScryptoCompileError::LexerError(LexerError {
                     error_kind: LexerErrorKind::UnexpectedEof,
                     span: Span {
@@ -313,7 +315,7 @@ mod tests {
                 NetworkID::Simulator
             ),
             CommonError::InvalidInstructionsString {
-                underlying: "LexerError(LexerError { error_kind: UnexpectedEof, span: Span { start: Position { full_index: 0, line_idx: 0, line_char_index: 0 }, end: Position { full_index: 0, line_idx: 0, line_char_index: 0 } } })".to_owned()
+                underlying: "error: unexpected end of file\n  |\n1 | invalid_manifest\n  | ^ unexpected end of file\n  |".to_owned()
             }
         );
     }
@@ -340,6 +342,7 @@ mod tests {
     fn extract_error_from_error_gen_non_addr_err() {
         assert_eq!(
             CommonError::from_scrypto_compile_error(
+                "invalid_manifest",
                 ScryptoCompileError::GeneratorError(GeneratorError {
                     error_kind: GeneratorErrorKind::BlobNotFound(
                         "dead".to_owned()
@@ -360,7 +363,7 @@ mod tests {
                 NetworkID::Simulator
             ),
             CommonError::InvalidInstructionsString {
-                underlying: "GeneratorError: BlobNotFound(\"dead\")".to_owned()
+                underlying: "error: blob with hash 'dead' not found\n  |\n1 | invalid_manifest\n  | ^ blob not found\n  |".to_owned()
             }
         );
     }
@@ -369,6 +372,7 @@ mod tests {
     fn extract_error_from_error_gen_err_package_addr() {
         assert_eq!(
             CommonError::from_scrypto_compile_error(
+                "invalid_manifest",
                 ScryptoCompileError::GeneratorError(GeneratorError {
                     error_kind: GeneratorErrorKind::InvalidPackageAddress(
                         PackageAddress::sample().to_string()
@@ -399,6 +403,7 @@ mod tests {
     fn extract_error_from_error_gen_err_resource_addr() {
         assert_eq!(
             CommonError::from_scrypto_compile_error(
+                "invalid_manifest",
                 ScryptoCompileError::GeneratorError(GeneratorError {
                     error_kind: GeneratorErrorKind::InvalidResourceAddress(
                         ResourceAddress::sample().to_string()

--- a/crates/sargon/src/wrapped_radix_engine_toolkit/low_level/v2/transaction_manifest_v2/instructions_v2/instructions_v2.rs
+++ b/crates/sargon/src/wrapped_radix_engine_toolkit/low_level/v2/transaction_manifest_v2/instructions_v2/instructions_v2.rs
@@ -87,7 +87,13 @@ impl InstructionsV2 {
             &network_definition,
             blob_provider,
         )
-        .map_err(|e| CommonError::from_scrypto_compile_error(e, network_id))
+        .map_err(|e| {
+            CommonError::from_scrypto_compile_error(
+                instructions_string.as_ref(),
+                e,
+                network_id,
+            )
+        })
         .and_then(|manifest: ScryptoTransactionManifestV2| {
             Self::try_from((manifest.instructions.as_ref(), network_id))
         })


### PR DESCRIPTION
Propagate pretty diagnostics error for CompileError. This will help dApp developers to understand better the reason when a manifest is invalid.