### PR TITLE
Update role threshold model

### DIFF
--- a/crates/profile/logic/logic_SPLIT_ME/src/tests/matrix_of_factor_instances_index_agnostic.rs
+++ b/crates/profile/logic/logic_SPLIT_ME/src/tests/matrix_of_factor_instances_index_agnostic.rs
@@ -9,7 +9,7 @@ type SUT = MatrixOfFactorInstances;
 fn wrong_entity_kind() {
     let invalid = unsafe {
         SUT::unbuilt_with_roles_and_days(
-            PrimaryRoleWithFactorInstances::unbuilt_with_factors(0, [
+            PrimaryRoleWithFactorInstances::unbuilt_with_factors(Threshold::All, [
                 HierarchicalDeterministicFactorInstance::sample_mainnet_entity_device_factor_fs_0_securified_at_index(
                 CAP26EntityKind::Account,
                 0,
@@ -18,12 +18,12 @@ fn wrong_entity_kind() {
                 1,
             ).into()], []),
             RecoveryRoleWithFactorInstances::unbuilt_with_factors(
-                0,
+                Threshold::Specific(0),
                 [],
                 [],
             ),
             ConfirmationRoleWithFactorInstances::unbuilt_with_factors(
-                0,
+                Threshold::Specific(0),
                 [],
                 [],
             ),
@@ -41,7 +41,7 @@ fn wrong_entity_kind() {
 fn wrong_key_kind() {
     let invalid = unsafe {
         SUT::unbuilt_with_roles_and_days(
-            PrimaryRoleWithFactorInstances::unbuilt_with_factors(0, [
+            PrimaryRoleWithFactorInstances::unbuilt_with_factors(Threshold::All, [
                 HierarchicalDeterministicFactorInstance::sample_mainnet_entity_device_factor_fs_0_securified_at_index(
                 CAP26EntityKind::Account,
                 0,
@@ -53,12 +53,12 @@ fn wrong_key_kind() {
                 SecurifiedU30::ZERO
             ).into()], []),
             RecoveryRoleWithFactorInstances::unbuilt_with_factors(
-                0,
+                Threshold::Specific(0),
                 [],
                 [],
             ),
             ConfirmationRoleWithFactorInstances::unbuilt_with_factors(
-                0,
+                Threshold::Specific(0),
                 [],
                 [],
             ),

--- a/crates/profile/logic/logic_SPLIT_ME/src/tests/matrix_of_factor_instances_index_agnostic.rs
+++ b/crates/profile/logic/logic_SPLIT_ME/src/tests/matrix_of_factor_instances_index_agnostic.rs
@@ -18,12 +18,12 @@ fn wrong_entity_kind() {
                 1,
             ).into()], []),
             RecoveryRoleWithFactorInstances::unbuilt_with_factors(
-                Threshold::Specific(0),
+                Threshold::zero(),
                 [],
                 [],
             ),
             ConfirmationRoleWithFactorInstances::unbuilt_with_factors(
-                Threshold::Specific(0),
+                Threshold::zero(),
                 [],
                 [],
             ),
@@ -53,12 +53,12 @@ fn wrong_key_kind() {
                 SecurifiedU30::ZERO
             ).into()], []),
             RecoveryRoleWithFactorInstances::unbuilt_with_factors(
-                Threshold::Specific(0),
+                Threshold::zero(),
                 [],
                 [],
             ),
             ConfirmationRoleWithFactorInstances::unbuilt_with_factors(
-                Threshold::Specific(0),
+                Threshold::zero(),
                 [],
                 [],
             ),

--- a/crates/profile/models/app-preferences/src/security.rs
+++ b/crates/profile/models/app-preferences/src/security.rs
@@ -195,7 +195,9 @@ mod tests {
                         },
                         "matrixOfFactors": {
                             "primaryRole": {
-                                "threshold": 2,
+                                "threshold": {
+                                    "specific": 2
+                                },
                                 "thresholdFactors": [
                                     {
                                         "discriminator": "fromHash",
@@ -215,7 +217,9 @@ mod tests {
                                 "overrideFactors": []
                             },
                             "recoveryRole": {
-                                "threshold": 0,
+                                "threshold": {
+                                    "specific": 0
+                                },
                                 "thresholdFactors": [],
                                 "overrideFactors": [
                                     {
@@ -235,7 +239,9 @@ mod tests {
                                 ]
                             },
                             "confirmationRole": {
-                                "threshold": 0,
+                                "threshold": {
+                                    "specific": 0
+                                },
                                 "thresholdFactors": [],
                                 "overrideFactors": [
                                     {
@@ -266,7 +272,9 @@ mod tests {
                         },
                         "matrixOfFactors": {
                             "primaryRole": {
-                                "threshold": 1,
+                                "threshold": {
+                                    "specific": 1
+                                },
                                 "thresholdFactors": [
                                     {
                                         "discriminator": "fromHash",
@@ -279,7 +287,9 @@ mod tests {
                                 "overrideFactors": []
                             },
                             "recoveryRole": {
-                                "threshold": 0,
+                                "threshold": {
+                                    "specific": 0
+                                },
                                 "thresholdFactors": [],
                                 "overrideFactors": [
                                     {
@@ -292,7 +302,9 @@ mod tests {
                                 ]
                             },
                             "confirmationRole": {
-                                "threshold": 0,
+                                "threshold": {
+                                    "specific": 0
+                                },
                                 "thresholdFactors": [],
                                 "overrideFactors": [
                                     {

--- a/crates/profile/models/app-preferences/src/security.rs
+++ b/crates/profile/models/app-preferences/src/security.rs
@@ -195,9 +195,7 @@ mod tests {
                         },
                         "matrixOfFactors": {
                             "primaryRole": {
-                                "threshold": {
-                                    "specific": 2
-                                },
+                                "threshold": "all",
                                 "thresholdFactors": [
                                     {
                                         "discriminator": "fromHash",
@@ -217,9 +215,7 @@ mod tests {
                                 "overrideFactors": []
                             },
                             "recoveryRole": {
-                                "threshold": {
-                                    "specific": 0
-                                },
+                                "threshold": "all",
                                 "thresholdFactors": [],
                                 "overrideFactors": [
                                     {
@@ -239,9 +235,7 @@ mod tests {
                                 ]
                             },
                             "confirmationRole": {
-                                "threshold": {
-                                    "specific": 0
-                                },
+                                "threshold": "all",
                                 "thresholdFactors": [],
                                 "overrideFactors": [
                                     {
@@ -272,9 +266,7 @@ mod tests {
                         },
                         "matrixOfFactors": {
                             "primaryRole": {
-                                "threshold": {
-                                    "specific": 1
-                                },
+                                "threshold": "all",
                                 "thresholdFactors": [
                                     {
                                         "discriminator": "fromHash",
@@ -287,9 +279,7 @@ mod tests {
                                 "overrideFactors": []
                             },
                             "recoveryRole": {
-                                "threshold": {
-                                    "specific": 0
-                                },
+                                "threshold": "all",
                                 "thresholdFactors": [],
                                 "overrideFactors": [
                                     {
@@ -302,9 +292,7 @@ mod tests {
                                 ]
                             },
                             "confirmationRole": {
-                                "threshold": {
-                                    "specific": 0
-                                },
+                                "threshold": "all",
                                 "thresholdFactors": [],
                                 "overrideFactors": [
                                     {

--- a/crates/profile/models/base-entity/src/entity_security_state/entity_security_state.rs
+++ b/crates/profile/models/base-entity/src/entity_security_state/entity_security_state.rs
@@ -368,7 +368,6 @@ mod tests {
         let model = EntitySecurityState::Securified {
             value: secured_entity_control,
         };
-        let value = serde_json::to_string(&model).unwrap();
         assert_eq_after_json_roundtrip(
             &model,
             r#"
@@ -405,9 +404,7 @@ mod tests {
                   "securityStructureId": "ffffffff-ffff-ffff-ffff-ffffffffffff",
                   "matrixOfFactors": {
                     "primaryRole": {
-                      "threshold": {
-                        "specific": 2
-                      },
+                      "threshold": "all",
                       "thresholdFactors": [
                         {
                           "factorSourceID": {
@@ -463,9 +460,7 @@ mod tests {
                       "overrideFactors": []
                     },
                     "recoveryRole": {
-                      "threshold": {
-                        "specific": 0
-                      },
+                      "threshold": "all",
                       "thresholdFactors": [],
                       "overrideFactors": [
                         {
@@ -521,9 +516,7 @@ mod tests {
                       ]
                     },
                     "confirmationRole": {
-                      "threshold": {
-                        "specific": 0
-                      },
+                      "threshold": "all",
                       "thresholdFactors": [],
                       "overrideFactors": [
                         {
@@ -587,9 +580,7 @@ mod tests {
                     "securityStructureId": "dededede-dede-dede-dede-dededededede",
                     "matrixOfFactors": {
                       "primaryRole": {
-                        "threshold": {
-                          "specific": 1
-                        },
+                        "threshold": "all",
                         "thresholdFactors": [
                           {
                             "factorSourceID": {
@@ -620,9 +611,7 @@ mod tests {
                         "overrideFactors": []
                       },
                       "recoveryRole": {
-                        "threshold": {
-                          "specific": 0
-                        },
+                        "threshold": "all",
                         "thresholdFactors": [],
                         "overrideFactors": [
                           {
@@ -653,9 +642,7 @@ mod tests {
                         ]
                       },
                       "confirmationRole": {
-                        "threshold": {
-                          "specific": 0
-                        },
+                        "threshold": "all",
                         "thresholdFactors": [],
                         "overrideFactors": [
                           {

--- a/crates/profile/models/base-entity/src/entity_security_state/entity_security_state.rs
+++ b/crates/profile/models/base-entity/src/entity_security_state/entity_security_state.rs
@@ -368,6 +368,7 @@ mod tests {
         let model = EntitySecurityState::Securified {
             value: secured_entity_control,
         };
+        let value = serde_json::to_string(&model).unwrap();
         assert_eq_after_json_roundtrip(
             &model,
             r#"
@@ -404,7 +405,9 @@ mod tests {
                   "securityStructureId": "ffffffff-ffff-ffff-ffff-ffffffffffff",
                   "matrixOfFactors": {
                     "primaryRole": {
-                      "threshold": 2,
+                      "threshold": {
+                        "specific": 2
+                      },
                       "thresholdFactors": [
                         {
                           "factorSourceID": {
@@ -460,7 +463,9 @@ mod tests {
                       "overrideFactors": []
                     },
                     "recoveryRole": {
-                      "threshold": 0,
+                      "threshold": {
+                        "specific": 0
+                      },
                       "thresholdFactors": [],
                       "overrideFactors": [
                         {
@@ -516,7 +521,9 @@ mod tests {
                       ]
                     },
                     "confirmationRole": {
-                      "threshold": 0,
+                      "threshold": {
+                        "specific": 0
+                      },
                       "thresholdFactors": [],
                       "overrideFactors": [
                         {
@@ -580,7 +587,9 @@ mod tests {
                     "securityStructureId": "dededede-dede-dede-dede-dededededede",
                     "matrixOfFactors": {
                       "primaryRole": {
-                        "threshold": 1,
+                        "threshold": {
+                          "specific": 1
+                        },
                         "thresholdFactors": [
                           {
                             "factorSourceID": {
@@ -611,7 +620,9 @@ mod tests {
                         "overrideFactors": []
                       },
                       "recoveryRole": {
-                        "threshold": 0,
+                        "threshold": {
+                          "specific": 0
+                        },
                         "thresholdFactors": [],
                         "overrideFactors": [
                           {
@@ -642,7 +653,9 @@ mod tests {
                         ]
                       },
                       "confirmationRole": {
-                        "threshold": 0,
+                        "threshold": {
+                          "specific": 0
+                        },
                         "thresholdFactors": [],
                         "overrideFactors": [
                           {

--- a/crates/profile/models/base-entity/src/entity_security_state/secured_entity_control/secured_entity_control.rs
+++ b/crates/profile/models/base-entity/src/entity_security_state/secured_entity_control/secured_entity_control.rs
@@ -270,7 +270,9 @@ mod tests {
                "securityStructureId": "ffffffff-ffff-ffff-ffff-ffffffffffff",
                "matrixOfFactors": {
                  "primaryRole": {
-                   "threshold": 2,
+                   "threshold": {
+                      "specific": 2
+                    },
                    "thresholdFactors": [
                      {
                        "factorSourceID": {
@@ -326,7 +328,9 @@ mod tests {
                    "overrideFactors": []
                  },
                  "recoveryRole": {
-                   "threshold": 0,
+                   "threshold": {
+                      "specific": 0
+                    },
                    "thresholdFactors": [],
                    "overrideFactors": [
                      {
@@ -382,7 +386,9 @@ mod tests {
                    ]
                  },
                  "confirmationRole": {
-                   "threshold": 0,
+                   "threshold": {
+                      "specific": 0
+                    },
                    "thresholdFactors": [],
                    "overrideFactors": [
                      {
@@ -446,7 +452,9 @@ mod tests {
                  "securityStructureId": "dededede-dede-dede-dede-dededededede",
                  "matrixOfFactors": {
                    "primaryRole": {
-                     "threshold": 1,
+                     "threshold": {
+                      "specific": 1
+                    },
                      "thresholdFactors": [
                        {
                          "factorSourceID": {
@@ -477,7 +485,9 @@ mod tests {
                      "overrideFactors": []
                    },
                    "recoveryRole": {
-                     "threshold": 0,
+                     "threshold": {
+                      "specific": 0
+                    },
                      "thresholdFactors": [],
                      "overrideFactors": [
                        {
@@ -508,7 +518,9 @@ mod tests {
                      ]
                    },
                    "confirmationRole": {
-                     "threshold": 0,
+                     "threshold": {
+                      "specific": 0
+                    },
                      "thresholdFactors": [],
                      "overrideFactors": [
                        {

--- a/crates/profile/models/base-entity/src/entity_security_state/secured_entity_control/secured_entity_control.rs
+++ b/crates/profile/models/base-entity/src/entity_security_state/secured_entity_control/secured_entity_control.rs
@@ -270,9 +270,7 @@ mod tests {
                "securityStructureId": "ffffffff-ffff-ffff-ffff-ffffffffffff",
                "matrixOfFactors": {
                  "primaryRole": {
-                   "threshold": {
-                      "specific": 2
-                    },
+                   "threshold": "all",
                    "thresholdFactors": [
                      {
                        "factorSourceID": {
@@ -328,9 +326,7 @@ mod tests {
                    "overrideFactors": []
                  },
                  "recoveryRole": {
-                   "threshold": {
-                      "specific": 0
-                    },
+                   "threshold": "all",
                    "thresholdFactors": [],
                    "overrideFactors": [
                      {
@@ -386,9 +382,7 @@ mod tests {
                    ]
                  },
                  "confirmationRole": {
-                   "threshold": {
-                      "specific": 0
-                    },
+                   "threshold": "all",
                    "thresholdFactors": [],
                    "overrideFactors": [
                      {
@@ -452,9 +446,7 @@ mod tests {
                  "securityStructureId": "dededede-dede-dede-dede-dededededede",
                  "matrixOfFactors": {
                    "primaryRole": {
-                     "threshold": {
-                      "specific": 1
-                    },
+                     "threshold": "all",
                      "thresholdFactors": [
                        {
                          "factorSourceID": {
@@ -485,9 +477,7 @@ mod tests {
                      "overrideFactors": []
                    },
                    "recoveryRole": {
-                     "threshold": {
-                      "specific": 0
-                    },
+                     "threshold": "all",                   
                      "thresholdFactors": [],
                      "overrideFactors": [
                        {
@@ -518,9 +508,7 @@ mod tests {
                      ]
                    },
                    "confirmationRole": {
-                     "threshold": {
-                      "specific": 0
-                    },
+                     "threshold": "all",                   
                      "thresholdFactors": [],
                      "overrideFactors": [
                        {

--- a/crates/profile/models/security-structures/src/lib.rs
+++ b/crates/profile/models/security-structures/src/lib.rs
@@ -5,6 +5,7 @@
 mod factor_list_kind;
 mod role_kind;
 mod roles_matrices_structures;
+mod threshold;
 
 pub mod prelude {
     pub use crate::factor_list_kind::*;

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/automatic_shield_builder/automatic_shield_builder.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/automatic_shield_builder/automatic_shield_builder.rs
@@ -128,7 +128,7 @@ impl SecurityShieldBuilder {
         self.set_authentication_signing_factor(Some(
             proto_shield.authentication_signing_factor,
         ));
-        self.set_threshold(proto_shield.primary.len() as u8);
+        self.set_threshold(Threshold::All);
         proto_shield.primary.into_iter().for_each(|f| {
             self.add_factor_source_to_primary_threshold(f);
         });
@@ -452,7 +452,7 @@ mod tests {
             AutoBuildOutcomeForTesting,
         )> {
             let shield_builder = SecurityShieldBuilder::default();
-            shield_builder.set_threshold(pick_primary_role_factors.len() as u8);
+            shield_builder.set_threshold(Threshold::All);
             pick_primary_role_factors.into_iter().for_each(|f| {
                 shield_builder.add_factor_source_to_primary_threshold(f);
             });

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/automatic_shield_builder/automatic_shield_builder.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/automatic_shield_builder/automatic_shield_builder.rs
@@ -575,8 +575,8 @@ mod tests {
 
         pretty_assertions::assert_eq!(
             matrix.primary(),
-            &PrimaryRoleWithFactorSourceIds::with_factors(
-                1,
+            &PrimaryRoleWithFactorSourceIds::with_factors_and_threshold_kind(
+                Threshold::All,
                 [FactorSourceID::sample_ledger()],
                 []
             )
@@ -646,8 +646,8 @@ mod tests {
 
         pretty_assertions::assert_eq!(
             matrix.primary(),
-            &PrimaryRoleWithFactorSourceIds::with_factors(
-                3,
+            &PrimaryRoleWithFactorSourceIds::with_factors_and_threshold_kind(
+                Threshold::All,
                 factors.clone().into_iter().map(|f| f.id()),
                 []
             )
@@ -706,8 +706,8 @@ mod tests {
 
         pretty_assertions::assert_eq!(
             matrix.primary(),
-            &PrimaryRoleWithFactorSourceIds::with_factors(
-                1,
+            &PrimaryRoleWithFactorSourceIds::with_factors_and_threshold_kind(
+                Threshold::All,
                 [FactorSourceID::sample_device()],
                 []
             )
@@ -767,8 +767,8 @@ mod tests {
 
         pretty_assertions::assert_eq!(
             matrix.primary(),
-            &PrimaryRoleWithFactorSourceIds::with_factors(
-                1,
+            &PrimaryRoleWithFactorSourceIds::with_factors_and_threshold_kind(
+                Threshold::All,
                 [FactorSourceID::sample_device()],
                 []
             )
@@ -828,8 +828,8 @@ mod tests {
 
         pretty_assertions::assert_eq!(
             matrix.primary(),
-            &PrimaryRoleWithFactorSourceIds::with_factors(
-                1,
+            &PrimaryRoleWithFactorSourceIds::with_factors_and_threshold_kind(
+                Threshold::All,
                 [FactorSourceID::sample_device()],
                 []
             )
@@ -895,8 +895,8 @@ mod tests {
 
         pretty_assertions::assert_eq!(
             matrix.primary(),
-            &PrimaryRoleWithFactorSourceIds::with_factors(
-                2,
+            &PrimaryRoleWithFactorSourceIds::with_factors_and_threshold_kind(
+                Threshold::All,
                 [
                     FactorSourceID::sample_device(),
                     FactorSourceID::sample_ledger()

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/matrices/builder/matrix_builder.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/matrices/builder/matrix_builder.rs
@@ -369,7 +369,7 @@ impl MatrixBuilder {
     /// Sets the threshold on the primary role builder.
     pub fn set_threshold(
         &mut self,
-        threshold: u8,
+        threshold: Threshold,
     ) -> MatrixBuilderMutateResult {
         self.primary_role
             .set_threshold(threshold)

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/matrices/builder/matrix_builder.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/matrices/builder/matrix_builder.rs
@@ -377,7 +377,7 @@ impl MatrixBuilder {
     }
 
     pub fn get_threshold(&self) -> u8 {
-        self.primary_role.get_threshold()
+        self.primary_role.get_threshold_value()
     }
 
     pub fn set_number_of_days_until_auto_confirm(

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/matrices/builder/matrix_builder_unit_tests.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/matrices/builder/matrix_builder_unit_tests.rs
@@ -1367,7 +1367,6 @@ mod shield_configs {
             .unwrap();
             let build0 = sut.build(); // build err
             assert!(build0.is_err());
-            sut.set_threshold(Threshold::Specific(2)).unwrap();
 
             // Recovery
             sut.add_factor_source_to_recovery_override(
@@ -1398,8 +1397,8 @@ mod shield_configs {
             pretty_assertions::assert_eq!(
                 built,
                 MatrixOfFactorSourceIds::with_roles(
-                    PrimaryRoleWithFactorSourceIds::with_factors(
-                        2,
+                    PrimaryRoleWithFactorSourceIds::with_factors_and_threshold_kind(
+                        Threshold::All,
                         [
                             FactorSourceID::sample_device(),
                             FactorSourceID::sample_ledger()
@@ -1495,7 +1494,6 @@ mod shield_configs {
                         res,
                         Err(MatrixBuilderValidation::RoleInIsolation { role: RoleKind::Primary, violation: RoleBuilderValidation::NotYetValid(NotYetValidReason::PrimaryRoleWithPasswordInThresholdListMustThresholdGreaterThanOne)}
                     ));
-            sut.set_threshold(Threshold::Specific(2)).unwrap();
 
             // Recovery
             sut.add_factor_source_to_recovery_override(
@@ -1519,8 +1517,8 @@ mod shield_configs {
             pretty_assertions::assert_eq!(
                 built,
                 MatrixOfFactorSourceIds::with_roles(
-                    PrimaryRoleWithFactorSourceIds::with_factors(
-                        2,
+                    PrimaryRoleWithFactorSourceIds::with_factors_and_threshold_kind(
+                        Threshold::All,
                         [
                             FactorSourceID::sample_device(),
                             FactorSourceID::sample_password()
@@ -1551,7 +1549,6 @@ mod shield_configs {
                 FactorSourceID::sample_device(),
             )
             .unwrap();
-            sut.set_threshold(Threshold::Specific(1)).unwrap();
 
             // Recovery
             sut.add_factor_source_to_recovery_override(
@@ -1571,8 +1568,8 @@ mod shield_configs {
             pretty_assertions::assert_eq!(
                 built,
                 MatrixOfFactorSourceIds::with_roles(
-                    PrimaryRoleWithFactorSourceIds::with_factors(
-                        1,
+                    PrimaryRoleWithFactorSourceIds::with_factors_and_threshold_kind(
+                        Threshold::All,
                         [FactorSourceID::sample_device(),],
                         [],
                     ),
@@ -1600,7 +1597,6 @@ mod shield_configs {
                 FactorSourceID::sample_ledger(),
             )
             .unwrap();
-            sut.set_threshold(Threshold::Specific(1)).unwrap();
 
             // Recovery
             sut.add_factor_source_to_recovery_override(
@@ -1620,8 +1616,8 @@ mod shield_configs {
             pretty_assertions::assert_eq!(
                 built,
                 MatrixOfFactorSourceIds::with_roles(
-                    PrimaryRoleWithFactorSourceIds::with_factors(
-                        1,
+                    PrimaryRoleWithFactorSourceIds::with_factors_and_threshold_kind(
+                        Threshold::All,
                         [FactorSourceID::sample_ledger(),],
                         [],
                     ),
@@ -1653,7 +1649,6 @@ mod shield_configs {
                 FactorSourceID::sample_ledger(),
             )
             .unwrap();
-            sut.set_threshold(Threshold::Specific(2)).unwrap();
 
             // Recovery
             sut.add_factor_source_to_recovery_override(
@@ -1677,8 +1672,8 @@ mod shield_configs {
             pretty_assertions::assert_eq!(
                 built,
                 MatrixOfFactorSourceIds::with_roles(
-                    PrimaryRoleWithFactorSourceIds::with_factors(
-                        2,
+                    PrimaryRoleWithFactorSourceIds::with_factors_and_threshold_kind(
+                        Threshold::All,
                         [
                             FactorSourceID::sample_device(),
                             FactorSourceID::sample_ledger()
@@ -1714,7 +1709,6 @@ mod shield_configs {
                 FactorSourceID::sample_ledger_other(),
             )
             .unwrap();
-            sut.set_threshold(Threshold::Specific(2)).unwrap();
 
             // Recovery
             sut.add_factor_source_to_recovery_override(
@@ -1738,8 +1732,8 @@ mod shield_configs {
             pretty_assertions::assert_eq!(
                 built,
                 MatrixOfFactorSourceIds::with_roles(
-                    PrimaryRoleWithFactorSourceIds::with_factors(
-                        2,
+                    PrimaryRoleWithFactorSourceIds::with_factors_and_threshold_kind(
+                        Threshold::All,
                         [
                             FactorSourceID::sample_ledger(),
                             FactorSourceID::sample_ledger_other()
@@ -1771,7 +1765,6 @@ mod shield_configs {
                 FactorSourceID::sample_ledger(),
             )
             .unwrap();
-            sut.set_threshold(Threshold::Specific(1)).unwrap();
 
             // Recovery
             sut.add_factor_source_to_recovery_override(
@@ -1791,8 +1784,8 @@ mod shield_configs {
             pretty_assertions::assert_eq!(
                 built,
                 MatrixOfFactorSourceIds::with_roles(
-                    PrimaryRoleWithFactorSourceIds::with_factors(
-                        1,
+                    PrimaryRoleWithFactorSourceIds::with_factors_and_threshold_kind(
+                        Threshold::All,
                         [FactorSourceID::sample_ledger(),],
                         [],
                     ),
@@ -1820,7 +1813,6 @@ mod shield_configs {
                 FactorSourceID::sample_device(),
             )
             .unwrap();
-            sut.set_threshold(Threshold::Specific(1)).unwrap();
 
             // Recovery
             sut.add_factor_source_to_recovery_override(
@@ -1840,8 +1832,8 @@ mod shield_configs {
             pretty_assertions::assert_eq!(
                 built,
                 MatrixOfFactorSourceIds::with_roles(
-                    PrimaryRoleWithFactorSourceIds::with_factors(
-                        1,
+                    PrimaryRoleWithFactorSourceIds::with_factors_and_threshold_kind(
+                        Threshold::All,
                         [FactorSourceID::sample_device(),],
                         [],
                     ),
@@ -1873,7 +1865,6 @@ mod shield_configs {
                 FactorSourceID::sample_ledger(),
             )
             .unwrap();
-            sut.set_threshold(Threshold::Specific(2)).unwrap();
 
             // Recovery
             sut.add_factor_source_to_recovery_override(
@@ -1901,8 +1892,8 @@ mod shield_configs {
             pretty_assertions::assert_eq!(
                 built,
                 MatrixOfFactorSourceIds::with_roles(
-                    PrimaryRoleWithFactorSourceIds::with_factors(
-                        2,
+                    PrimaryRoleWithFactorSourceIds::with_factors_and_threshold_kind(
+                        Threshold::All,
                         [
                             FactorSourceID::sample_device(),
                             FactorSourceID::sample_ledger()
@@ -1939,7 +1930,6 @@ mod shield_configs {
                 FactorSourceID::sample_ledger(),
             )
             .unwrap();
-            sut.set_threshold(Threshold::Specific(2)).unwrap();
 
             // Recovery
             sut.add_factor_source_to_recovery_override(
@@ -1971,8 +1961,8 @@ mod shield_configs {
             pretty_assertions::assert_eq!(
                 built,
                 MatrixOfFactorSourceIds::with_roles(
-                    PrimaryRoleWithFactorSourceIds::with_factors(
-                        2,
+                    PrimaryRoleWithFactorSourceIds::with_factors_and_threshold_kind(
+                        Threshold::All,
                         [
                             FactorSourceID::sample_device(),
                             FactorSourceID::sample_ledger()

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/matrices/builder/matrix_builder_unit_tests.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/matrices/builder/matrix_builder_unit_tests.rs
@@ -74,7 +74,7 @@ fn set_number_of_days_cannot_be_zero() {
     sut.add_factor_source_to_primary_threshold(FactorSourceID::sample_device())
         .unwrap();
 
-    sut.set_threshold(1).unwrap();
+    sut.set_threshold(Threshold::Specific(1)).unwrap();
 
     // Recovery
     sut.add_factor_source_to_recovery_override(FactorSourceID::sample_ledger())
@@ -105,7 +105,7 @@ fn set_number_of_days_42() {
     sut.add_factor_source_to_primary_threshold(FactorSourceID::sample_device())
         .unwrap();
 
-    sut.set_threshold(1).unwrap();
+    sut.set_threshold(Threshold::Specific(1)).unwrap();
 
     // Recovery
     sut.add_factor_source_to_recovery_override(FactorSourceID::sample_ledger())
@@ -154,7 +154,7 @@ fn set_number_of_days_if_not_set_uses_default() {
     sut.add_factor_source_to_primary_threshold(FactorSourceID::sample_device())
         .unwrap();
 
-    sut.set_threshold(1).unwrap();
+    sut.set_threshold(Threshold::Specific(1)).unwrap();
 
     // Recovery
     sut.add_factor_source_to_recovery_override(FactorSourceID::sample_ledger())
@@ -206,7 +206,7 @@ fn single_factor_in_primary_threshold_cannot_be_in_recovery() {
         FactorSourceID::sample_arculus_other(),
     )
     .unwrap();
-    sut.set_threshold(1).unwrap();
+    sut.set_threshold(Threshold::Specific(1)).unwrap();
 
     // ACT
     sut.add_factor_source_to_recovery_override(fs).unwrap();
@@ -272,7 +272,7 @@ fn single_factor_in_primary_threshold_cannot_be_in_confirmation() {
     let mut sut = make();
     sut.add_factor_source_to_recovery_override(FactorSourceID::sample_arculus())
         .unwrap();
-    _ = sut.set_threshold(1);
+    _ = sut.set_threshold(Threshold::Specific(1));
 
     // ACT
     let fs = FactorSourceID::sample_ledger();
@@ -362,7 +362,7 @@ fn add_factor_to_confirmation_then_same_to_primary_threshold_is_not_yet_valid()
         FactorSourceID::sample_arculus(),
     )
     .unwrap();
-    _ = sut.set_threshold(1);
+    _ = sut.set_threshold(Threshold::Specific(1));
 
     // ACT
     let fs = FactorSourceID::sample_ledger();
@@ -1198,7 +1198,7 @@ mod validation_of_addition_of_kind {
                 FactorSourceID::sample_arculus(),
             )
             .unwrap();
-            _ = sut.set_threshold(2);
+            _ = sut.set_threshold(Threshold::Specific(2));
 
             // ASSERT
             let res = sut.validation_for_addition_of_factor_source_of_kind_to_primary_threshold(
@@ -1367,7 +1367,7 @@ mod shield_configs {
             .unwrap();
             let build0 = sut.build(); // build err
             assert!(build0.is_err());
-            sut.set_threshold(2).unwrap();
+            sut.set_threshold(Threshold::Specific(2)).unwrap();
 
             // Recovery
             sut.add_factor_source_to_recovery_override(
@@ -1435,7 +1435,7 @@ mod shield_configs {
                     res,
                     Err(MatrixBuilderValidation::RoleInIsolation { role: RoleKind::Primary, violation: RoleBuilderValidation::NotYetValid(NotYetValidReason::PrimaryRoleWithPasswordInThresholdListMustThresholdGreaterThanOne)}
                 ));
-            sut.set_threshold(2).unwrap();
+            sut.set_threshold(Threshold::Specific(2)).unwrap();
 
             // Recovery
             sut.add_factor_source_to_recovery_override(
@@ -1495,7 +1495,7 @@ mod shield_configs {
                         res,
                         Err(MatrixBuilderValidation::RoleInIsolation { role: RoleKind::Primary, violation: RoleBuilderValidation::NotYetValid(NotYetValidReason::PrimaryRoleWithPasswordInThresholdListMustThresholdGreaterThanOne)}
                     ));
-            sut.set_threshold(2).unwrap();
+            sut.set_threshold(Threshold::Specific(2)).unwrap();
 
             // Recovery
             sut.add_factor_source_to_recovery_override(
@@ -1551,7 +1551,7 @@ mod shield_configs {
                 FactorSourceID::sample_device(),
             )
             .unwrap();
-            sut.set_threshold(1).unwrap();
+            sut.set_threshold(Threshold::Specific(1)).unwrap();
 
             // Recovery
             sut.add_factor_source_to_recovery_override(
@@ -1600,7 +1600,7 @@ mod shield_configs {
                 FactorSourceID::sample_ledger(),
             )
             .unwrap();
-            sut.set_threshold(1).unwrap();
+            sut.set_threshold(Threshold::Specific(1)).unwrap();
 
             // Recovery
             sut.add_factor_source_to_recovery_override(
@@ -1653,7 +1653,7 @@ mod shield_configs {
                 FactorSourceID::sample_ledger(),
             )
             .unwrap();
-            sut.set_threshold(2).unwrap();
+            sut.set_threshold(Threshold::Specific(2)).unwrap();
 
             // Recovery
             sut.add_factor_source_to_recovery_override(
@@ -1714,7 +1714,7 @@ mod shield_configs {
                 FactorSourceID::sample_ledger_other(),
             )
             .unwrap();
-            sut.set_threshold(2).unwrap();
+            sut.set_threshold(Threshold::Specific(2)).unwrap();
 
             // Recovery
             sut.add_factor_source_to_recovery_override(
@@ -1771,7 +1771,7 @@ mod shield_configs {
                 FactorSourceID::sample_ledger(),
             )
             .unwrap();
-            sut.set_threshold(1).unwrap();
+            sut.set_threshold(Threshold::Specific(1)).unwrap();
 
             // Recovery
             sut.add_factor_source_to_recovery_override(
@@ -1820,7 +1820,7 @@ mod shield_configs {
                 FactorSourceID::sample_device(),
             )
             .unwrap();
-            sut.set_threshold(1).unwrap();
+            sut.set_threshold(Threshold::Specific(1)).unwrap();
 
             // Recovery
             sut.add_factor_source_to_recovery_override(
@@ -1873,7 +1873,7 @@ mod shield_configs {
                 FactorSourceID::sample_ledger(),
             )
             .unwrap();
-            sut.set_threshold(2).unwrap();
+            sut.set_threshold(Threshold::Specific(2)).unwrap();
 
             // Recovery
             sut.add_factor_source_to_recovery_override(
@@ -1939,7 +1939,7 @@ mod shield_configs {
                 FactorSourceID::sample_ledger(),
             )
             .unwrap();
-            sut.set_threshold(2).unwrap();
+            sut.set_threshold(Threshold::Specific(2)).unwrap();
 
             // Recovery
             sut.add_factor_source_to_recovery_override(

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/matrices/builder/matrix_template.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/matrices/builder/matrix_template.rs
@@ -22,7 +22,7 @@ impl<const ROLE: u8> AbstractBuiltRoleWithFactor<ROLE, FactorSourceTemplate> {
                     .collect::<Result<Vec<_>, CommonError>>()
             };
         Ok(RoleWithFactorSourceIds::with_factors_and_threshold_kind(
-            self.get_threshold_kind(),
+            self.get_threshold(),
             fulfill(self.get_threshold_factors())?,
             fulfill(self.get_override_factors())?,
         ))

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/matrices/builder/matrix_template.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/matrices/builder/matrix_template.rs
@@ -21,8 +21,8 @@ impl<const ROLE: u8> AbstractBuiltRoleWithFactor<ROLE, FactorSourceTemplate> {
                     .map(|f| factor_source_id_assigner.next(f))
                     .collect::<Result<Vec<_>, CommonError>>()
             };
-        Ok(RoleWithFactorSourceIds::with_factors(
-            self.get_threshold(),
+        Ok(RoleWithFactorSourceIds::with_factors_and_threshold_kind(
+            self.get_threshold_kind(),
             fulfill(self.get_threshold_factors())?,
             fulfill(self.get_override_factors())?,
         ))

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/matrices/matrix_of_factor_instances.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/matrices/matrix_of_factor_instances.rs
@@ -362,14 +362,18 @@ mod tests {
     fn empty_is_err() {
         let invalid = unsafe {
             SUT::unbuilt_with_roles_and_days(
-                PrimaryRoleWithFactorInstances::unbuilt_with_factors(0, [], []),
+                PrimaryRoleWithFactorInstances::unbuilt_with_factors(
+                    Threshold::All,
+                    [],
+                    [],
+                ),
                 RecoveryRoleWithFactorInstances::unbuilt_with_factors(
-                    0,
+                    Threshold::Specific(0),
                     [],
                     [],
                 ),
                 ConfirmationRoleWithFactorInstances::unbuilt_with_factors(
-                    0,
+                    Threshold::Specific(0),
                     [],
                     [],
                 ),
@@ -383,6 +387,7 @@ mod tests {
             Err(CommonError::NoTransactionSigningFactorInstance)
         ));
     }
+
     #[test]
     fn err_if_empty_instance_found_for_factor_source() {
         assert!(matches!(
@@ -405,9 +410,7 @@ mod tests {
             r#"
             {
               "primaryRole": {
-                "threshold": {
-                  "specific": 2
-                },
+                "threshold": "all",
                 "thresholdFactors": [
                   {
                     "factorSourceID": {
@@ -463,9 +466,7 @@ mod tests {
                 "overrideFactors": []
               },
               "recoveryRole": {
-                "threshold": {
-                  "specific": 0
-                },
+                "threshold": "all",
                 "thresholdFactors": [],
                 "overrideFactors": [
                   {
@@ -521,9 +522,7 @@ mod tests {
                 ]
               },
               "confirmationRole": {
-                "threshold": {
-                  "specific": 0
-                },
+                "threshold": "all",
                 "thresholdFactors": [],
                 "overrideFactors": [
                   {

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/matrices/matrix_of_factor_instances.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/matrices/matrix_of_factor_instances.rs
@@ -405,7 +405,9 @@ mod tests {
             r#"
             {
               "primaryRole": {
-                "threshold": 2,
+                "threshold": {
+                  "specific": 2
+                },
                 "thresholdFactors": [
                   {
                     "factorSourceID": {
@@ -461,7 +463,9 @@ mod tests {
                 "overrideFactors": []
               },
               "recoveryRole": {
-                "threshold": 0,
+                "threshold": {
+                  "specific": 0
+                },
                 "thresholdFactors": [],
                 "overrideFactors": [
                   {
@@ -517,7 +521,9 @@ mod tests {
                 ]
               },
               "confirmationRole": {
-                "threshold": 0,
+                "threshold": {
+                  "specific": 0
+                },
                 "thresholdFactors": [],
                 "overrideFactors": [
                   {

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/matrices/matrix_of_factor_instances.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/matrices/matrix_of_factor_instances.rs
@@ -368,12 +368,12 @@ mod tests {
                     [],
                 ),
                 RecoveryRoleWithFactorInstances::unbuilt_with_factors(
-                    Threshold::Specific(0),
+                    Threshold::zero(),
                     [],
                     [],
                 ),
                 ConfirmationRoleWithFactorInstances::unbuilt_with_factors(
-                    Threshold::Specific(0),
+                    Threshold::zero(),
                     [],
                     [],
                 ),

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/matrices/matrix_of_factor_source_ids.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/matrices/matrix_of_factor_source_ids.rs
@@ -269,9 +269,7 @@ mod tests {
             r#"
             {
               "primaryRole": {
-                "threshold": {
-                  "specific": 2
-                },
+                "threshold": "all",
                 "thresholdFactors": [
                   {
                     "discriminator": "fromHash",
@@ -291,9 +289,7 @@ mod tests {
                 "overrideFactors": []
               },
               "recoveryRole": {
-                "threshold": {
-                  "specific": 0
-                },
+                "threshold": "all",
                 "thresholdFactors": [],
                 "overrideFactors": [
                   {
@@ -313,9 +309,7 @@ mod tests {
                 ]
               },
               "confirmationRole": {
-                "threshold": {
-                  "specific": 0
-                },
+                "threshold": "all",
                 "thresholdFactors": [],
                 "overrideFactors": [
                   {
@@ -341,9 +335,7 @@ mod tests {
             r#"
             {
               "primaryRole": {
-                "threshold": {
-                  "specific": 1
-                },
+                "threshold": "all",
                 "thresholdFactors": [
                     {
                     "discriminator": "fromHash",
@@ -356,9 +348,7 @@ mod tests {
                 "overrideFactors": []
               },
               "recoveryRole": {
-                "threshold": {
-                  "specific": 0
-                },
+                "threshold": "all",
                 "thresholdFactors": [],
                 "overrideFactors": [
                   {
@@ -371,9 +361,7 @@ mod tests {
                 ]
               },
               "confirmationRole": {
-                "threshold": {
-                  "specific": 0
-                },
+                "threshold": "all",
                 "thresholdFactors": [],
                 "overrideFactors": [
                   {

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/matrices/matrix_of_factor_source_ids.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/matrices/matrix_of_factor_source_ids.rs
@@ -269,7 +269,9 @@ mod tests {
             r#"
             {
               "primaryRole": {
-                "threshold": 2,
+                "threshold": {
+                  "specific": 2
+                },
                 "thresholdFactors": [
                   {
                     "discriminator": "fromHash",
@@ -289,7 +291,9 @@ mod tests {
                 "overrideFactors": []
               },
               "recoveryRole": {
-                "threshold": 0,
+                "threshold": {
+                  "specific": 0
+                },
                 "thresholdFactors": [],
                 "overrideFactors": [
                   {
@@ -309,7 +313,9 @@ mod tests {
                 ]
               },
               "confirmationRole": {
-                "threshold": 0,
+                "threshold": {
+                  "specific": 0
+                },
                 "thresholdFactors": [],
                 "overrideFactors": [
                   {
@@ -335,7 +341,9 @@ mod tests {
             r#"
             {
               "primaryRole": {
-                "threshold": 1,
+                "threshold": {
+                  "specific": 1
+                },
                 "thresholdFactors": [
                     {
                     "discriminator": "fromHash",
@@ -348,7 +356,9 @@ mod tests {
                 "overrideFactors": []
               },
               "recoveryRole": {
-                "threshold": 0,
+                "threshold": {
+                  "specific": 0
+                },
                 "thresholdFactors": [],
                 "overrideFactors": [
                   {
@@ -361,7 +371,9 @@ mod tests {
                 ]
               },
               "confirmationRole": {
-                "threshold": 0,
+                "threshold": {
+                  "specific": 0
+                },
                 "thresholdFactors": [],
                 "overrideFactors": [
                   {

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/mod.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/mod.rs
@@ -11,6 +11,7 @@ mod security_structure_metadata;
 mod security_structure_of_factors;
 mod selected_primary_threshold_factors_status;
 
+pub use crate::threshold::*;
 pub use automatic_shield_builder::*;
 pub use has_role_kind::*;
 pub use matrices::*;

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/roles/abstract_role_builder_or_built.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/roles/abstract_role_builder_or_built.rs
@@ -201,7 +201,7 @@ impl<const ROLE: u8> RoleBuilder<ROLE> {
         }
     }
 
-    pub(crate) fn unchecked_set_threshold(&mut self, threshold: u8) {
-        self.threshold = Threshold::Specific(threshold);
+    pub(crate) fn unchecked_set_threshold(&mut self, threshold: Threshold) {
+        self.threshold = threshold;
     }
 }

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/roles/abstract_role_builder_or_built.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/roles/abstract_role_builder_or_built.rs
@@ -67,7 +67,7 @@ impl<const ROLE: u8, const MODE: u8, FACTOR: IsMaybeKeySpaceAware>
     /// of unsafe - as in application **unsecure** - Role of Factors, which might
     /// lead to increase risk for end user to loose funds.
     pub unsafe fn unbuilt_with_factors(
-        threshold: u8,
+        threshold: Threshold,
         threshold_factors: impl IntoIterator<Item = FACTOR>,
         override_factors: impl IntoIterator<Item = FACTOR>,
     ) -> Self {
@@ -98,7 +98,7 @@ impl<const ROLE: u8, const MODE: u8, FACTOR: IsMaybeKeySpaceAware>
             .expect("Should not have allowed building of invalid Role");
 
         Self {
-            threshold: Threshold::Specific(threshold),
+            threshold,
             threshold_factors,
             override_factors,
         }
@@ -106,6 +106,20 @@ impl<const ROLE: u8, const MODE: u8, FACTOR: IsMaybeKeySpaceAware>
 
     pub fn with_factors(
         threshold: u8,
+        threshold_factors: impl IntoIterator<Item = FACTOR>,
+        override_factors: impl IntoIterator<Item = FACTOR>,
+    ) -> Self {
+        unsafe {
+            Self::unbuilt_with_factors(
+                Threshold::Specific(threshold),
+                threshold_factors,
+                override_factors,
+            )
+        }
+    }
+
+    pub fn with_factors_and_threshold_kind(
+        threshold: Threshold,
         threshold_factors: impl IntoIterator<Item = FACTOR>,
         override_factors: impl IntoIterator<Item = FACTOR>,
     ) -> Self {
@@ -147,6 +161,12 @@ impl<const ROLE: u8, const MODE: u8, FACTOR>
     /// this role.
     pub fn get_threshold(&self) -> u8 {
         self.threshold.value(self.threshold_factors.len())
+    }
+
+    /// How many threshold factors that must be used to perform some function with
+    /// this role.
+    pub fn get_threshold_kind(&self) -> Threshold {
+        self.threshold
     }
 }
 pub(crate) const ROLE_PRIMARY: u8 = 1;

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/roles/abstract_role_builder_or_built.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/roles/abstract_role_builder_or_built.rs
@@ -159,13 +159,13 @@ impl<const ROLE: u8, const MODE: u8, FACTOR>
 
     /// How many threshold factors that must be used to perform some function with
     /// this role.
-    pub fn get_threshold(&self) -> u8 {
+    pub fn get_threshold_value(&self) -> u8 {
         self.threshold.value(self.threshold_factors.len())
     }
 
     /// How many threshold factors that must be used to perform some function with
     /// this role.
-    pub fn get_threshold_kind(&self) -> Threshold {
+    pub fn get_threshold(&self) -> Threshold {
         self.threshold
     }
 }

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/roles/abstract_role_builder_or_built.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/roles/abstract_role_builder_or_built.rs
@@ -30,7 +30,7 @@ use crate::prelude::*;
 pub struct AbstractRoleBuilderOrBuilt<const ROLE: u8, const MODE: u8, FACTOR> {
     /// How many threshold factors that must be used to perform some function with
     /// this role.
-    threshold: u8,
+    threshold: Threshold,
 
     /// Factors which are used in combination with other factors, amounting to at
     /// least `threshold` many factors to perform some function with this role.
@@ -54,7 +54,7 @@ impl<const ROLE: u8, const MODE: u8, FACTOR: IsMaybeKeySpaceAware>
     /// Removes all factors from this role and set threshold to 0.
     pub fn reset(&mut self) {
         self.threshold_factors.clear();
-        self.threshold = 0;
+        self.threshold = Threshold::All;
         self.override_factors.clear();
     }
 
@@ -98,7 +98,7 @@ impl<const ROLE: u8, const MODE: u8, FACTOR: IsMaybeKeySpaceAware>
             .expect("Should not have allowed building of invalid Role");
 
         Self {
-            threshold,
+            threshold: Threshold::Specific(threshold),
             threshold_factors,
             override_factors,
         }
@@ -146,7 +146,7 @@ impl<const ROLE: u8, const MODE: u8, FACTOR>
     /// How many threshold factors that must be used to perform some function with
     /// this role.
     pub fn get_threshold(&self) -> u8 {
-        self.threshold
+        self.threshold.value(self.threshold_factors.len())
     }
 }
 pub(crate) const ROLE_PRIMARY: u8 = 1;
@@ -172,7 +172,7 @@ impl RoleFromDiscriminator for RoleKind {
 impl<const ROLE: u8> RoleBuilder<ROLE> {
     pub(crate) fn new() -> Self {
         Self {
-            threshold: 0,
+            threshold: Threshold::All,
             threshold_factors: Vec::new(),
             override_factors: Vec::new(),
         }
@@ -202,6 +202,6 @@ impl<const ROLE: u8> RoleBuilder<ROLE> {
     }
 
     pub(crate) fn unchecked_set_threshold(&mut self, threshold: u8) {
-        self.threshold = threshold;
+        self.threshold = Threshold::Specific(threshold);
     }
 }

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/roles/builder/confirmation_roles_builder_unit_tests.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/roles/builder/confirmation_roles_builder_unit_tests.rs
@@ -71,7 +71,7 @@ mod device_in_isolation {
     fn set_threshold_is_unsupported() {
         let mut sut = make();
         assert_eq!(
-            sut.set_threshold(1),
+            sut.set_specific_threshold(1),
             MutRes::basic_violation(
                 BasicViolation::ConfirmationCannotSetThreshold
             )

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/roles/builder/primary_roles_builder_unit_tests.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/roles/builder/primary_roles_builder_unit_tests.rs
@@ -193,7 +193,15 @@ mod threshold_suite {
         assert_eq!(sut.get_threshold(), 2);
         sut.remove_factor_source(&fs0, FactorListKind::Threshold)
             .unwrap();
-        assert_eq!(sut.get_threshold_kind(), Threshold::All);
+        assert_eq!(sut.get_threshold_kind(), Threshold::All); // assert that we DIDN'T change the threshold kind from All to Specific
+        assert_eq!(sut.get_threshold(), 1);
+
+        sut.add_factor_source_to_threshold(fs0).unwrap();
+        sut.set_threshold(Threshold::Specific(2)).unwrap();
+        assert_eq!(sut.get_threshold_kind(), Threshold::Specific(2));
+        sut.remove_factor_source(&fs0, FactorListKind::Threshold)
+            .unwrap();
+        assert_eq!(sut.get_threshold_kind(), Threshold::Specific(1)); // assert that we DIDN'T change the threshold kind from Specific to All
         assert_eq!(sut.get_threshold(), 1);
     }
 

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/roles/builder/primary_roles_builder_unit_tests.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/roles/builder/primary_roles_builder_unit_tests.rs
@@ -197,12 +197,21 @@ mod threshold_suite {
         assert_eq!(sut.get_threshold(), 1);
 
         sut.add_factor_source_to_threshold(fs0).unwrap();
-        sut.set_threshold(Threshold::Specific(2)).unwrap();
-        assert_eq!(sut.get_threshold_kind(), Threshold::Specific(2));
+        sut.add_factor_source_to_threshold(
+            FactorSourceID::sample_arculus_other(),
+        )
+        .unwrap(); // now we have 3 factors
+
+        sut.set_threshold(Threshold::Specific(1)).unwrap();
+        assert_eq!(sut.get_threshold_kind(), Threshold::Specific(1));
         sut.remove_factor_source(&fs0, FactorListKind::Threshold)
             .unwrap();
-        assert_eq!(sut.get_threshold_kind(), Threshold::Specific(1)); // assert that we DIDN'T change the threshold kind from Specific to All
-        assert_eq!(sut.get_threshold(), 1);
+        assert_eq!(sut.get_threshold_kind(), Threshold::Specific(1)); // assert that we DIDN'T change the threshold specific value
+
+        sut.remove_factor_source(&fs1, FactorListKind::Threshold)
+            .unwrap();
+
+        assert_eq!(sut.get_threshold(), 1); // assert that we DIDN'T change the threshold kind from Specific to All
     }
 
     #[test]

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/roles/builder/primary_roles_builder_unit_tests.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/roles/builder/primary_roles_builder_unit_tests.rs
@@ -153,8 +153,8 @@ mod threshold_suite {
     fn remove_lowers_threshold_from_1_to_0() {
         let mut sut = make();
         let fs = sample();
-        assert_eq!(sut.get_threshold(), 0);
-        sut.add_factor_source_to_threshold(fs).unwrap(); // should automatically increase threshold to 1
+        assert_eq!(sut.get_threshold_kind(), Threshold::All);
+        sut.add_factor_source_to_threshold(fs).unwrap();
         assert_eq!(sut.get_threshold(), 1);
         sut.remove_factor_source(&fs, FactorListKind::Threshold)
             .unwrap();
@@ -180,6 +180,34 @@ mod threshold_suite {
         sut.remove_factor_source(&fs1, FactorListKind::Threshold)
             .unwrap();
         assert_eq!(sut.get_threshold(), 1); // assert that we DID lower the threshold now that we have 1 factor
+    }
+
+    #[test]
+    fn remove_does_not_change_threshold_kind() {
+        let mut sut = make();
+        let fs0 = sample();
+        let fs1 = sample_other();
+        sut.add_factor_source_to_threshold(fs0).unwrap();
+        sut.add_factor_source_to_threshold(fs1).unwrap();
+        assert_eq!(sut.get_threshold_kind(), Threshold::All);
+        assert_eq!(sut.get_threshold(), 2);
+        sut.remove_factor_source(&fs0, FactorListKind::Threshold)
+            .unwrap();
+        assert_eq!(sut.get_threshold_kind(), Threshold::All);
+        assert_eq!(sut.get_threshold(), 1);
+    }
+
+    #[test]
+    fn remove_single_factor_changes_threshold_to_all() {
+        let mut sut = make();
+        let fs0 = sample();
+        let fs1 = sample_other();
+        sut.add_factor_source_to_threshold(fs0).unwrap();
+        sut.set_specific_threshold(1).unwrap();
+        assert_eq!(sut.get_threshold(), 1);
+        sut.remove_factor_source(&fs0, FactorListKind::Threshold)
+            .unwrap();
+        assert_eq!(sut.get_threshold_kind(), Threshold::All);
     }
 
     #[test]
@@ -720,7 +748,11 @@ mod ledger {
 
             // Assert
             let expected =
-                PrimaryRoleWithFactorSourceIds::with_factors(0, [], [sample()]);
+                PrimaryRoleWithFactorSourceIds::with_factors_and_threshold_kind(
+                    Threshold::All,
+                    [],
+                    [sample()],
+                );
             assert_eq!(sut.build().unwrap(), expected);
         }
 
@@ -734,11 +766,12 @@ mod ledger {
             sut.add_factor_source_to_override(sample_other()).unwrap();
 
             // Assert
-            let expected = PrimaryRoleWithFactorSourceIds::with_factors(
-                0,
-                [],
-                [sample(), sample_other()],
-            );
+            let expected =
+                PrimaryRoleWithFactorSourceIds::with_factors_and_threshold_kind(
+                    Threshold::All,
+                    [],
+                    [sample(), sample_other()],
+                );
             assert_eq!(sut.build().unwrap(), expected);
         }
     }
@@ -830,7 +863,11 @@ mod arculus {
 
             // Assert
             let expected =
-                PrimaryRoleWithFactorSourceIds::with_factors(0, [], [sample()]);
+                PrimaryRoleWithFactorSourceIds::with_factors_and_threshold_kind(
+                    Threshold::All,
+                    [],
+                    [sample()],
+                );
             assert_eq!(sut.build().unwrap(), expected);
         }
 
@@ -844,11 +881,12 @@ mod arculus {
             sut.add_factor_source_to_override(sample_other()).unwrap();
 
             // Assert
-            let expected = PrimaryRoleWithFactorSourceIds::with_factors(
-                0,
-                [],
-                [sample(), sample_other()],
-            );
+            let expected =
+                PrimaryRoleWithFactorSourceIds::with_factors_and_threshold_kind(
+                    Threshold::All,
+                    [],
+                    [sample(), sample_other()],
+                );
             assert_eq!(sut.build().unwrap(), expected);
         }
     }
@@ -944,7 +982,11 @@ mod device_factor_source {
 
             // Assert
             let expected =
-                PrimaryRoleWithFactorSourceIds::with_factors(0, [], [sample()]);
+                PrimaryRoleWithFactorSourceIds::with_factors_and_threshold_kind(
+                    Threshold::All,
+                    [],
+                    [sample()],
+                );
             assert_eq!(sut.build().unwrap(), expected);
         }
     }

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/roles/builder/primary_roles_builder_unit_tests.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/roles/builder/primary_roles_builder_unit_tests.rs
@@ -153,12 +153,12 @@ mod threshold_suite {
     fn remove_lowers_threshold_from_1_to_0() {
         let mut sut = make();
         let fs = sample();
-        assert_eq!(sut.get_threshold_kind(), Threshold::All);
+        assert_eq!(sut.get_threshold(), Threshold::All);
         sut.add_factor_source_to_threshold(fs).unwrap();
-        assert_eq!(sut.get_threshold(), 1);
+        assert_eq!(sut.get_threshold_value(), 1);
         sut.remove_factor_source(&fs, FactorListKind::Threshold)
             .unwrap();
-        assert_eq!(sut.get_threshold(), 0);
+        assert_eq!(sut.get_threshold_value(), 0);
     }
 
     #[test]
@@ -173,13 +173,13 @@ mod threshold_suite {
         )
         .unwrap();
         sut.set_specific_threshold(2).unwrap();
-        assert_eq!(sut.get_threshold(), 2);
+        assert_eq!(sut.get_threshold_value(), 2);
         sut.remove_factor_source(&fs0, FactorListKind::Threshold)
             .unwrap();
-        assert_eq!(sut.get_threshold(), 2); // assert that we DIDN'T lower the threshold, since we have 2 factors
+        assert_eq!(sut.get_threshold_value(), 2); // assert that we DIDN'T lower the threshold, since we have 2 factors
         sut.remove_factor_source(&fs1, FactorListKind::Threshold)
             .unwrap();
-        assert_eq!(sut.get_threshold(), 1); // assert that we DID lower the threshold now that we have 1 factor
+        assert_eq!(sut.get_threshold_value(), 1); // assert that we DID lower the threshold now that we have 1 factor
     }
 
     #[test]
@@ -189,12 +189,12 @@ mod threshold_suite {
         let fs1 = sample_other();
         sut.add_factor_source_to_threshold(fs0).unwrap();
         sut.add_factor_source_to_threshold(fs1).unwrap();
-        assert_eq!(sut.get_threshold_kind(), Threshold::All);
-        assert_eq!(sut.get_threshold(), 2);
+        assert_eq!(sut.get_threshold(), Threshold::All);
+        assert_eq!(sut.get_threshold_value(), 2);
         sut.remove_factor_source(&fs0, FactorListKind::Threshold)
             .unwrap();
-        assert_eq!(sut.get_threshold_kind(), Threshold::All); // assert that we DIDN'T change the threshold kind from All to Specific
-        assert_eq!(sut.get_threshold(), 1);
+        assert_eq!(sut.get_threshold(), Threshold::All); // assert that we DIDN'T change the threshold kind from All to Specific
+        assert_eq!(sut.get_threshold_value(), 1);
 
         sut.add_factor_source_to_threshold(fs0).unwrap();
         sut.add_factor_source_to_threshold(
@@ -203,15 +203,15 @@ mod threshold_suite {
         .unwrap(); // now we have 3 factors
 
         sut.set_threshold(Threshold::Specific(1)).unwrap();
-        assert_eq!(sut.get_threshold_kind(), Threshold::Specific(1));
+        assert_eq!(sut.get_threshold(), Threshold::Specific(1));
         sut.remove_factor_source(&fs0, FactorListKind::Threshold)
             .unwrap();
-        assert_eq!(sut.get_threshold_kind(), Threshold::Specific(1)); // assert that we DIDN'T change the threshold specific value
+        assert_eq!(sut.get_threshold(), Threshold::Specific(1)); // assert that we DIDN'T change the threshold specific value
 
         sut.remove_factor_source(&fs1, FactorListKind::Threshold)
             .unwrap();
 
-        assert_eq!(sut.get_threshold(), 1); // assert that we DIDN'T change the threshold kind from Specific to All
+        assert_eq!(sut.get_threshold_value(), 1); // assert that we DIDN'T change the threshold kind from Specific to All
     }
 
     #[test]
@@ -221,10 +221,10 @@ mod threshold_suite {
         let fs1 = sample_other();
         sut.add_factor_source_to_threshold(fs0).unwrap();
         sut.set_specific_threshold(1).unwrap();
-        assert_eq!(sut.get_threshold(), 1);
+        assert_eq!(sut.get_threshold_value(), 1);
         sut.remove_factor_source(&fs0, FactorListKind::Threshold)
             .unwrap();
-        assert_eq!(sut.get_threshold_kind(), Threshold::All);
+        assert_eq!(sut.get_threshold(), Threshold::All);
     }
 
     #[test]
@@ -238,14 +238,14 @@ mod threshold_suite {
         let _ = sut.build(); // build should not mutate neither consume
         sut.set_specific_threshold(2).unwrap();
         let _ = sut.build(); // build should not mutate neither consume
-        assert_eq!(sut.get_threshold(), 2);
+        assert_eq!(sut.get_threshold_value(), 2);
         sut.remove_factor_source(&fs, FactorListKind::Override)
             .unwrap();
-        assert_eq!(sut.get_threshold(), 2);
+        assert_eq!(sut.get_threshold_value(), 2);
 
         let built = sut.build().unwrap();
         let built2 = sut.build().unwrap();
-        assert_eq!(built.get_threshold(), 2);
+        assert_eq!(built.get_threshold_value(), 2);
         assert_eq!(built2, built); // can built many times
 
         assert_eq!(built.role(), RoleKind::Primary);

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/roles/builder/primary_roles_builder_unit_tests.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/roles/builder/primary_roles_builder_unit_tests.rs
@@ -172,7 +172,7 @@ mod threshold_suite {
             FactorSourceID::sample_arculus_other(),
         )
         .unwrap();
-        sut.set_threshold(2).unwrap();
+        sut.set_specific_threshold(2).unwrap();
         assert_eq!(sut.get_threshold(), 2);
         sut.remove_factor_source(&fs0, FactorListKind::Threshold)
             .unwrap();
@@ -191,7 +191,7 @@ mod threshold_suite {
         let fs = FactorSourceID::sample_arculus_other();
         sut.add_factor_source_to_override(fs).unwrap();
         let _ = sut.build(); // build should not mutate neither consume
-        sut.set_threshold(2).unwrap();
+        sut.set_specific_threshold(2).unwrap();
         let _ = sut.build(); // build should not mutate neither consume
         assert_eq!(sut.get_threshold(), 2);
         sut.remove_factor_source(&fs, FactorListKind::Override)
@@ -220,7 +220,7 @@ mod threshold_suite {
 
         // Act
         sut.add_factor_source_to_threshold(sample_other()).unwrap();
-        sut.set_threshold(1).unwrap();
+        sut.set_specific_threshold(1).unwrap();
 
         // Assert
         let expected = PrimaryRoleWithFactorSourceIds::with_factors(
@@ -239,7 +239,7 @@ mod threshold_suite {
 
         // Act
         assert_eq!(
-            sut.set_threshold(1),
+            sut.set_specific_threshold(1),
             Err(Validation::NotYetValid(
                 ThresholdHigherThanThresholdFactorsLen
             ))
@@ -263,7 +263,7 @@ mod threshold_suite {
 
         // Act
         assert_eq!(
-            sut.set_threshold(2),
+            sut.set_specific_threshold(2),
             Err(Validation::NotYetValid(
                 ThresholdHigherThanThresholdFactorsLen
             ))
@@ -290,7 +290,7 @@ mod threshold_suite {
         sut.add_factor_source_to_threshold(sample_other()).unwrap();
 
         // Act
-        assert_eq!(sut.set_threshold(2), Ok(()));
+        assert_eq!(sut.set_specific_threshold(2), Ok(()));
 
         // Assert
         let expected = PrimaryRoleWithFactorSourceIds::with_factors(
@@ -312,7 +312,7 @@ mod threshold_suite {
 
         // Act
         assert_eq!(
-            sut.set_threshold(3),
+            sut.set_specific_threshold(3),
             Err(Validation::NotYetValid(
                 ThresholdHigherThanThresholdFactorsLen
             ))
@@ -336,7 +336,7 @@ mod threshold_suite {
 
         // Act
         sut.add_factor_source_to_threshold(sample_other()).unwrap();
-        sut.set_threshold(1).unwrap();
+        sut.set_specific_threshold(1).unwrap();
 
         // Assert
         let expected = PrimaryRoleWithFactorSourceIds::with_factors(
@@ -355,7 +355,7 @@ mod threshold_suite {
         // Act
         sut.add_factor_source_to_override(sample_other()).unwrap();
         assert_eq!(
-            sut.set_threshold(1),
+            sut.set_specific_threshold(1),
             Err(Validation::NotYetValid(
                 ThresholdHigherThanThresholdFactorsLen
             ))
@@ -395,7 +395,7 @@ mod threshold_suite {
             ]
         );
         _ = sut.add_factor_source_to_threshold(fs0);
-        _ = sut.set_threshold(2);
+        _ = sut.set_specific_threshold(2);
 
         let xs = sut.validation_for_addition_of_factor_source_for_each(
             FactorListKind::Threshold,
@@ -449,7 +449,7 @@ mod password {
             let mut sut = make();
             sut.add_factor_source_to_threshold(FactorSourceID::sample_device())
                 .unwrap();
-            _ = sut.set_threshold(2);
+            _ = sut.set_specific_threshold(2);
             test_duplicates_not_allowed(
                 sut,
                 FactorListKind::Threshold,
@@ -461,7 +461,7 @@ mod password {
         fn alone_is_not_ok() {
             // Arrange
             let mut sut = make();
-            let _ = sut.set_threshold(1);
+            let _ = sut.set_specific_threshold(1);
             // Act
             let res = sut.add_factor_source_to_threshold(sample());
 
@@ -525,7 +525,7 @@ mod password {
                     FactorSourceID::sample_device(),
                 )
                 .unwrap();
-                _ = sut.set_threshold(2);
+                _ = sut.set_specific_threshold(2);
             });
 
             not_ok(SecurityQuestions);
@@ -652,7 +652,7 @@ mod ledger {
 
             // Act
             sut.add_factor_source_to_threshold(sample()).unwrap();
-            sut.set_threshold(1).unwrap();
+            sut.set_specific_threshold(1).unwrap();
 
             // Assert
             let expected =
@@ -668,7 +668,7 @@ mod ledger {
             // Act
             sut.add_factor_source_to_threshold(sample()).unwrap(); // should automatically bump threshold to 1
 
-            let _ = sut.set_threshold(0);
+            let _ = sut.set_specific_threshold(0);
 
             // Assert
             assert_eq!(
@@ -687,7 +687,7 @@ mod ledger {
             // Act
             sut.add_factor_source_to_threshold(sample()).unwrap();
             sut.add_factor_source_to_threshold(sample_other()).unwrap();
-            sut.set_threshold(2).unwrap();
+            sut.set_specific_threshold(2).unwrap();
 
             // Assert
             let expected = PrimaryRoleWithFactorSourceIds::with_factors(
@@ -781,7 +781,7 @@ mod arculus {
 
             // Act
             sut.add_factor_source_to_threshold(sample()).unwrap();
-            sut.set_threshold(1).unwrap();
+            sut.set_specific_threshold(1).unwrap();
 
             // Assert
             let expected =
@@ -797,7 +797,7 @@ mod arculus {
             // Act
             sut.add_factor_source_to_threshold(sample()).unwrap();
             sut.add_factor_source_to_threshold(sample_other()).unwrap();
-            sut.set_threshold(1).unwrap();
+            sut.set_specific_threshold(1).unwrap();
 
             // Assert
             let expected = PrimaryRoleWithFactorSourceIds::with_factors(
@@ -893,7 +893,7 @@ mod device_factor_source {
 
             // Act
             sut.add_factor_source_to_threshold(sample()).unwrap();
-            sut.set_threshold(1).unwrap();
+            sut.set_specific_threshold(1).unwrap();
 
             // Assert
             let expected =

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/roles/builder/recovery_roles_builder_unit_tests.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/roles/builder/recovery_roles_builder_unit_tests.rs
@@ -58,7 +58,7 @@ fn validation_for_addition_of_factor_source_of_kind_to_list() {
 fn set_threshold_is_unsupported() {
     let mut sut = make();
     assert_eq!(
-        sut.set_threshold(1),
+        sut.set_specific_threshold(1),
         MutRes::basic_violation(BasicViolation::RecoveryCannotSetThreshold)
     );
 }

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/roles/builder/roles_builder.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/roles/builder/roles_builder.rs
@@ -699,7 +699,7 @@ impl<const ROLE: u8> RoleBuilder<ROLE> {
 
     /// Removes a factor source from the list of `factor_list_kind`.
     ///
-    /// Lowers the threshold if the deleted factor source is in the threshold list
+    /// Lowers the threshold if the deleted factor source is in the `factor_list_kind` list
     /// and if after removal of `factor_source_id` `self.threshold > self.threshold_factors.len()`
     ///
     /// Returns `Ok` if `factor_source_id` was found and deleted. However, does not call `self.validate()`,
@@ -729,7 +729,7 @@ impl<const ROLE: u8> RoleBuilder<ROLE> {
                         self.get_threshold_factors().len() as u8;
                     if threshold_factors_len == 0 {
                         self.unchecked_set_threshold(Threshold::All);
-                    } else {
+                    } else if self.get_threshold() > threshold_factors_len {
                         self.unchecked_set_threshold(Threshold::Specific(
                             threshold_factors_len,
                         ));

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/roles/factor_levels/factor_instance_level/general_role_with_hierarchical_deterministic_factor_instances.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/roles/factor_levels/factor_instance_level/general_role_with_hierarchical_deterministic_factor_instances.rs
@@ -88,19 +88,19 @@ impl TryFrom<(MatrixOfFactorInstances, RoleKind)>
         match role_kind {
             RoleKind::Primary => {
                 let role = matrix.primary();
-                threshold = role.get_threshold();
+                threshold = role.get_threshold_value();
                 threshold_factors = role.get_threshold_factors().clone();
                 override_factors = role.get_override_factors().clone();
             }
             RoleKind::Recovery => {
                 let role = matrix.recovery();
-                threshold = role.get_threshold();
+                threshold = role.get_threshold_value();
                 threshold_factors = role.get_threshold_factors().clone();
                 override_factors = role.get_override_factors().clone();
             }
             RoleKind::Confirmation => {
                 let role = matrix.confirmation();
-                threshold = role.get_threshold();
+                threshold = role.get_threshold_value();
                 threshold_factors = role.get_threshold_factors().clone();
                 override_factors = role.get_override_factors().clone();
             }

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/roles/factor_levels/factor_instance_level/primary_role_with_factor_instances.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/roles/factor_levels/factor_instance_level/primary_role_with_factor_instances.rs
@@ -50,9 +50,7 @@ mod tests {
             &sut,
             r#"
                         {
-              "threshold": {
-                "specific": 2
-              },
+              "threshold": "all",
               "thresholdFactors": [
                 {
                   "factorSourceID": {

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/roles/factor_levels/factor_instance_level/primary_role_with_factor_instances.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/roles/factor_levels/factor_instance_level/primary_role_with_factor_instances.rs
@@ -50,7 +50,9 @@ mod tests {
             &sut,
             r#"
                         {
-              "threshold": 2,
+              "threshold": {
+                "specific": 2
+              },
               "thresholdFactors": [
                 {
                   "factorSourceID": {

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/roles/factor_levels/factor_instance_level/role_into_scrypto_access_rule.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/roles/factor_levels/factor_instance_level/role_into_scrypto_access_rule.rs
@@ -13,7 +13,7 @@ impl<const ROLE: u8> From<RoleWithFactorInstances<ROLE>> for ScryptoAccessRule {
         ScryptoAccessRule::Protected(ScryptoCompositeRequirement::AnyOf(vec![
             ScryptoCompositeRequirement::BasicRequirement(
                 ScryptoBasicRequirement::CountOf(
-                    value.get_threshold(),
+                    value.get_threshold_value(),
                     from_factors(value.get_threshold_factors()),
                 ),
             ),

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/roles/factor_levels/factor_instance_level/role_with_factor_instances.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/roles/factor_levels/factor_instance_level/role_with_factor_instances.rs
@@ -12,7 +12,7 @@ impl<const ROLE: u8> RoleWithFactorInstances<ROLE> {
 
         let role_of_sources = matrix_of_factor_sources.get_role::<ROLE>();
         assert_eq!(role_of_sources.role(), role_kind);
-        let threshold: u8 = role_of_sources.get_threshold();
+        let threshold: Threshold = role_of_sources.get_threshold_kind();
 
         // Threshold factors
         let threshold_factors =
@@ -28,8 +28,11 @@ impl<const ROLE: u8> RoleWithFactorInstances<ROLE> {
                 role_of_sources.get_override_factors(),
             )?;
 
-        let role_with_instances =
-            Self::with_factors(threshold, threshold_factors, override_factors);
+        let role_with_instances = Self::with_factors_and_threshold_kind(
+            threshold,
+            threshold_factors,
+            override_factors,
+        );
 
         assert_eq!(role_with_instances.role(), role_kind);
         Ok(role_with_instances)

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/roles/factor_levels/factor_instance_level/role_with_factor_instances.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/roles/factor_levels/factor_instance_level/role_with_factor_instances.rs
@@ -12,7 +12,7 @@ impl<const ROLE: u8> RoleWithFactorInstances<ROLE> {
 
         let role_of_sources = matrix_of_factor_sources.get_role::<ROLE>();
         assert_eq!(role_of_sources.role(), role_kind);
-        let threshold: Threshold = role_of_sources.get_threshold_kind();
+        let threshold: Threshold = role_of_sources.get_threshold();
 
         // Threshold factors
         let threshold_factors =

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/roles/factor_levels/factor_source_id_level/confirmation_role_with_factor_source_ids.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/roles/factor_levels/factor_source_id_level/confirmation_role_with_factor_source_ids.rs
@@ -86,9 +86,7 @@ mod tests {
             &sut,
             r#"
            {
-              "threshold": {
-                "specific": 0
-              },
+              "threshold": "all",
               "thresholdFactors": [],
               "overrideFactors": [
                 {

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/roles/factor_levels/factor_source_id_level/confirmation_role_with_factor_source_ids.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/roles/factor_levels/factor_source_id_level/confirmation_role_with_factor_source_ids.rs
@@ -86,7 +86,9 @@ mod tests {
             &sut,
             r#"
            {
-              "threshold": 0,
+              "threshold": {
+                "specific": 0
+              },
               "thresholdFactors": [],
               "overrideFactors": [
                 {

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/roles/factor_levels/factor_source_id_level/primary_role_with_factor_source_ids.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/roles/factor_levels/factor_source_id_level/primary_role_with_factor_source_ids.rs
@@ -82,7 +82,9 @@ mod tests {
             &sut,
             r#"
             {
-              "threshold": 2,
+              "threshold": {
+                "specific": 2
+              },
               "thresholdFactors": [
                 {
                   "discriminator": "fromHash",

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/roles/factor_levels/factor_source_id_level/primary_role_with_factor_source_ids.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/roles/factor_levels/factor_source_id_level/primary_role_with_factor_source_ids.rs
@@ -71,7 +71,7 @@ mod tests {
     #[test]
     fn get_threshold() {
         let sut = SUT::sample_primary();
-        assert_eq!(sut.get_threshold(), 2);
+        assert_eq!(sut.get_threshold_value(), 2);
     }
 
     #[test]

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/roles/factor_levels/factor_source_id_level/primary_role_with_factor_source_ids.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/roles/factor_levels/factor_source_id_level/primary_role_with_factor_source_ids.rs
@@ -15,7 +15,6 @@ impl PrimaryRoleWithFactorSourceIds {
         builder
             .add_factor_source_to_threshold(FactorSourceID::sample_ledger())
             .unwrap();
-        builder.set_specific_threshold(2).unwrap();
         builder.build().unwrap()
     }
 }
@@ -82,8 +81,38 @@ mod tests {
             &sut,
             r#"
             {
+              "threshold": "all",
+              "thresholdFactors": [
+                {
+                  "discriminator": "fromHash",
+                  "fromHash": {
+                    "kind": "device",
+                    "body": "f1a93d324dd0f2bff89963ab81ed6e0c2ee7e18c0827dc1d3576b2d9f26bbd0a"
+                  }
+                },
+                {
+                  "discriminator": "fromHash",
+                  "fromHash": {
+                    "kind": "ledgerHQHardwareWallet",
+                    "body": "ab59987eedd181fe98e512c1ba0f5ff059f11b5c7c56f15614dcc9fe03fec58b"
+                  }
+                }
+              ],
+              "overrideFactors": []
+            }
+            "#,
+        );
+    }
+
+    #[test]
+    fn assert_json_sample_other_primary() {
+        let sut = SUT::sample_other();
+        assert_eq_after_json_roundtrip(
+            &sut,
+            r#"
+            {
               "threshold": {
-                "specific": 2
+                 "specific": 1
               },
               "thresholdFactors": [
                 {

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/roles/factor_levels/factor_source_id_level/primary_role_with_factor_source_ids.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/roles/factor_levels/factor_source_id_level/primary_role_with_factor_source_ids.rs
@@ -15,7 +15,7 @@ impl PrimaryRoleWithFactorSourceIds {
         builder
             .add_factor_source_to_threshold(FactorSourceID::sample_ledger())
             .unwrap();
-        builder.set_threshold(2).unwrap();
+        builder.set_specific_threshold(2).unwrap();
         builder.build().unwrap()
     }
 }
@@ -34,7 +34,7 @@ impl HasSampleValues for PrimaryRoleWithFactorSourceIds {
         builder
             .add_factor_source_to_threshold(FactorSourceID::sample_ledger())
             .unwrap();
-        builder.set_threshold(1).unwrap();
+        builder.set_specific_threshold(1).unwrap();
         builder.build().unwrap()
     }
 }

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/roles/factor_levels/factor_source_id_level/recovery_role_with_factor_source_ids.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/roles/factor_levels/factor_source_id_level/recovery_role_with_factor_source_ids.rs
@@ -41,9 +41,7 @@ mod tests {
             &sut,
             r#"
             {
-              "threshold": {
-                "specific": 0
-              },
+              "threshold": "all",
               "thresholdFactors": [],
               "overrideFactors": [
                 {

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/roles/factor_levels/factor_source_id_level/recovery_role_with_factor_source_ids.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/roles/factor_levels/factor_source_id_level/recovery_role_with_factor_source_ids.rs
@@ -41,7 +41,9 @@ mod tests {
             &sut,
             r#"
             {
-              "threshold": 0,
+              "threshold": {
+                "specific": 0
+              },
               "thresholdFactors": [],
               "overrideFactors": [
                 {

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/roles/factor_levels/factor_source_kind_level/role_template.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/roles/factor_levels/factor_source_kind_level/role_template.rs
@@ -26,7 +26,11 @@ impl PrimaryRoleTemplate {
         threshold_factors: impl IntoIterator<Item = FactorSourceTemplate>,
     ) -> Self {
         let threshold_factors = threshold_factors.into_iter().collect_vec();
-        Self::with_factors(threshold_factors.len() as u8, threshold_factors, [])
+        Self::with_factors_and_threshold_kind(
+            Threshold::All,
+            threshold_factors,
+            [],
+        )
     }
 }
 
@@ -34,7 +38,11 @@ impl RecoveryRoleTemplate {
     pub(crate) fn new(
         override_factors: impl IntoIterator<Item = FactorSourceTemplate>,
     ) -> Self {
-        Self::with_factors(0, [], override_factors)
+        Self::with_factors_and_threshold_kind(
+            Threshold::All,
+            [],
+            override_factors,
+        )
     }
 }
 
@@ -42,7 +50,11 @@ impl ConfirmationRoleTemplate {
     pub(crate) fn new(
         override_factors: impl IntoIterator<Item = FactorSourceTemplate>,
     ) -> Self {
-        Self::with_factors(0, [], override_factors)
+        Self::with_factors_and_threshold_kind(
+            Threshold::All,
+            [],
+            override_factors,
+        )
     }
 }
 

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/roles/factor_levels/factor_source_level/roles_with_factor_sources.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/roles/factor_levels/factor_source_level/roles_with_factor_sources.rs
@@ -7,8 +7,8 @@ impl<const ROLE: u8> RoleWithFactorSources<ROLE> {
     fn from<const ROLE_FROM: u8>(
         other: &RoleWithFactorSources<ROLE_FROM>,
     ) -> Self {
-        Self::with_factors(
-            other.get_threshold(),
+        Self::with_factors_and_threshold_kind(
+            other.get_threshold_kind(),
             other.get_threshold_factors().clone(),
             other.get_override_factors().clone(),
         )
@@ -58,8 +58,8 @@ impl<const ROLE: u8> RoleWithFactorSources<ROLE> {
         let override_factors =
             lookup(role_with_factor_source_ids.get_override_factors())?;
 
-        Ok(Self::with_factors(
-            role_with_factor_source_ids.get_threshold(),
+        Ok(Self::with_factors_and_threshold_kind(
+            role_with_factor_source_ids.get_threshold_kind(),
             threshold_factors,
             override_factors,
         ))

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/roles/factor_levels/factor_source_level/roles_with_factor_sources.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/roles/factor_levels/factor_source_level/roles_with_factor_sources.rs
@@ -8,7 +8,7 @@ impl<const ROLE: u8> RoleWithFactorSources<ROLE> {
         other: &RoleWithFactorSources<ROLE_FROM>,
     ) -> Self {
         Self::with_factors_and_threshold_kind(
-            other.get_threshold_kind(),
+            other.get_threshold(),
             other.get_threshold_factors().clone(),
             other.get_override_factors().clone(),
         )
@@ -59,7 +59,7 @@ impl<const ROLE: u8> RoleWithFactorSources<ROLE> {
             lookup(role_with_factor_source_ids.get_override_factors())?;
 
         Ok(Self::with_factors_and_threshold_kind(
-            role_with_factor_source_ids.get_threshold_kind(),
+            role_with_factor_source_ids.get_threshold(),
             threshold_factors,
             override_factors,
         ))

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/security_shield_builder.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/security_shield_builder.rs
@@ -385,7 +385,7 @@ impl SecurityShieldBuilder {
         })
     }
 
-    pub fn set_threshold(&self, threshold: u8) -> &Self {
+    pub fn set_threshold(&self, threshold: Threshold) -> &Self {
         self.set(|builder| builder.set_threshold(threshold))
     }
 
@@ -863,7 +863,7 @@ mod tests {
     #[test]
     fn add_factor_to_primary_threshold_does_not_change_already_set_threshold() {
         let sut = SUT::strict();
-        sut.set_threshold(42);
+        sut.set_threshold(Threshold::Specific(42));
         sut.add_factor_source_to_primary_threshold(
             FactorSourceID::sample_device(),
         );
@@ -992,7 +992,7 @@ mod tests {
             add(sut, FactorSourceID::sample_device());
             add(sut, FactorSourceID::sample_ledger());
 
-            sut.set_threshold(2);
+            sut.set_threshold(Threshold::Specific(2));
             assert!(is_fully_valid(sut, FactorSourceKind::Password)); // not alone any more!
             assert!(can_be(sut, FactorSourceKind::Password));
         } else {
@@ -1197,7 +1197,7 @@ mod tests {
         let sut = SUT::default();
 
         let _ = sut
-            .set_threshold(2)
+            .set_threshold(Threshold::Specific(2))
             .add_factor_source_to_primary_threshold(
                 FactorSourceID::sample_password(),
             )
@@ -1257,7 +1257,7 @@ mod test_invalid {
             FactorSourceID::sample_device(),
         );
         assert_eq!(sut.get_threshold(), 1);
-        sut.set_threshold(0);
+        sut.set_threshold(Threshold::Specific(0));
         assert_eq!(
             sut.validate().unwrap(),
             SecurityShieldBuilderInvalidReason::PrimaryRoleWithThresholdFactorsCannotHaveAThresholdValueOfZero
@@ -1437,7 +1437,7 @@ mod test_invalid {
             FactorSourceID::sample_arculus(),
         );
 
-        sut.set_threshold(1);
+        sut.set_threshold(Threshold::Specific(1));
         sut.add_factor_source_to_primary_threshold(
             FactorSourceID::sample_password(),
         );
@@ -1466,7 +1466,7 @@ mod test_invalid {
             FactorSourceID::sample_arculus(),
         );
 
-        sut.set_threshold(1);
+        sut.set_threshold(Threshold::Specific(1));
         sut.add_factor_source_to_primary_threshold(
             FactorSourceID::sample_password(),
         );
@@ -1492,7 +1492,7 @@ mod test_invalid {
             FactorSourceID::sample_arculus(),
         );
 
-        sut.set_threshold(2);
+        sut.set_threshold(Threshold::Specific(2));
         sut.add_factor_source_to_primary_threshold(
             FactorSourceID::sample_password(),
         );
@@ -1585,7 +1585,7 @@ mod test_invalid {
             .add_factor_source_to_primary_threshold(
                 FactorSourceID::sample_device_other(),
             );
-        let _ = sut.set_threshold(0);
+        let _ = sut.set_threshold(Threshold::Specific(0));
         let status = sut.selected_primary_threshold_factors_status();
 
         pretty_assertions::assert_eq!(

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/security_shield_builder.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/security_shield_builder.rs
@@ -960,7 +960,7 @@ mod tests {
             shield.matrix_of_factors.primary().get_override_factors(),
             &vec![FactorSourceID::sample_arculus()]
         );
-        assert_eq!(shield.matrix_of_factors.primary().get_threshold(), 1);
+        assert_eq!(shield.matrix_of_factors.primary().get_threshold_value(), 1);
         assert_eq!(
             shield.matrix_of_factors.recovery().get_override_factors(),
             &vec![FactorSourceID::sample_ledger()]
@@ -1257,7 +1257,7 @@ mod test_invalid {
             FactorSourceID::sample_device(),
         );
         assert_eq!(sut.get_threshold(), 1);
-        sut.set_threshold(Threshold::Specific(0));
+        sut.set_threshold(Threshold::zero());
         assert_eq!(
             sut.validate().unwrap(),
             SecurityShieldBuilderInvalidReason::PrimaryRoleWithThresholdFactorsCannotHaveAThresholdValueOfZero
@@ -1585,7 +1585,7 @@ mod test_invalid {
             .add_factor_source_to_primary_threshold(
                 FactorSourceID::sample_device_other(),
             );
-        let _ = sut.set_threshold(Threshold::Specific(0));
+        let _ = sut.set_threshold(Threshold::zero());
         let status = sut.selected_primary_threshold_factors_status();
 
         pretty_assertions::assert_eq!(

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/security_structure_of_factors/security_structure_of_factor_instances.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/security_structure_of_factors/security_structure_of_factor_instances.rs
@@ -195,7 +195,9 @@ mod tests {
               "securityStructureId": "dededede-dede-dede-dede-dededededede",
               "matrixOfFactors": {
                 "primaryRole": {
-                  "threshold": 1,
+                  "threshold": {
+                    "specific": 1
+                  },
                   "thresholdFactors": [
                     {
                       "factorSourceID": {
@@ -226,7 +228,9 @@ mod tests {
                   "overrideFactors": []
                 },
                 "recoveryRole": {
-                  "threshold": 0,
+                  "threshold": {
+                    "specific": 0
+                  },
                   "thresholdFactors": [],
                   "overrideFactors": [
                     {
@@ -257,7 +261,9 @@ mod tests {
                   ]
                 },
                 "confirmationRole": {
-                  "threshold": 0,
+                  "threshold": {
+                    "specific": 0
+                  },
                   "thresholdFactors": [],
                   "overrideFactors": [
                     {
@@ -329,7 +335,9 @@ mod tests {
               "securityStructureId": "ffffffff-ffff-ffff-ffff-ffffffffffff",
               "matrixOfFactors": {
                 "primaryRole": {
-                  "threshold": 2,
+                  "threshold": {
+                    "specific": 2
+                  },
                   "thresholdFactors": [
                     {
                       "factorSourceID": {
@@ -385,7 +393,9 @@ mod tests {
                   "overrideFactors": []
                 },
                 "recoveryRole": {
-                  "threshold": 0,
+                  "threshold": {
+                    "specific": 0
+                  },
                   "thresholdFactors": [],
                   "overrideFactors": [
                     {
@@ -441,7 +451,9 @@ mod tests {
                   ]
                 },
                 "confirmationRole": {
-                  "threshold": 0,
+                  "threshold": {
+                    "specific": 0
+                  },
                   "thresholdFactors": [],
                   "overrideFactors": [
                     {

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/security_structure_of_factors/security_structure_of_factor_instances.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/security_structure_of_factors/security_structure_of_factor_instances.rs
@@ -195,9 +195,7 @@ mod tests {
               "securityStructureId": "dededede-dede-dede-dede-dededededede",
               "matrixOfFactors": {
                 "primaryRole": {
-                  "threshold": {
-                    "specific": 1
-                  },
+                  "threshold": "all",
                   "thresholdFactors": [
                     {
                       "factorSourceID": {
@@ -228,9 +226,7 @@ mod tests {
                   "overrideFactors": []
                 },
                 "recoveryRole": {
-                  "threshold": {
-                    "specific": 0
-                  },
+                  "threshold": "all",
                   "thresholdFactors": [],
                   "overrideFactors": [
                     {
@@ -261,9 +257,7 @@ mod tests {
                   ]
                 },
                 "confirmationRole": {
-                  "threshold": {
-                    "specific": 0
-                  },
+                  "threshold": "all",
                   "thresholdFactors": [],
                   "overrideFactors": [
                     {
@@ -335,9 +329,7 @@ mod tests {
               "securityStructureId": "ffffffff-ffff-ffff-ffff-ffffffffffff",
               "matrixOfFactors": {
                 "primaryRole": {
-                  "threshold": {
-                    "specific": 2
-                  },
+                  "threshold": "all",
                   "thresholdFactors": [
                     {
                       "factorSourceID": {
@@ -393,9 +385,7 @@ mod tests {
                   "overrideFactors": []
                 },
                 "recoveryRole": {
-                  "threshold": {
-                    "specific": 0
-                  },
+                  "threshold": "all",
                   "thresholdFactors": [],
                   "overrideFactors": [
                     {
@@ -451,9 +441,7 @@ mod tests {
                   ]
                 },
                 "confirmationRole": {
-                  "threshold": {
-                    "specific": 0
-                  },
+                  "threshold": "all",
                   "thresholdFactors": [],
                   "overrideFactors": [
                     {

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/security_structure_of_factors/security_structure_of_factor_source_ids.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/security_structure_of_factors/security_structure_of_factor_source_ids.rs
@@ -65,7 +65,9 @@ mod tests {
               },
               "matrixOfFactors": {
                 "primaryRole": {
-                  "threshold": 2,
+                  "threshold": {
+                    "specific": 2
+                  },
                   "thresholdFactors": [
                     {
                       "discriminator": "fromHash",
@@ -85,7 +87,9 @@ mod tests {
                   "overrideFactors": []
                 },
                 "recoveryRole": {
-                  "threshold": 0,
+                  "threshold": {
+                    "specific": 0
+                  },
                   "thresholdFactors": [],
                   "overrideFactors": [
                     {
@@ -105,7 +109,9 @@ mod tests {
                   ]
                 },
                 "confirmationRole": {
-                  "threshold": 0,
+                  "threshold": {
+                    "specific": 0
+                  },
                   "thresholdFactors": [],
                   "overrideFactors": [
                     {
@@ -146,7 +152,9 @@ mod tests {
               },
               "matrixOfFactors": {
                 "primaryRole": {
-                  "threshold": 1,
+                  "threshold": {
+                    "specific": 1
+                  },
                   "thresholdFactors": [
                     {
                     "discriminator": "fromHash",
@@ -159,7 +167,9 @@ mod tests {
                   "overrideFactors": []
                 },
                 "recoveryRole": {
-                  "threshold": 0,
+                  "threshold": {
+                    "specific": 0
+                  },
                   "thresholdFactors": [],
                   "overrideFactors": [
                     {
@@ -172,7 +182,9 @@ mod tests {
                   ]
                 },
                 "confirmationRole": {
-                  "threshold": 0,
+                  "threshold": {
+                    "specific": 0
+                  },
                   "thresholdFactors": [],
                   "overrideFactors": [
                     {

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/security_structure_of_factors/security_structure_of_factor_source_ids.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/security_structure_of_factors/security_structure_of_factor_source_ids.rs
@@ -65,9 +65,7 @@ mod tests {
               },
               "matrixOfFactors": {
                 "primaryRole": {
-                  "threshold": {
-                    "specific": 2
-                  },
+                  "threshold": "all",
                   "thresholdFactors": [
                     {
                       "discriminator": "fromHash",
@@ -87,9 +85,7 @@ mod tests {
                   "overrideFactors": []
                 },
                 "recoveryRole": {
-                  "threshold": {
-                    "specific": 0
-                  },
+                  "threshold": "all",
                   "thresholdFactors": [],
                   "overrideFactors": [
                     {
@@ -109,9 +105,7 @@ mod tests {
                   ]
                 },
                 "confirmationRole": {
-                  "threshold": {
-                    "specific": 0
-                  },
+                  "threshold": "all",
                   "thresholdFactors": [],
                   "overrideFactors": [
                     {
@@ -152,9 +146,7 @@ mod tests {
               },
               "matrixOfFactors": {
                 "primaryRole": {
-                  "threshold": {
-                    "specific": 1
-                  },
+                  "threshold": "all",
                   "thresholdFactors": [
                     {
                     "discriminator": "fromHash",
@@ -167,9 +159,7 @@ mod tests {
                   "overrideFactors": []
                 },
                 "recoveryRole": {
-                  "threshold": {
-                    "specific": 0
-                  },
+                  "threshold": "all",
                   "thresholdFactors": [],
                   "overrideFactors": [
                     {
@@ -182,9 +172,7 @@ mod tests {
                   ]
                 },
                 "confirmationRole": {
-                  "threshold": {
-                    "specific": 0
-                  },
+                  "threshold": "all",
                   "thresholdFactors": [],
                   "overrideFactors": [
                     {

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/security_structure_of_factors/security_structure_of_factor_sources.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/security_structure_of_factors/security_structure_of_factor_sources.rs
@@ -81,8 +81,8 @@ impl<const ROLE: u8>
     fn from(
         value: AbstractRoleBuilderOrBuilt<ROLE, IS_BUILT_ROLE, FactorSource>,
     ) -> Self {
-        Self::with_factors(
-            value.get_threshold(),
+        Self::with_factors_and_threshold_kind(
+            value.get_threshold_kind(),
             value
                 .get_threshold_factors()
                 .iter()

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/security_structure_of_factors/security_structure_of_factor_sources.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/security_structure_of_factors/security_structure_of_factor_sources.rs
@@ -82,7 +82,7 @@ impl<const ROLE: u8>
         value: AbstractRoleBuilderOrBuilt<ROLE, IS_BUILT_ROLE, FactorSource>,
     ) -> Self {
         Self::with_factors_and_threshold_kind(
-            value.get_threshold_kind(),
+            value.get_threshold(),
             value
                 .get_threshold_factors()
                 .iter()

--- a/crates/profile/models/security-structures/src/threshold.rs
+++ b/crates/profile/models/security-structures/src/threshold.rs
@@ -12,6 +12,10 @@ pub enum Threshold {
 }
 
 impl Threshold {
+    pub fn zero() -> Self {
+        Threshold::Specific(0)
+    }
+
     /// Returns the threshold value considering the number of threshold factors for `ThresholdKind::All`.
     pub fn value(&self, threshold_factor_count: usize) -> u8 {
         match self {

--- a/crates/profile/models/security-structures/src/threshold.rs
+++ b/crates/profile/models/security-structures/src/threshold.rs
@@ -1,0 +1,65 @@
+use crate::prelude::*;
+
+/// A kind of threshold, either All or a specific number of factors
+/// must be used to perform some function with.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "camelCase")]
+pub enum Threshold {
+    /// All factors in the threshold factors list must be used to perform some function with
+    All,
+    /// A specific number of factors in the threshold factors list must be used to perform some function with
+    Specific(u8),
+}
+
+impl Threshold {
+    /// Returns the threshold value considering the number of threshold factors for `ThresholdKind::All`.
+    pub fn value(&self, threshold_factor_count: usize) -> u8 {
+        match self {
+            Threshold::All => threshold_factor_count as u8,
+            Threshold::Specific(value) => *value,
+        }
+    }
+}
+
+impl HasSampleValues for Threshold {
+    fn sample() -> Self {
+        Threshold::All
+    }
+
+    fn sample_other() -> Self {
+        Threshold::Specific(1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[allow(clippy::upper_case_acronyms)]
+    type SUT = Threshold;
+
+    #[test]
+    fn equality() {
+        assert_eq!(SUT::sample(), SUT::sample());
+        assert_eq!(SUT::sample_other(), SUT::sample_other());
+    }
+
+    #[test]
+    fn inequality() {
+        assert_ne!(SUT::sample(), SUT::sample_other());
+    }
+
+    #[test]
+    fn json_roundtrip_all() {
+        let model = SUT::All;
+        assert_json_value_eq_after_roundtrip(&model, json!("all"));
+        assert_json_roundtrip(&model);
+    }
+
+    #[test]
+    fn json_roundtrip_specific() {
+        let model = SUT::Specific(2);
+        assert_json_value_eq_after_roundtrip(&model, json!({"specific": 2}));
+        assert_json_roundtrip(&model);
+    }
+}

--- a/crates/system/os/os/src/test_instances_provider.rs
+++ b/crates/system/os/os/src/test_instances_provider.rs
@@ -806,7 +806,7 @@ async fn test_securified_accounts() {
         .unwrap();
 
     let alice_matrix = alice_sec.matrix_of_factors.clone();
-    assert_eq!(alice_matrix.primary().get_threshold(), 2);
+    assert_eq!(alice_matrix.primary().get_threshold_value(), 2);
 
     assert_eq!(
         alice_matrix
@@ -847,7 +847,7 @@ async fn test_securified_accounts() {
         .unwrap();
 
     let bob_matrix = bob_sec.matrix_of_factors.clone();
-    assert_eq!(bob_matrix.primary().get_threshold(), 2);
+    assert_eq!(bob_matrix.primary().get_threshold_value(), 2);
 
     assert_eq!(
         bob_matrix
@@ -1702,7 +1702,7 @@ async fn securified_personas() {
         .unwrap();
 
     let batman_matrix = batman_sec.matrix_of_factors.clone();
-    assert_eq!(batman_matrix.primary().get_threshold(), 2);
+    assert_eq!(batman_matrix.primary().get_threshold_value(), 2);
 
     assert_eq!(
         batman_matrix
@@ -1743,7 +1743,7 @@ async fn securified_personas() {
         .unwrap();
 
     let satoshi_matrix = satoshi_sec.matrix_of_factors.clone();
-    assert_eq!(satoshi_matrix.primary().get_threshold(), 2);
+    assert_eq!(satoshi_matrix.primary().get_threshold_value(), 2);
 
     assert_eq!(
         satoshi_matrix

--- a/crates/uniffi/uniffi_SPLIT_ME/src/profile/mfa/security_structures/models/mod.rs
+++ b/crates/uniffi/uniffi_SPLIT_ME/src/profile/mfa/security_structures/models/mod.rs
@@ -1,7 +1,9 @@
 mod factor_list_kind;
 mod factor_source_in_role_builder_validation_status;
 mod role_kind;
+mod threshold;
 
 pub use factor_list_kind::*;
 pub use factor_source_in_role_builder_validation_status::*;
 pub use role_kind::*;
+pub use threshold::*;

--- a/crates/uniffi/uniffi_SPLIT_ME/src/profile/mfa/security_structures/models/threshold.rs
+++ b/crates/uniffi/uniffi_SPLIT_ME/src/profile/mfa/security_structures/models/threshold.rs
@@ -1,0 +1,14 @@
+use crate::prelude::*;
+use sargon::Threshold as InternalThreshold;
+
+/// A kind of threshold, either All or a specific number of factors
+/// must be used to perform some function with.
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, Hash, InternalConversion, uniffi::Enum,
+)]
+pub enum Threshold {
+    /// All factors in the threshold factors list must be used to perform some function with
+    All,
+    /// A specific number of factors in the threshold factors list must be used to perform some function with
+    Specific(u8),
+}

--- a/crates/uniffi/uniffi_SPLIT_ME/src/profile/mfa/security_structures/roles/decl_role_macro.rs
+++ b/crates/uniffi/uniffi_SPLIT_ME/src/profile/mfa/security_structures/roles/decl_role_macro.rs
@@ -3,7 +3,7 @@
 // or `FactorSourceID` etc.
 // It will generate the following:
 // struct PrimaryRoleWithFactor<$FACTOR_LEVEL> {
-//     threshold: u8,
+//     threshold: Threshold,
 //     threshold_factors: Vec<$FACTOR_LEVEL>,
 //     override_factors: Vec<$FACTOR_LEVEL>,
 // }
@@ -64,7 +64,7 @@ macro_rules! role_conversion_inner {
         impl From<$internal> for $uniffi {
             fn from(value: $internal) -> Self {
                 Self {
-                    threshold: value.get_threshold(),
+                    threshold: value.get_threshold_kind().into(),
                     threshold_factors: value
                         .get_threshold_factors()
                         .into_iter()
@@ -86,7 +86,7 @@ macro_rules! role_conversion_inner {
             pub fn into_internal(&self) -> $internal {
                 unsafe {
                     <$internal>::unbuilt_with_factors(
-                        self.threshold,
+                        self.threshold.into_internal(),
                         self.threshold_factors.clone().into_iter().map(|x| Into::<$internal_factor>::into(x.clone())).collect::<Vec<_>>(),
                         self.override_factors.clone().into_iter().map(|x| Into::<$internal_factor>::into(x.clone())).collect::<Vec<_>>(),
                     )
@@ -150,7 +150,7 @@ macro_rules! role_conversion_inner {
 
             /// How many threshold factors that must be used to perform some function with
             /// this role.
-            pub threshold: u8,
+            pub threshold: Threshold,
 
             /// Factors which are used in combination with other factors, amounting to at
             /// least `threshold` many factors to perform some function with this role.

--- a/crates/uniffi/uniffi_SPLIT_ME/src/profile/mfa/security_structures/roles/decl_role_macro.rs
+++ b/crates/uniffi/uniffi_SPLIT_ME/src/profile/mfa/security_structures/roles/decl_role_macro.rs
@@ -64,7 +64,7 @@ macro_rules! role_conversion_inner {
         impl From<$internal> for $uniffi {
             fn from(value: $internal) -> Self {
                 Self {
-                    threshold: value.get_threshold_kind().into(),
+                    threshold: value.get_threshold().into(),
                     threshold_factors: value
                         .get_threshold_factors()
                         .into_iter()

--- a/crates/uniffi/uniffi_SPLIT_ME/src/profile/mfa/security_structures/security_shield_builder.rs
+++ b/crates/uniffi/uniffi_SPLIT_ME/src/profile/mfa/security_structures/security_shield_builder.rs
@@ -927,7 +927,6 @@ mod tests {
         sut = sut
             .set_name(name.to_owned())
             .set_number_of_days_until_auto_confirm(days_to_auto_confirm)
-            .set_threshold(Threshold::Specific(2))
             .add_factor_source_to_primary_threshold(
                 FactorSource::sample_device_babylon().id(),
             )
@@ -936,7 +935,8 @@ mod tests {
             )
             .auto_assign_factors_to_recovery_and_confirmation_based_on_primary(
                 all_factors_in_profile.clone(),
-            );
+            )
+            .set_threshold(Threshold::Specific(2));
 
         let shield = sut.clone().build().unwrap();
 
@@ -950,7 +950,7 @@ mod tests {
         pretty_assertions::assert_eq!(
             matrix.primary_role,
             PrimaryRoleWithFactorSourceIDs {
-                threshold: 2,
+                threshold: Threshold::Specific(2),
                 threshold_factors: vec![
                     FactorSourceID::sample_device(),
                     FactorSourceID::sample_ledger()
@@ -962,7 +962,7 @@ mod tests {
         pretty_assertions::assert_eq!(
             matrix.recovery_role,
             RecoveryRoleWithFactorSourceIDs {
-                threshold: 0,
+                threshold: Threshold::All,
                 threshold_factors: Vec::new(),
                 override_factors: vec![
                     FactorSourceID::sample_trusted_contact(),
@@ -976,7 +976,7 @@ mod tests {
         pretty_assertions::assert_eq!(
             matrix.confirmation_role,
             ConfirmationRoleWithFactorSourceIDs {
-                threshold: 0,
+                threshold: Threshold::All,
                 threshold_factors: Vec::new(),
                 override_factors: vec![
                     FactorSourceID::sample_password(),


### PR DESCRIPTION
[Ticket](https://radixdlt.atlassian.net/browse/ABW-4047)

Expressed the role threshold of a security structure with an `enum` instead of a value. This way we can reflect the user preference regarding the number of factors required to sign with.  By default, the threshold should be set to `All`.