### PR TITLE
Replace url with dapp origin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2761,7 +2761,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.1.97"
+version = "1.1.98"
 dependencies = [
  "actix-rt",
  "aes-gcm",
@@ -2816,7 +2816,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-uniffi"
-version = "1.1.97"
+version = "1.1.98"
 dependencies = [
  "actix-rt",
  "assert-json-diff",

--- a/crates/sargon-uniffi/Cargo.toml
+++ b/crates/sargon-uniffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sargon-uniffi"
 # Don't forget to update version in crates/sargon/Cargo.toml
-version = "1.1.97"
+version = "1.1.98"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/sargon-uniffi/src/signing/authentication/auth_intent.rs
+++ b/crates/sargon-uniffi/src/signing/authentication/auth_intent.rs
@@ -12,7 +12,7 @@ pub struct AuthIntent {
     pub network_id: NetworkID,
 
     /// The origin `Url` of the dApp from which the request was made
-    pub origin: Url,
+    pub origin: DappOrigin,
 
     /// The dApp's definition address
     pub dapp_definition_address: DappDefinitionAddress,
@@ -42,7 +42,7 @@ impl From<InternalAuthIntent> for AuthIntent {
         Self {
             challenge_nonce: value.challenge_nonce.into(),
             network_id: value.network_id.into(),
-            origin: value.origin,
+            origin: value.origin.into(),
             dapp_definition_address: value.dapp_definition_address.into(),
             entities_to_sign: value
                 .entities_to_sign
@@ -58,7 +58,7 @@ impl From<AuthIntent> for InternalAuthIntent {
         Self::new(
             value.challenge_nonce.into(),
             value.network_id.into(),
-            value.origin,
+            value.origin.into(),
             value.dapp_definition_address.into(),
             value.entities_to_sign.into_iter().map(Into::into).collect(),
         )

--- a/crates/sargon/Cargo.toml
+++ b/crates/sargon/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sargon"
 # Don't forget to update version in crates/sargon-uniffi/Cargo.toml
-version = "1.1.97"
+version = "1.1.98"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/sargon/src/signing/authentication/auth_intent.rs
+++ b/crates/sargon/src/signing/authentication/auth_intent.rs
@@ -11,7 +11,7 @@ pub struct AuthIntent {
     pub network_id: NetworkID,
 
     /// The origin `Url` of the dApp from which the request was made
-    pub origin: Url,
+    pub origin: DappOrigin,
 
     /// The dApp's definition address
     pub dapp_definition_address: DappDefinitionAddress,
@@ -30,7 +30,7 @@ impl AuthIntent {
         metadata: DappToWalletInteractionMetadata,
         entities_to_sign: impl IntoIterator<Item = AddressOfAccountOrPersona>,
     ) -> Result<Self> {
-        let origin = TryInto::<Url>::try_into(metadata.origin.clone())?;
+        TryInto::<Url>::try_into(metadata.origin.clone())?;
 
         if metadata.network_id != metadata.dapp_definition_address.network_id()
         {
@@ -53,7 +53,7 @@ impl AuthIntent {
         Ok(Self::new(
             challenge_nonce.0,
             metadata.network_id,
-            origin,
+            metadata.origin,
             metadata.dapp_definition_address,
             entities,
         ))
@@ -62,7 +62,7 @@ impl AuthIntent {
     pub fn new(
         challenge_nonce: Exactly32Bytes,
         network_id: NetworkID,
-        origin: Url,
+        origin: DappOrigin,
         dapp_definition_address: DappDefinitionAddress,
         entities_to_sign: IndexSet<AddressOfAccountOrPersona>,
     ) -> Self {

--- a/crates/sargon/src/signing/authentication/auth_intent_hash.rs
+++ b/crates/sargon/src/signing/authentication/auth_intent_hash.rs
@@ -43,17 +43,12 @@ impl From<AuthIntent> for AuthIntentHash {
     /// * Extends with the bytes of the bech32-encoded dapp-definition address
     /// * Extends with the bytes of the origin UTF-8 encoded.
     fn from(value: AuthIntent) -> Self {
-        let mut origin_str = value.origin.to_string();
-        if origin_str.ends_with("/") {
-            origin_str.truncate(origin_str.len() - 1);
-        }
-
         let mut payload = Vec::<u8>::new();
         payload.push(ROLA_PREFIX);
         payload.extend(value.challenge_nonce.bytes());
         payload.push(value.dapp_definition_address.address().len() as u8);
         payload.extend(value.dapp_definition_address.address().bytes());
-        payload.extend(origin_str.as_bytes());
+        payload.extend(value.origin.0.as_bytes());
 
         Self {
             payload: BagOfBytes::from(payload),
@@ -142,15 +137,6 @@ mod tests {
         626f6172642e7261646978646c742e636f6d";
 
         assert_eq!(expected_payload_hex, challenge.payload.to_hex());
-
-        let challenge_with_origin_with_slash =
-            sut(nonce, metadata("https://stokenet-dashboard.radixdlt.com/"))
-                .unwrap();
-
-        assert_eq!(
-            expected_payload_hex,
-            challenge_with_origin_with_slash.payload.to_hex()
-        );
     }
 
     #[test]


### PR DESCRIPTION
AuthIntent needs to keep the origin string as received from the dApp and not change the contents of it. So instead of keeping it as a `Url`, it keeps track of a `DappOrigin` which is a wrapper around `String`.

The function `new_from_request` still performs a check of unwrapping a dApp origin into a Url to check if its validity, but the string is kept in `AuthIntent`. This string can be used in hosts to pass the request to ledger.