### PR TITLE
Add word count in off device mnemonic hint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "account-for-display"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "addresses",
  "derive_more",
@@ -48,10 +48,10 @@ dependencies = [
 
 [[package]]
 name = "addresses"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "assert-json",
- "bytes 1.1.104",
+ "bytes 1.1.105",
  "cap26-models",
  "core-utils",
  "derive_more",
@@ -242,7 +242,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "assert-json"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "assert-json-diff",
  "error",
@@ -550,7 +550,7 @@ dependencies = [
 
 [[package]]
 name = "build-info"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "assert-json",
  "cargo_toml 0.15.3 (git+https://gitlab.com/lib.rs/cargo_toml?rev=e498c94fc42a660c1ca1a28999ce1d757cfe77fe)",
@@ -583,7 +583,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "assert-json",
  "delegate",
@@ -622,7 +622,7 @@ dependencies = [
 
 [[package]]
 name = "cap26-models"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "assert-json",
  "derive_more",
@@ -806,7 +806,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "clients"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -866,7 +866,7 @@ checksum = "0d8a42181e0652c2997ae4d217f25b63c5337a52fd2279736e97b832fa0a3cff"
 
 [[package]]
 name = "core-collections"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "has-sample-values",
  "indexmap 2.7.0",
@@ -893,7 +893,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-misc"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "assert-json",
  "core-utils",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "core-utils"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "error",
  "iso8601-timestamp",
@@ -1139,7 +1139,7 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "drivers"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -1163,10 +1163,10 @@ dependencies = [
 
 [[package]]
 name = "ecc"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "assert-json",
- "bytes 1.1.104",
+ "bytes 1.1.105",
  "derive_more",
  "enum-as-inner",
  "error",
@@ -1267,11 +1267,11 @@ dependencies = [
 
 [[package]]
 name = "encryption"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "aes-gcm",
  "assert-json",
- "bytes 1.1.104",
+ "bytes 1.1.105",
  "derive_more",
  "error",
  "has-sample-values",
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "entity-by-address"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "addresses",
  "error",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "entity-foundation"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "assert-json",
  "derive_more",
@@ -1372,7 +1372,7 @@ dependencies = [
 
 [[package]]
 name = "error"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "derive_more",
  "log",
@@ -1431,7 +1431,7 @@ dependencies = [
 
 [[package]]
 name = "factor-instances-provider"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -1457,9 +1457,9 @@ dependencies = [
 
 [[package]]
 name = "factors"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
- "bytes 1.1.104",
+ "bytes 1.1.105",
  "cap26-models",
  "core-collections",
  "core-misc",
@@ -1494,7 +1494,7 @@ dependencies = [
 
 [[package]]
 name = "factors-supporting-types"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "async-trait",
  "error",
@@ -1675,7 +1675,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-client-and-api"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -1695,7 +1695,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-models"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "addresses",
  "assert-json",
@@ -1800,7 +1800,7 @@ dependencies = [
 
 [[package]]
 name = "has-sample-values"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "error",
  "indexmap 2.7.0",
@@ -1811,9 +1811,9 @@ dependencies = [
 
 [[package]]
 name = "hash"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
- "bytes 1.1.104",
+ "bytes 1.1.105",
  "derive_more",
  "prelude",
  "radix-common",
@@ -1882,11 +1882,11 @@ source = "git+https://github.com/KokaKiwi/rust-hex/?rev=b2b4370b5bf021b98ee7adc9
 
 [[package]]
 name = "hierarchical-deterministic"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "assert-json",
  "bip39",
- "bytes 1.1.104",
+ "bytes 1.1.105",
  "cap26-models",
  "derive_more",
  "ecc",
@@ -1928,13 +1928,13 @@ dependencies = [
 
 [[package]]
 name = "home-cards"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "actix-rt",
  "addresses",
  "async-trait",
  "base64 0.22.1 (git+https://github.com/marshallpierce/rust-base64.git?rev=e14400697453bcc85997119b874bc03d9601d0af)",
- "bytes 1.1.104",
+ "bytes 1.1.105",
  "core-utils",
  "derive_more",
  "drivers",
@@ -1954,7 +1954,7 @@ dependencies = [
 
 [[package]]
 name = "host-info"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "assert-json",
  "derive_more",
@@ -2001,10 +2001,10 @@ dependencies = [
 
 [[package]]
 name = "http-client"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "actix-rt",
- "bytes 1.1.104",
+ "bytes 1.1.105",
  "core-utils",
  "drivers",
  "error",
@@ -2229,7 +2229,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "identified-vec-of"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "assert-json",
  "derive_more",
@@ -2302,7 +2302,7 @@ dependencies = [
 
 [[package]]
 name = "interactors"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -2432,7 +2432,7 @@ dependencies = [
 
 [[package]]
 name = "key-derivation-traits"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "addresses",
  "async-trait",
@@ -2450,7 +2450,7 @@ dependencies = [
 
 [[package]]
 name = "keys-collector"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -2539,7 +2539,7 @@ dependencies = [
 
 [[package]]
 name = "manifests"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "account-for-display",
  "addresses",
@@ -2579,7 +2579,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "metadata"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "derive_more",
  "has-sample-values",
@@ -2679,7 +2679,7 @@ dependencies = [
 
 [[package]]
 name = "network"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "assert-json",
  "enum-iterator",
@@ -2695,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "next-derivation-index-ephemeral"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "addresses",
  "assert-json",
@@ -2771,9 +2771,9 @@ dependencies = [
 
 [[package]]
 name = "numeric"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
- "bytes 1.1.104",
+ "bytes 1.1.105",
  "delegate",
  "derive_more",
  "enum-iterator",
@@ -3011,7 +3011,7 @@ dependencies = [
 
 [[package]]
 name = "prelude"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "radix-engine",
  "radix-engine-toolkit",
@@ -3046,7 +3046,7 @@ dependencies = [
 
 [[package]]
 name = "profile"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "account-for-display",
  "addresses",
@@ -3090,7 +3090,7 @@ dependencies = [
 
 [[package]]
 name = "profile-account"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "account-for-display",
  "addresses",
@@ -3110,7 +3110,7 @@ dependencies = [
 
 [[package]]
 name = "profile-account-or-persona"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "cap26-models",
  "derive_more",
@@ -3127,7 +3127,7 @@ dependencies = [
 
 [[package]]
 name = "profile-app-preferences"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "addresses",
  "core-misc",
@@ -3150,7 +3150,7 @@ dependencies = [
 
 [[package]]
 name = "profile-base-entity"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "addresses",
  "derive_more",
@@ -3173,7 +3173,7 @@ dependencies = [
 
 [[package]]
 name = "profile-gateway"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "addresses",
  "assert-json",
@@ -3197,7 +3197,7 @@ dependencies = [
 
 [[package]]
 name = "profile-logic"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "addresses",
  "derive_more",
@@ -3219,7 +3219,7 @@ dependencies = [
 
 [[package]]
 name = "profile-persona"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "addresses",
  "cap26-models",
@@ -3240,7 +3240,7 @@ dependencies = [
 
 [[package]]
 name = "profile-persona-data"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "addresses",
  "assert-json",
@@ -3259,7 +3259,7 @@ dependencies = [
 
 [[package]]
 name = "profile-security-structures"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "addresses",
  "cap26-models",
@@ -3286,7 +3286,7 @@ dependencies = [
 
 [[package]]
 name = "profile-state-holder"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "derive_more",
  "error",
@@ -3301,7 +3301,7 @@ dependencies = [
 
 [[package]]
 name = "profile-supporting-types"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "addresses",
  "derive_more",
@@ -3390,14 +3390,14 @@ dependencies = [
 
 [[package]]
 name = "radix-connect"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "actix-rt",
  "addresses",
  "assert-json",
  "async-trait",
  "base64 0.22.1 (git+https://github.com/marshallpierce/rust-base64.git?rev=e14400697453bcc85997119b874bc03d9601d0af)",
- "bytes 1.1.104",
+ "bytes 1.1.105",
  "core-misc",
  "core-utils",
  "derive_more",
@@ -3425,10 +3425,10 @@ dependencies = [
 
 [[package]]
 name = "radix-connect-models"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "addresses",
- "bytes 1.1.104",
+ "bytes 1.1.105",
  "core-misc",
  "derive_more",
  "error",
@@ -3912,7 +3912,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -3977,7 +3977,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -4004,7 +4004,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-accounts"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -4027,7 +4027,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-factors"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -4047,7 +4047,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-security-center"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "actix-rt",
  "derive_more",
@@ -4063,7 +4063,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-signing"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -4089,7 +4089,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-transaction"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "actix-rt",
  "async-std",
@@ -4118,7 +4118,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-uniffi"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -4175,7 +4175,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-uniffi-conversion-macros"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4349,7 +4349,7 @@ dependencies = [
 
 [[package]]
 name = "security-center"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "addresses",
  "assert-json",
@@ -4554,7 +4554,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "short-string"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "arraystring",
  "assert-json",
@@ -4589,13 +4589,13 @@ dependencies = [
 
 [[package]]
 name = "signing"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "actix-rt",
  "addresses",
  "assert-json",
  "async-trait",
- "bytes 1.1.104",
+ "bytes 1.1.105",
  "cap26-models",
  "core-collections",
  "core-misc",
@@ -4627,10 +4627,10 @@ dependencies = [
 
 [[package]]
 name = "signing-traits"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "async-trait",
- "bytes 1.1.104",
+ "bytes 1.1.105",
  "core-collections",
  "derive_more",
  "ecc",
@@ -4793,7 +4793,7 @@ dependencies = [
 
 [[package]]
 name = "sub-systems"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "derive_more",
  "drivers",
@@ -4967,7 +4967,7 @@ dependencies = [
 
 [[package]]
 name = "time-utils"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "iso8601-timestamp",
  "prelude",
@@ -5096,10 +5096,10 @@ dependencies = [
 
 [[package]]
 name = "transaction-foundation"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "assert-json",
- "bytes 1.1.104",
+ "bytes 1.1.105",
  "derive_more",
  "has-sample-values",
  "paste 1.0.14",
@@ -5111,10 +5111,10 @@ dependencies = [
 
 [[package]]
 name = "transaction-models"
-version = "1.1.104"
+version = "1.1.105"
 dependencies = [
  "addresses",
- "bytes 1.1.104",
+ "bytes 1.1.105",
  "cargo_toml 0.15.3 (git+https://gitlab.com/lib.rs/cargo_toml?rev=e498c94fc42a660c1ca1a28999ce1d757cfe77fe)",
  "core-collections",
  "core-misc",

--- a/apple/Tests/TestCases/Profile/Factor/OffDeviceMnemonicFactorSourceTests.swift
+++ b/apple/Tests/TestCases/Profile/Factor/OffDeviceMnemonicFactorSourceTests.swift
@@ -18,7 +18,7 @@ final class OffDeviceMnemonicFactorSourceTests: SpecificFactorSourceTest<OffDevi
 					mnemonic: .sampleOffDeviceMnemonic,
 					passphrase: ""
 				),
-				hint: .init(label: "Test")
+				hint: .init(label: "Test", wordCount: .twentyFour)
 			).id,
 			SUT.sample.id
 		)

--- a/crates/app/home-cards/Cargo.toml
+++ b/crates/app/home-cards/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "home-cards"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/key-derivation-traits/Cargo.toml
+++ b/crates/app/key-derivation-traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "key-derivation-traits"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/radix-connect-models/Cargo.toml
+++ b/crates/app/radix-connect-models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "radix-connect-models"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/radix-connect/Cargo.toml
+++ b/crates/app/radix-connect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "radix-connect"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 

--- a/crates/app/security-center/Cargo.toml
+++ b/crates/app/security-center/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "security-center"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/signing-traits/Cargo.toml
+++ b/crates/app/signing-traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signing-traits"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/signing/Cargo.toml
+++ b/crates/app/signing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signing"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 

--- a/crates/common/build-info/Cargo.toml
+++ b/crates/common/build-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "build-info"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/common/bytes/Cargo.toml
+++ b/crates/common/bytes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bytes"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/entity-foundation/Cargo.toml
+++ b/crates/common/entity-foundation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entity-foundation"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/host-info/Cargo.toml
+++ b/crates/common/host-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "host-info"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/identified-vec-of/Cargo.toml
+++ b/crates/common/identified-vec-of/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "identified-vec-of"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/metadata/Cargo.toml
+++ b/crates/common/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metadata"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/network/Cargo.toml
+++ b/crates/common/network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "network"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/numeric/Cargo.toml
+++ b/crates/common/numeric/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numeric"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/short-string/Cargo.toml
+++ b/crates/common/short-string/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "short-string"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/assert-json/Cargo.toml
+++ b/crates/core/assert-json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assert-json"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/collections/Cargo.toml
+++ b/crates/core/collections/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-collections"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/error/Cargo.toml
+++ b/crates/core/error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "error"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/has-sample-values/Cargo.toml
+++ b/crates/core/has-sample-values/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "has-sample-values"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/misc/Cargo.toml
+++ b/crates/core/misc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-misc"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/prelude/Cargo.toml
+++ b/crates/core/prelude/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prelude"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/time-utils/Cargo.toml
+++ b/crates/core/time-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "time-utils"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/utils/Cargo.toml
+++ b/crates/core/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-utils"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/addresses/Cargo.toml
+++ b/crates/crypto/addresses/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "addresses"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/cap26-models/Cargo.toml
+++ b/crates/crypto/cap26-models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cap26-models"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/ecc/Cargo.toml
+++ b/crates/crypto/ecc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecc"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/encryption/Cargo.toml
+++ b/crates/crypto/encryption/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "encryption"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/hash/Cargo.toml
+++ b/crates/crypto/hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hash"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/hd/Cargo.toml
+++ b/crates/crypto/hd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hierarchical-deterministic"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/factors/Cargo.toml
+++ b/crates/factors/factors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factors"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/factors/src/mfa_factor_sources/off_device_mnemonic_factor_source/off_device_factor_source_hint.rs
+++ b/crates/factors/factors/src/mfa_factor_sources/off_device_mnemonic_factor_source/off_device_factor_source_hint.rs
@@ -21,8 +21,8 @@ pub struct OffDeviceMnemonicHint {
     /// differentiate between multiple passphrases.
     pub label: DisplayName,
 
-    /// The number of words the `OffDeviceMnemonic`, intended to help the host provide the correct
-    /// input form for validation when the user enters the words.
+    /// The number of words the `OffDeviceMnemonic` has, intended to help the host provide
+    /// the correct input form for validation when the user enters the words.
     pub word_count: BIP39WordCount,
 }
 

--- a/crates/factors/factors/src/mfa_factor_sources/off_device_mnemonic_factor_source/off_device_factor_source_hint.rs
+++ b/crates/factors/factors/src/mfa_factor_sources/off_device_mnemonic_factor_source/off_device_factor_source_hint.rs
@@ -15,26 +15,37 @@ use crate::prelude::*;
     derive_more::Display,
 )]
 #[serde(rename_all = "camelCase")]
+#[display("{label} {word_count}")]
 pub struct OffDeviceMnemonicHint {
     /// A user-assigned name for the passphrase, intended to help users
     /// differentiate between multiple passphrases.
     pub label: DisplayName,
+
+    /// The number of words the `OffDeviceMnemonic`, intended to help the host provide the correct
+    /// input form for validation when the user enters the words.
+    pub word_count: BIP39WordCount,
 }
 
 impl OffDeviceMnemonicHint {
-    pub fn new(label: DisplayName) -> Self {
-        Self { label }
+    pub fn new(label: DisplayName, word_count: BIP39WordCount) -> Self {
+        Self { label, word_count }
     }
 }
 
 impl HasSampleValues for OffDeviceMnemonicHint {
     fn sample() -> Self {
         // https://xkcd.com/936/
-        Self::new(DisplayName::new("Story about a horse").unwrap())
+        Self::new(
+            DisplayName::new("Story about a horse").unwrap(),
+            BIP39WordCount::sample(),
+        )
     }
 
     fn sample_other() -> Self {
-        Self::new(DisplayName::new("Thrilled with a shark").unwrap())
+        Self::new(
+            DisplayName::new("Thrilled with a shark").unwrap(),
+            BIP39WordCount::sample_other(),
+        )
     }
 }
 

--- a/crates/factors/factors/src/samples/factor_source_samples.rs
+++ b/crates/factors/factors/src/samples/factor_source_samples.rs
@@ -74,6 +74,7 @@ impl FactorSource {
                             id.body.to_hex()
                         ))
                         .unwrap(),
+                        BIP39WordCount::TwentyFour,
                     ),
                 )
                 .into()

--- a/crates/factors/instances-provider/Cargo.toml
+++ b/crates/factors/instances-provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factor-instances-provider"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/keys-collector/Cargo.toml
+++ b/crates/factors/keys-collector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keys-collector"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/next-derivation-index-ephemeral/Cargo.toml
+++ b/crates/factors/next-derivation-index-ephemeral/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "next-derivation-index-ephemeral"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/supporting-types/Cargo.toml
+++ b/crates/factors/supporting-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factors-supporting-types"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/gateway/client-and-api/Cargo.toml
+++ b/crates/gateway/client-and-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gateway-client-and-api"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/gateway/models/Cargo.toml
+++ b/crates/gateway/models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gateway-models"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 

--- a/crates/profile/logic/logic_SPLIT_ME/Cargo.toml
+++ b/crates/profile/logic/logic_SPLIT_ME/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-logic"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/account-for-display/Cargo.toml
+++ b/crates/profile/models/account-for-display/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "account-for-display"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/account-or-persona/Cargo.toml
+++ b/crates/profile/models/account-or-persona/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-account-or-persona"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/account/Cargo.toml
+++ b/crates/profile/models/account/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-account"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/app-preferences/Cargo.toml
+++ b/crates/profile/models/app-preferences/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-app-preferences"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/base-entity/Cargo.toml
+++ b/crates/profile/models/base-entity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-base-entity"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/gateway/Cargo.toml
+++ b/crates/profile/models/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-gateway"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/persona-data/Cargo.toml
+++ b/crates/profile/models/persona-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-persona-data"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/persona/Cargo.toml
+++ b/crates/profile/models/persona/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-persona"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/profile_SPLIT_ME/Cargo.toml
+++ b/crates/profile/models/profile_SPLIT_ME/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 

--- a/crates/profile/models/security-structures/Cargo.toml
+++ b/crates/profile/models/security-structures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-security-structures"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/supporting-types/Cargo.toml
+++ b/crates/profile/models/supporting-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-supporting-types"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/traits/entity-by-address/Cargo.toml
+++ b/crates/profile/traits/entity-by-address/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entity-by-address"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/sargon/Cargo.toml
+++ b/crates/sargon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 resolver = "2" # features enabled in integration test

--- a/crates/system/clients/clients/Cargo.toml
+++ b/crates/system/clients/clients/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clients"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 

--- a/crates/system/clients/http/Cargo.toml
+++ b/crates/system/clients/http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http-client"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/drivers/Cargo.toml
+++ b/crates/system/drivers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drivers"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 

--- a/crates/system/interactors/Cargo.toml
+++ b/crates/system/interactors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interactors"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/accounts/Cargo.toml
+++ b/crates/system/os/accounts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-accounts"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/factors/Cargo.toml
+++ b/crates/system/os/factors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-factors"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/os/Cargo.toml
+++ b/crates/system/os/os/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/security-center/Cargo.toml
+++ b/crates/system/os/security-center/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-security-center"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/signing/Cargo.toml
+++ b/crates/system/os/signing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-signing"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/transaction/Cargo.toml
+++ b/crates/system/os/transaction/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-transaction"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/profile-state-holder/Cargo.toml
+++ b/crates/system/profile-state-holder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-state-holder"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/sub-systems/Cargo.toml
+++ b/crates/system/sub-systems/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sub-systems"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/transaction/foundation/Cargo.toml
+++ b/crates/transaction/foundation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transaction-foundation"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/transaction/manifests/Cargo.toml
+++ b/crates/transaction/manifests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "manifests"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 

--- a/crates/transaction/models/Cargo.toml
+++ b/crates/transaction/models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transaction-models"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 

--- a/crates/uniffi/conversion-macros/Cargo.toml
+++ b/crates/uniffi/conversion-macros/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "sargon-uniffi-conversion-macros"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 
 [dependencies]

--- a/crates/uniffi/uniffi_SPLIT_ME/Cargo.toml
+++ b/crates/uniffi/uniffi_SPLIT_ME/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-uniffi"
-version = "1.1.104"
+version = "1.1.105"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/uniffi/uniffi_SPLIT_ME/src/profile/mfa/mfa_factor_sources/off_device_mnemonic_factor_source/off_device_factor_source_hint.rs
+++ b/crates/uniffi/uniffi_SPLIT_ME/src/profile/mfa/mfa_factor_sources/off_device_mnemonic_factor_source/off_device_factor_source_hint.rs
@@ -8,4 +8,7 @@ pub struct OffDeviceMnemonicHint {
     /// A user-assigned name for the passphrase, intended to help users
     /// differentiate between multiple passphrases.
     pub label: DisplayName,
+    /// The number of words the `OffDeviceMnemonic`, intended to help the host provide the correct
+    /// input form for validation when the user enters the words.
+    pub word_count: BIP39WordCount,
 }

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/FactorSource.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/FactorSource.kt
@@ -48,6 +48,7 @@ fun OffDeviceMnemonicFactorSource.asGeneral() = FactorSource.OffDeviceMnemonic(v
 fun SecurityQuestionsNotProductionReadyFactorSource.asGeneral() =
     FactorSource.SecurityQuestions(value = this)
 fun TrustedContactFactorSource.asGeneral() = FactorSource.TrustedContact(value = this)
+fun PasswordFactorSource.asGeneral() = FactorSource.Password(value = this)
 
 fun FactorSource.Device.Companion.olympia(
     mnemonicWithPassphrase: MnemonicWithPassphrase,

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/ArculusFactorSourceSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/ArculusFactorSourceSample.kt
@@ -1,0 +1,14 @@
+package com.radixdlt.sargon.samples
+
+import com.radixdlt.sargon.ArculusCardFactorSource
+import com.radixdlt.sargon.annotation.UsesSampleValues
+import com.radixdlt.sargon.newArculusCardFactorSourceSample
+import com.radixdlt.sargon.newArculusCardFactorSourceSampleOther
+
+@UsesSampleValues
+val ArculusCardFactorSource.Companion.sample: Sample<ArculusCardFactorSource>
+    get() = object : Sample<ArculusCardFactorSource> {
+        override fun invoke(): ArculusCardFactorSource = newArculusCardFactorSourceSample()
+
+        override fun other(): ArculusCardFactorSource = newArculusCardFactorSourceSampleOther()
+    }

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/OffDeviceMnemonicFactorSourceSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/OffDeviceMnemonicFactorSourceSample.kt
@@ -1,0 +1,15 @@
+package com.radixdlt.sargon.samples
+
+import com.radixdlt.sargon.OffDeviceMnemonicFactorSource
+import com.radixdlt.sargon.annotation.UsesSampleValues
+import com.radixdlt.sargon.newOffDeviceMnemonicFactorSourceSample
+import com.radixdlt.sargon.newOffDeviceMnemonicFactorSourceSampleOther
+
+@UsesSampleValues
+val OffDeviceMnemonicFactorSource.Companion.sample: Sample<OffDeviceMnemonicFactorSource>
+    get() = object : Sample<OffDeviceMnemonicFactorSource> {
+        override fun invoke(): OffDeviceMnemonicFactorSource = newOffDeviceMnemonicFactorSourceSample()
+
+        override fun other(): OffDeviceMnemonicFactorSource = newOffDeviceMnemonicFactorSourceSampleOther()
+
+    }

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/PasswordFactorSourceSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/PasswordFactorSourceSample.kt
@@ -1,0 +1,14 @@
+package com.radixdlt.sargon.samples
+
+import com.radixdlt.sargon.PasswordFactorSource
+import com.radixdlt.sargon.annotation.UsesSampleValues
+import com.radixdlt.sargon.newPasswordFactorSourceSample
+import com.radixdlt.sargon.newPasswordFactorSourceSampleOther
+
+@UsesSampleValues
+val PasswordFactorSource.Companion.sample: Sample<PasswordFactorSource>
+    get() = object : Sample<PasswordFactorSource> {
+        override fun invoke(): PasswordFactorSource = newPasswordFactorSourceSample()
+
+        override fun other(): PasswordFactorSource = newPasswordFactorSourceSampleOther()
+    }

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/SecurityQuestionsFactorSource.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/SecurityQuestionsFactorSource.kt
@@ -1,0 +1,17 @@
+package com.radixdlt.sargon.samples
+
+import com.radixdlt.sargon.SecurityQuestionsNotProductionReadyFactorSource
+import com.radixdlt.sargon.annotation.UsesSampleValues
+import com.radixdlt.sargon.newSecurityQuestionsFactorSourceSample
+import com.radixdlt.sargon.newSecurityQuestionsFactorSourceSampleOther
+
+@UsesSampleValues
+val SecurityQuestionsNotProductionReadyFactorSource.Companion.sample: Sample<SecurityQuestionsNotProductionReadyFactorSource>
+    get() = object : Sample<SecurityQuestionsNotProductionReadyFactorSource> {
+        override fun invoke(): SecurityQuestionsNotProductionReadyFactorSource
+            = newSecurityQuestionsFactorSourceSample()
+
+        override fun other(): SecurityQuestionsNotProductionReadyFactorSource
+            = newSecurityQuestionsFactorSourceSampleOther()
+
+    }

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/TrustedContactFactorSource.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/TrustedContactFactorSource.kt
@@ -1,0 +1,14 @@
+package com.radixdlt.sargon.samples
+
+import com.radixdlt.sargon.TrustedContactFactorSource
+import com.radixdlt.sargon.annotation.UsesSampleValues
+import com.radixdlt.sargon.newTrustedContactFactorSourceSample
+import com.radixdlt.sargon.newTrustedContactFactorSourceSampleOther
+
+@UsesSampleValues
+val TrustedContactFactorSource.Companion.sample: Sample<TrustedContactFactorSource>
+    get() = object : Sample<TrustedContactFactorSource> {
+        override fun invoke(): TrustedContactFactorSource = newTrustedContactFactorSourceSample()
+
+        override fun other(): TrustedContactFactorSource = newTrustedContactFactorSourceSampleOther()
+    }

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/ArculusCardFactorSourceTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/ArculusCardFactorSourceTest.kt
@@ -1,0 +1,9 @@
+package com.radixdlt.sargon
+
+import com.radixdlt.sargon.samples.Sample
+import com.radixdlt.sargon.samples.sample
+
+class ArculusCardFactorSourceTest: SampleTestable<ArculusCardFactorSource> {
+    override val samples: List<Sample<ArculusCardFactorSource>>
+        get() = listOf(ArculusCardFactorSource.sample)
+}

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/FactorSourceTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/FactorSourceTest.kt
@@ -247,7 +247,8 @@ class FactorSourceTest : SampleTestable<FactorSource> {
                 flags = emptyList()
             ),
             hint = OffDeviceMnemonicHint(
-                label = DisplayName("My mnemonic stored somewhere")
+                label = DisplayName("My mnemonic stored somewhere"),
+                wordCount = Bip39WordCount.TWENTY_FOUR
             )
         )
     )

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/FactorSourceTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/FactorSourceTest.kt
@@ -56,6 +56,11 @@ class FactorSourceTest : SampleTestable<FactorSource> {
             FactorSourceKind.SECURITY_QUESTIONS,
             sequrityQuestions.kind
         )
+
+        assertEquals(
+            FactorSourceKind.PASSWORD,
+            password.kind
+        )
     }
 
     @Test
@@ -102,6 +107,13 @@ class FactorSourceTest : SampleTestable<FactorSource> {
                 value.id.asGeneral()
             )
         }
+
+        with(password) {
+            assertEquals(
+                id,
+                value.id.asGeneral()
+            )
+        }
     }
 
     @Test
@@ -134,6 +146,11 @@ class FactorSourceTest : SampleTestable<FactorSource> {
         assertEquals(
             sequrityQuestions,
             sequrityQuestions.value.asGeneral()
+        )
+
+        assertEquals(
+            password,
+            password.value.asGeneral()
         )
     }
 
@@ -188,99 +205,13 @@ class FactorSourceTest : SampleTestable<FactorSource> {
         assertFalse(factorSource.supportsBabylon)
     }
 
-    private val trustedContact = FactorSource.TrustedContact(
-        value = TrustedContactFactorSource(
-            id = FactorSourceIdFromAddress(
-                kind = FactorSourceKind.TRUSTED_CONTACT, body = AccountAddress.sampleMainnet().string
-            ),
-            common = FactorSourceCommon(
-                cryptoParameters = FactorSourceCryptoParameters(
-                    supportedCurves = listOf(Slip10Curve.CURVE25519),
-                    supportedDerivationPathSchemes = listOf(DerivationPathScheme.CAP26)
-                ),
-                addedOn = Timestamp.now(),
-                lastUsedOn = Timestamp.now(),
-                flags = emptyList()
-            ),
-            contact = TrustedContactFactorSourceContact(
-                emailAddress = EmailAddress("mail@email.com"),
-                name = DisplayName("Trusted contact")
-            )
-        )
-    )
+    private val trustedContact = TrustedContactFactorSource.sample().asGeneral()
 
-    private val arculusCard = FactorSource.ArculusCard(
-        value = ArculusCardFactorSource(
-            id = FactorSourceIdFromHash(
-                kind = FactorSourceKind.ARCULUS_CARD,
-                body = Exactly32Bytes.sample()
-            ),
-            common = FactorSourceCommon(
-                cryptoParameters = FactorSourceCryptoParameters(
-                    supportedCurves = listOf(Slip10Curve.CURVE25519),
-                    supportedDerivationPathSchemes = listOf(DerivationPathScheme.CAP26)
-                ),
-                addedOn = Timestamp.now(),
-                lastUsedOn = Timestamp.now(),
-                flags = emptyList()
-            ),
-            hint = ArculusCardHint(
-                label = "My Arculus",
-                model = ArculusCardModel.ARCULUS_COLD_STORAGE_WALLET
-            )
-        )
-    )
+    private val arculusCard = ArculusCardFactorSource.sample().asGeneral()
 
-    private val offDeviceMnemonic = FactorSource.OffDeviceMnemonic(
-        value = OffDeviceMnemonicFactorSource(
-            id = FactorSourceIdFromHash(
-                kind = FactorSourceKind.ARCULUS_CARD,
-                body = Exactly32Bytes.sample()
-            ),
-            common = FactorSourceCommon(
-                cryptoParameters = FactorSourceCryptoParameters(
-                    supportedCurves = listOf(Slip10Curve.CURVE25519),
-                    supportedDerivationPathSchemes = listOf(DerivationPathScheme.CAP26)
-                ),
-                addedOn = Timestamp.now(),
-                lastUsedOn = Timestamp.now(),
-                flags = emptyList()
-            ),
-            hint = OffDeviceMnemonicHint(
-                label = DisplayName("My mnemonic stored somewhere"),
-                wordCount = Bip39WordCount.TWENTY_FOUR
-            )
-        )
-    )
+    private val offDeviceMnemonic = OffDeviceMnemonicFactorSource.sample().asGeneral()
 
-    private val sequrityQuestions = FactorSource.SecurityQuestions(
-        value = SecurityQuestionsNotProductionReadyFactorSource(
-            id = FactorSourceIdFromHash(
-                kind = FactorSourceKind.SECURITY_QUESTIONS,
-                body = Exactly32Bytes.sample()
-            ),
-            common = FactorSourceCommon(
-                cryptoParameters = FactorSourceCryptoParameters(
-                    supportedCurves = listOf(Slip10Curve.CURVE25519),
-                    supportedDerivationPathSchemes = listOf(DerivationPathScheme.CAP26)
-                ),
-                addedOn = Timestamp.now(),
-                lastUsedOn = Timestamp.now(),
-                flags = emptyList()
-            ),
-            sealedMnemonic = SecurityQuestionsSealedNotProductionReadyMnemonic(
-                securityQuestions = emptyList(),
-                kdfScheme = SecurityQuestionsNotProductionReadyKdfScheme.Version1(
-                    v1 = SecurityQuestionsNotProductionReadyKdfSchemeVersion1(
-                        kdfEncryptionKeysFromKeyExchangeKeys = SecurityQuestionsNotProductionReadyEncryptionKeysByDiffieHellmanFold(),
-                        kdfKeyExchangesKeysFromQuestionsAndAnswers = SecurityQuestionsNotProductionReadyKeyExchangeKeysFromQandAsLowerTrimUtf8()
-                    )
-                ),
-                encryptionScheme = EncryptionScheme.Version1(
-                    v1 = AesGcm256()
-                ),
-                encryptions = emptyList()
-            ),
-        )
-    )
+    private val sequrityQuestions = SecurityQuestionsNotProductionReadyFactorSource.sample().asGeneral()
+
+    private val password = PasswordFactorSource.sample().asGeneral()
 }

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/OffDeviceMnemonicFactorSourceTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/OffDeviceMnemonicFactorSourceTest.kt
@@ -1,0 +1,9 @@
+package com.radixdlt.sargon
+
+import com.radixdlt.sargon.samples.Sample
+import com.radixdlt.sargon.samples.sample
+
+class OffDeviceMnemonicFactorSourceTest: SampleTestable<OffDeviceMnemonicFactorSource> {
+    override val samples: List<Sample<OffDeviceMnemonicFactorSource>>
+        get() = listOf(OffDeviceMnemonicFactorSource.sample)
+}

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/PasswordFactorSourceTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/PasswordFactorSourceTest.kt
@@ -1,0 +1,9 @@
+package com.radixdlt.sargon
+
+import com.radixdlt.sargon.samples.Sample
+import com.radixdlt.sargon.samples.sample
+
+class PasswordFactorSourceTest: SampleTestable<PasswordFactorSource> {
+    override val samples: List<Sample<PasswordFactorSource>>
+        get() = listOf(PasswordFactorSource.sample)
+}

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/SecurityQuestionsFactorSourceTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/SecurityQuestionsFactorSourceTest.kt
@@ -1,0 +1,9 @@
+package com.radixdlt.sargon
+
+import com.radixdlt.sargon.samples.Sample
+import com.radixdlt.sargon.samples.sample
+
+class SecurityQuestionsFactorSourceTest: SampleTestable<SecurityQuestionsNotProductionReadyFactorSource> {
+    override val samples: List<Sample<SecurityQuestionsNotProductionReadyFactorSource>>
+        get() = listOf(SecurityQuestionsNotProductionReadyFactorSource.sample)
+}

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/TrustedContactFactorSourceTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/TrustedContactFactorSourceTest.kt
@@ -1,0 +1,9 @@
+package com.radixdlt.sargon
+
+import com.radixdlt.sargon.samples.Sample
+import com.radixdlt.sargon.samples.sample
+
+class TrustedContactFactorSourceTest: SampleTestable<TrustedContactFactorSource> {
+    override val samples: List<Sample<TrustedContactFactorSource>>
+        get() = listOf(TrustedContactFactorSource.sample)
+}


### PR DESCRIPTION
Added the `word_count`. Decided to not call it `mnemonic_word_count` as in `DeviceFactorSourceHint` since the mnemonic is implied by the struct's name.

Update:
Kotlinised some factor source samples.