### PR TITLE
[ABW-4131] Set main FactorSource

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "account-for-display"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "addresses",
  "derive_more",
@@ -48,10 +48,10 @@ dependencies = [
 
 [[package]]
 name = "addresses"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "assert-json",
- "bytes 1.1.105",
+ "bytes 1.1.106",
  "cap26-models",
  "core-utils",
  "derive_more",
@@ -242,7 +242,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "assert-json"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "assert-json-diff",
  "error",
@@ -550,7 +550,7 @@ dependencies = [
 
 [[package]]
 name = "build-info"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "assert-json",
  "cargo_toml 0.15.3 (git+https://gitlab.com/lib.rs/cargo_toml?rev=e498c94fc42a660c1ca1a28999ce1d757cfe77fe)",
@@ -583,7 +583,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "assert-json",
  "delegate",
@@ -622,7 +622,7 @@ dependencies = [
 
 [[package]]
 name = "cap26-models"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "assert-json",
  "derive_more",
@@ -806,7 +806,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "clients"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -866,7 +866,7 @@ checksum = "0d8a42181e0652c2997ae4d217f25b63c5337a52fd2279736e97b832fa0a3cff"
 
 [[package]]
 name = "core-collections"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "has-sample-values",
  "indexmap 2.7.0",
@@ -893,7 +893,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-misc"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "assert-json",
  "core-utils",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "core-utils"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "error",
  "iso8601-timestamp",
@@ -1139,7 +1139,7 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "drivers"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -1163,10 +1163,10 @@ dependencies = [
 
 [[package]]
 name = "ecc"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "assert-json",
- "bytes 1.1.105",
+ "bytes 1.1.106",
  "derive_more",
  "enum-as-inner",
  "error",
@@ -1267,11 +1267,11 @@ dependencies = [
 
 [[package]]
 name = "encryption"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "aes-gcm",
  "assert-json",
- "bytes 1.1.105",
+ "bytes 1.1.106",
  "derive_more",
  "error",
  "has-sample-values",
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "entity-by-address"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "addresses",
  "error",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "entity-foundation"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "assert-json",
  "derive_more",
@@ -1372,7 +1372,7 @@ dependencies = [
 
 [[package]]
 name = "error"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "derive_more",
  "log",
@@ -1431,7 +1431,7 @@ dependencies = [
 
 [[package]]
 name = "factor-instances-provider"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -1457,9 +1457,9 @@ dependencies = [
 
 [[package]]
 name = "factors"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
- "bytes 1.1.105",
+ "bytes 1.1.106",
  "cap26-models",
  "core-collections",
  "core-misc",
@@ -1494,7 +1494,7 @@ dependencies = [
 
 [[package]]
 name = "factors-supporting-types"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "async-trait",
  "error",
@@ -1675,7 +1675,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-client-and-api"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -1695,7 +1695,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-models"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "addresses",
  "assert-json",
@@ -1800,7 +1800,7 @@ dependencies = [
 
 [[package]]
 name = "has-sample-values"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "error",
  "indexmap 2.7.0",
@@ -1811,9 +1811,9 @@ dependencies = [
 
 [[package]]
 name = "hash"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
- "bytes 1.1.105",
+ "bytes 1.1.106",
  "derive_more",
  "prelude",
  "radix-common",
@@ -1882,11 +1882,11 @@ source = "git+https://github.com/KokaKiwi/rust-hex/?rev=b2b4370b5bf021b98ee7adc9
 
 [[package]]
 name = "hierarchical-deterministic"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "assert-json",
  "bip39",
- "bytes 1.1.105",
+ "bytes 1.1.106",
  "cap26-models",
  "derive_more",
  "ecc",
@@ -1928,13 +1928,13 @@ dependencies = [
 
 [[package]]
 name = "home-cards"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "actix-rt",
  "addresses",
  "async-trait",
  "base64 0.22.1 (git+https://github.com/marshallpierce/rust-base64.git?rev=e14400697453bcc85997119b874bc03d9601d0af)",
- "bytes 1.1.105",
+ "bytes 1.1.106",
  "core-utils",
  "derive_more",
  "drivers",
@@ -1954,7 +1954,7 @@ dependencies = [
 
 [[package]]
 name = "host-info"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "assert-json",
  "derive_more",
@@ -2001,10 +2001,10 @@ dependencies = [
 
 [[package]]
 name = "http-client"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "actix-rt",
- "bytes 1.1.105",
+ "bytes 1.1.106",
  "core-utils",
  "drivers",
  "error",
@@ -2229,7 +2229,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "identified-vec-of"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "assert-json",
  "derive_more",
@@ -2302,7 +2302,7 @@ dependencies = [
 
 [[package]]
 name = "interactors"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -2432,7 +2432,7 @@ dependencies = [
 
 [[package]]
 name = "key-derivation-traits"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "addresses",
  "async-trait",
@@ -2450,7 +2450,7 @@ dependencies = [
 
 [[package]]
 name = "keys-collector"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -2539,7 +2539,7 @@ dependencies = [
 
 [[package]]
 name = "manifests"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "account-for-display",
  "addresses",
@@ -2579,7 +2579,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "metadata"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "derive_more",
  "has-sample-values",
@@ -2679,7 +2679,7 @@ dependencies = [
 
 [[package]]
 name = "network"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "assert-json",
  "enum-iterator",
@@ -2695,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "next-derivation-index-ephemeral"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "addresses",
  "assert-json",
@@ -2771,9 +2771,9 @@ dependencies = [
 
 [[package]]
 name = "numeric"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
- "bytes 1.1.105",
+ "bytes 1.1.106",
  "delegate",
  "derive_more",
  "enum-iterator",
@@ -3011,7 +3011,7 @@ dependencies = [
 
 [[package]]
 name = "prelude"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "radix-engine",
  "radix-engine-toolkit",
@@ -3046,7 +3046,7 @@ dependencies = [
 
 [[package]]
 name = "profile"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "account-for-display",
  "addresses",
@@ -3090,7 +3090,7 @@ dependencies = [
 
 [[package]]
 name = "profile-account"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "account-for-display",
  "addresses",
@@ -3110,7 +3110,7 @@ dependencies = [
 
 [[package]]
 name = "profile-account-or-persona"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "cap26-models",
  "derive_more",
@@ -3127,7 +3127,7 @@ dependencies = [
 
 [[package]]
 name = "profile-app-preferences"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "addresses",
  "core-misc",
@@ -3150,7 +3150,7 @@ dependencies = [
 
 [[package]]
 name = "profile-base-entity"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "addresses",
  "derive_more",
@@ -3173,7 +3173,7 @@ dependencies = [
 
 [[package]]
 name = "profile-gateway"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "addresses",
  "assert-json",
@@ -3197,7 +3197,7 @@ dependencies = [
 
 [[package]]
 name = "profile-logic"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "addresses",
  "derive_more",
@@ -3219,7 +3219,7 @@ dependencies = [
 
 [[package]]
 name = "profile-persona"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "addresses",
  "cap26-models",
@@ -3240,7 +3240,7 @@ dependencies = [
 
 [[package]]
 name = "profile-persona-data"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "addresses",
  "assert-json",
@@ -3259,7 +3259,7 @@ dependencies = [
 
 [[package]]
 name = "profile-security-structures"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "addresses",
  "cap26-models",
@@ -3286,7 +3286,7 @@ dependencies = [
 
 [[package]]
 name = "profile-state-holder"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "derive_more",
  "error",
@@ -3301,7 +3301,7 @@ dependencies = [
 
 [[package]]
 name = "profile-supporting-types"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "addresses",
  "derive_more",
@@ -3390,14 +3390,14 @@ dependencies = [
 
 [[package]]
 name = "radix-connect"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "actix-rt",
  "addresses",
  "assert-json",
  "async-trait",
  "base64 0.22.1 (git+https://github.com/marshallpierce/rust-base64.git?rev=e14400697453bcc85997119b874bc03d9601d0af)",
- "bytes 1.1.105",
+ "bytes 1.1.106",
  "core-misc",
  "core-utils",
  "derive_more",
@@ -3425,10 +3425,10 @@ dependencies = [
 
 [[package]]
 name = "radix-connect-models"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "addresses",
- "bytes 1.1.105",
+ "bytes 1.1.106",
  "core-misc",
  "derive_more",
  "error",
@@ -3912,7 +3912,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -3977,7 +3977,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -4004,7 +4004,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-accounts"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -4027,7 +4027,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-factors"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -4047,7 +4047,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-security-center"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "actix-rt",
  "derive_more",
@@ -4063,7 +4063,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-signing"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -4089,7 +4089,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-transaction"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "actix-rt",
  "async-std",
@@ -4118,7 +4118,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-uniffi"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -4175,7 +4175,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-uniffi-conversion-macros"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4349,7 +4349,7 @@ dependencies = [
 
 [[package]]
 name = "security-center"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "addresses",
  "assert-json",
@@ -4554,7 +4554,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "short-string"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "arraystring",
  "assert-json",
@@ -4589,13 +4589,13 @@ dependencies = [
 
 [[package]]
 name = "signing"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "actix-rt",
  "addresses",
  "assert-json",
  "async-trait",
- "bytes 1.1.105",
+ "bytes 1.1.106",
  "cap26-models",
  "core-collections",
  "core-misc",
@@ -4627,10 +4627,10 @@ dependencies = [
 
 [[package]]
 name = "signing-traits"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "async-trait",
- "bytes 1.1.105",
+ "bytes 1.1.106",
  "core-collections",
  "derive_more",
  "ecc",
@@ -4793,7 +4793,7 @@ dependencies = [
 
 [[package]]
 name = "sub-systems"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "derive_more",
  "drivers",
@@ -4967,7 +4967,7 @@ dependencies = [
 
 [[package]]
 name = "time-utils"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "iso8601-timestamp",
  "prelude",
@@ -5096,10 +5096,10 @@ dependencies = [
 
 [[package]]
 name = "transaction-foundation"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "assert-json",
- "bytes 1.1.105",
+ "bytes 1.1.106",
  "derive_more",
  "has-sample-values",
  "paste 1.0.14",
@@ -5111,10 +5111,10 @@ dependencies = [
 
 [[package]]
 name = "transaction-models"
-version = "1.1.105"
+version = "1.1.106"
 dependencies = [
  "addresses",
- "bytes 1.1.105",
+ "bytes 1.1.106",
  "cargo_toml 0.15.3 (git+https://gitlab.com/lib.rs/cargo_toml?rev=e498c94fc42a660c1ca1a28999ce1d757cfe77fe)",
  "core-collections",
  "core-misc",

--- a/crates/app/home-cards/Cargo.toml
+++ b/crates/app/home-cards/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "home-cards"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/key-derivation-traits/Cargo.toml
+++ b/crates/app/key-derivation-traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "key-derivation-traits"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/radix-connect-models/Cargo.toml
+++ b/crates/app/radix-connect-models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "radix-connect-models"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/radix-connect/Cargo.toml
+++ b/crates/app/radix-connect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "radix-connect"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 

--- a/crates/app/security-center/Cargo.toml
+++ b/crates/app/security-center/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "security-center"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/signing-traits/Cargo.toml
+++ b/crates/app/signing-traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signing-traits"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/signing/Cargo.toml
+++ b/crates/app/signing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signing"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 

--- a/crates/common/build-info/Cargo.toml
+++ b/crates/common/build-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "build-info"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/common/bytes/Cargo.toml
+++ b/crates/common/bytes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bytes"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/entity-foundation/Cargo.toml
+++ b/crates/common/entity-foundation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entity-foundation"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/host-info/Cargo.toml
+++ b/crates/common/host-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "host-info"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/identified-vec-of/Cargo.toml
+++ b/crates/common/identified-vec-of/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "identified-vec-of"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/metadata/Cargo.toml
+++ b/crates/common/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metadata"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/network/Cargo.toml
+++ b/crates/common/network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "network"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/numeric/Cargo.toml
+++ b/crates/common/numeric/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numeric"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/short-string/Cargo.toml
+++ b/crates/common/short-string/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "short-string"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/assert-json/Cargo.toml
+++ b/crates/core/assert-json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assert-json"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/collections/Cargo.toml
+++ b/crates/core/collections/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-collections"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/error/Cargo.toml
+++ b/crates/core/error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "error"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/has-sample-values/Cargo.toml
+++ b/crates/core/has-sample-values/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "has-sample-values"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/misc/Cargo.toml
+++ b/crates/core/misc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-misc"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/prelude/Cargo.toml
+++ b/crates/core/prelude/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prelude"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/time-utils/Cargo.toml
+++ b/crates/core/time-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "time-utils"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/utils/Cargo.toml
+++ b/crates/core/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-utils"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/addresses/Cargo.toml
+++ b/crates/crypto/addresses/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "addresses"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/cap26-models/Cargo.toml
+++ b/crates/crypto/cap26-models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cap26-models"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/ecc/Cargo.toml
+++ b/crates/crypto/ecc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecc"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/encryption/Cargo.toml
+++ b/crates/crypto/encryption/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "encryption"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/hash/Cargo.toml
+++ b/crates/crypto/hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hash"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/hd/Cargo.toml
+++ b/crates/crypto/hd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hierarchical-deterministic"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/factors/Cargo.toml
+++ b/crates/factors/factors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factors"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/factors/src/factor_source_common.rs
+++ b/crates/factors/factors/src/factor_source_common.rs
@@ -100,10 +100,14 @@ impl FactorSourceCommon {
         self.crypto_parameters.supports_olympia()
     }
 
-    /// Checks if its Main Babylon Device Factor Source (BDFS).
+    /// Checks if it is Main Babylon Device Factor Source (BDFS).
     pub fn is_main_bdfs(&self) -> bool {
-        self.supports_babylon()
-            && self.flags.contains_by_id(&FactorSourceFlag::Main)
+        self.supports_babylon() && self.is_main()
+    }
+
+    /// Checks if it is a main factor source.
+    pub fn is_main(&self) -> bool {
+        self.flags.contains_by_id(&FactorSourceFlag::Main)
     }
 }
 
@@ -219,5 +223,20 @@ mod tests {
     #[test]
     fn main_flag_not_present_if_not_main() {
         assert!(FactorSourceCommon::new_bdfs(false).flags.is_empty());
+    }
+
+    #[test]
+    fn main() {
+        let sut = FactorSourceCommon::new(
+            FactorSourceCryptoParameters::olympia(),
+            [FactorSourceFlag::Main],
+        );
+        assert!(sut.is_main());
+
+        let sut = FactorSourceCommon::new(
+            FactorSourceCryptoParameters::olympia(),
+            Vec::new(),
+        );
+        assert!(!sut.is_main());
     }
 }

--- a/crates/factors/instances-provider/Cargo.toml
+++ b/crates/factors/instances-provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factor-instances-provider"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/keys-collector/Cargo.toml
+++ b/crates/factors/keys-collector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keys-collector"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/next-derivation-index-ephemeral/Cargo.toml
+++ b/crates/factors/next-derivation-index-ephemeral/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "next-derivation-index-ephemeral"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/supporting-types/Cargo.toml
+++ b/crates/factors/supporting-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factors-supporting-types"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/gateway/client-and-api/Cargo.toml
+++ b/crates/gateway/client-and-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gateway-client-and-api"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/gateway/models/Cargo.toml
+++ b/crates/gateway/models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gateway-models"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 

--- a/crates/profile/logic/logic_SPLIT_ME/Cargo.toml
+++ b/crates/profile/logic/logic_SPLIT_ME/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-logic"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/logic/logic_SPLIT_ME/src/logic/profile_update.rs
+++ b/crates/profile/logic/logic_SPLIT_ME/src/logic/profile_update.rs
@@ -291,6 +291,15 @@ pub trait ProfileFactorSourceUpdating {
             common.flags.remove_id(&FactorSourceFlag::Main);
         })
     }
+
+    fn update_factor_source_add_flag_main(
+        &mut self,
+        id: &FactorSourceID,
+    ) -> Result<()> {
+        self.update_any_factor_source_common(id, |common| {
+            common.flags.insert(FactorSourceFlag::Main);
+        })
+    }
 }
 
 impl ProfileFactorSourceUpdating for Profile {

--- a/crates/profile/logic/logic_SPLIT_ME/src/logic/profile_update.rs
+++ b/crates/profile/logic/logic_SPLIT_ME/src/logic/profile_update.rs
@@ -526,4 +526,33 @@ mod tests {
             "Batman"
         );
     }
+
+    #[test]
+    fn add_remove_main() {
+        let mut sut = SUT::sample();
+        let id: &FactorSourceID =
+            &DeviceFactorSource::sample_babylon().id.into();
+
+        fn assert_is_main(sut: &SUT, id: &FactorSourceID, expected: bool) {
+            assert_eq!(
+                sut.factor_sources
+                    .get_id(id)
+                    .unwrap()
+                    .common_properties()
+                    .is_main(),
+                expected
+            );
+        }
+
+        // Verify that the factor source is main
+        assert_is_main(&sut, id, true);
+
+        // Remove the main flag and verify it is updated
+        sut.update_factor_source_remove_flag_main(id).unwrap();
+        assert_is_main(&sut, id, false);
+
+        // Add the main flag and verify it is updated
+        sut.update_factor_source_add_flag_main(id).unwrap();
+        assert_is_main(&sut, id, true);
+    }
 }

--- a/crates/profile/logic/logic_SPLIT_ME/src/logic/query_factor_sources.rs
+++ b/crates/profile/logic/logic_SPLIT_ME/src/logic/query_factor_sources.rs
@@ -17,6 +17,11 @@ pub trait ProfileFactorSourceQuerying {
 
     fn device_factor_sources(&self) -> Vec<DeviceFactorSource>;
 
+    fn main_factor_source_of_kind(
+        &self,
+        kind: FactorSourceKind,
+    ) -> Result<Option<FactorSourceID>>;
+
     fn bdfs(&self) -> DeviceFactorSource {
         let device_factor_sources = self.device_factor_sources();
         let explicit_main = device_factor_sources
@@ -67,6 +72,24 @@ impl ProfileFactorSourceQuerying for Profile {
             .iter()
             .filter_map(|f| f.as_device().cloned())
             .collect_vec()
+    }
+
+    fn main_factor_source_of_kind(
+        &self,
+        kind: FactorSourceKind,
+    ) -> Result<Option<FactorSourceID>> {
+        let main_factor_sources = self
+            .factor_sources
+            .iter()
+            .filter(|f| {
+                f.factor_source_kind() == kind
+                    && f.common_properties().is_main()
+            })
+            .map(|f| f.factor_source_id())
+            .collect::<Vec<_>>();
+        assert!(main_factor_sources.len() <= 1, "We should never have more than 1 main FactorSource of a given FactorSourceKind");
+
+        Ok(main_factor_sources.first().cloned())
     }
 }
 

--- a/crates/profile/models/account-for-display/Cargo.toml
+++ b/crates/profile/models/account-for-display/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "account-for-display"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/account-or-persona/Cargo.toml
+++ b/crates/profile/models/account-or-persona/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-account-or-persona"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/account/Cargo.toml
+++ b/crates/profile/models/account/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-account"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/app-preferences/Cargo.toml
+++ b/crates/profile/models/app-preferences/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-app-preferences"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/base-entity/Cargo.toml
+++ b/crates/profile/models/base-entity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-base-entity"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/gateway/Cargo.toml
+++ b/crates/profile/models/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-gateway"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/persona-data/Cargo.toml
+++ b/crates/profile/models/persona-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-persona-data"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/persona/Cargo.toml
+++ b/crates/profile/models/persona/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-persona"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/profile_SPLIT_ME/Cargo.toml
+++ b/crates/profile/models/profile_SPLIT_ME/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 

--- a/crates/profile/models/security-structures/Cargo.toml
+++ b/crates/profile/models/security-structures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-security-structures"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/supporting-types/Cargo.toml
+++ b/crates/profile/models/supporting-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-supporting-types"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/traits/entity-by-address/Cargo.toml
+++ b/crates/profile/traits/entity-by-address/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entity-by-address"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/sargon/Cargo.toml
+++ b/crates/sargon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 resolver = "2" # features enabled in integration test

--- a/crates/system/clients/clients/Cargo.toml
+++ b/crates/system/clients/clients/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clients"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 

--- a/crates/system/clients/http/Cargo.toml
+++ b/crates/system/clients/http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http-client"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/drivers/Cargo.toml
+++ b/crates/system/drivers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drivers"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 

--- a/crates/system/drivers/src/drivers/event_bus_driver/support/event_kind.rs
+++ b/crates/system/drivers/src/drivers/event_bus_driver/support/event_kind.rs
@@ -54,6 +54,9 @@ pub enum EventKind {
     /// An existing factor source has been updated
     FactorSourceUpdated,
 
+    /// A collection of existing factor sources have been updated
+    FactorSourcesUpdated,
+
     /// Profile updated with a new Security Structure.
     SecurityStructureAdded,
 }
@@ -147,6 +150,7 @@ impl EventKind {
                 | FactorSourceAdded
                 | FactorSourceUpdated
                 | FactorSourcesAdded
+                | FactorSourcesUpdated
         )
     }
 }
@@ -199,6 +203,7 @@ mod tests {
                 | FactorSourceAdded
                 | FactorSourcesAdded
                 | FactorSourceUpdated
+                | FactorSourcesUpdated
                 | PersonaAdded
                 | PersonasAdded
                 | PersonasUpdated
@@ -228,6 +233,7 @@ mod tests {
                 | FactorSourceAdded
                 | FactorSourcesAdded
                 | FactorSourceUpdated
+                | FactorSourcesUpdated
                 | AccountAdded
                 | AccountsAdded
                 | AccountUpdated
@@ -250,6 +256,7 @@ mod tests {
                 ProfileUsedOnOtherDevice
                 | FactorSourceAdded
                 | FactorSourceUpdated
+                | FactorSourcesUpdated
                 | ProfileSaved
                 | AccountAdded
                 | SecurityStructureAdded
@@ -277,6 +284,7 @@ mod tests {
                 ProfileUsedOnOtherDevice
                 | FactorSourceAdded
                 | FactorSourceUpdated
+                | FactorSourcesUpdated
                 | ProfileSaved
                 | AccountAdded
                 | GatewayChangedCurrent
@@ -304,6 +312,7 @@ mod tests {
                 ProfileUsedOnOtherDevice
                 | FactorSourceAdded
                 | FactorSourceUpdated
+                | FactorSourcesUpdated
                 | ProfileSaved
                 | AccountAdded
                 | FactorSourcesAdded
@@ -326,7 +335,8 @@ mod tests {
             .map(|sut| (sut, sut.affects_factor_sources()))
             .for_each(|(sut, affects)| match sut {
                 Booted | ProfileImported | FactorSourceAdded
-                | FactorSourcesAdded | FactorSourceUpdated => {
+                | FactorSourcesAdded | FactorSourceUpdated
+                | FactorSourcesUpdated => {
                     assert!(affects)
                 }
                 ProfileUsedOnOtherDevice

--- a/crates/system/drivers/src/drivers/event_bus_driver/support/event_profile_modified.rs
+++ b/crates/system/drivers/src/drivers/event_bus_driver/support/event_profile_modified.rs
@@ -36,6 +36,9 @@ pub enum EventProfileModified {
     /// An existing factor source has been updated
     FactorSourceUpdated { id: FactorSourceID },
 
+    /// A collection of existing factor sources have been updated
+    FactorSourcesUpdated { ids: Vec<FactorSourceID> },
+
     /// Profile updated with a new Security Structure.
     SecurityStructureAdded { id: SecurityStructureID },
 }
@@ -61,6 +64,9 @@ impl HasEventKind for EventProfileModified {
             Self::FactorSourceAdded { id: _ } => EventKind::FactorSourceAdded,
             Self::FactorSourceUpdated { id: _ } => {
                 EventKind::FactorSourceUpdated
+            }
+            Self::FactorSourcesUpdated { ids: _ } => {
+                EventKind::FactorSourcesUpdated
             }
             Self::SecurityStructureAdded { id: _ } => {
                 EventKind::SecurityStructureAdded
@@ -232,6 +238,13 @@ mod tests {
                 id: FactorSourceID::sample(),
             },
             EventKind::FactorSourceUpdated,
+        );
+
+        test(
+            SUT::FactorSourcesUpdated {
+                ids: vec![FactorSourceID::sample()],
+            },
+            EventKind::FactorSourcesUpdated,
         );
     }
 }

--- a/crates/system/drivers/src/drivers/event_bus_driver/support/test/rust_event_bus_driver.rs
+++ b/crates/system/drivers/src/drivers/event_bus_driver/support/test/rust_event_bus_driver.rs
@@ -34,4 +34,8 @@ impl RustEventBusDriver {
             recorded: RwLock::new(Vec::new()),
         })
     }
+
+    pub fn clear_recorded(&self) {
+        self.recorded.try_write().unwrap().clear();
+    }
 }

--- a/crates/system/interactors/Cargo.toml
+++ b/crates/system/interactors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interactors"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/accounts/Cargo.toml
+++ b/crates/system/os/accounts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-accounts"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/factors/Cargo.toml
+++ b/crates/system/os/factors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-factors"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/os/Cargo.toml
+++ b/crates/system/os/os/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/security-center/Cargo.toml
+++ b/crates/system/os/security-center/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-security-center"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/signing/Cargo.toml
+++ b/crates/system/os/signing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-signing"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/transaction/Cargo.toml
+++ b/crates/system/os/transaction/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-transaction"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/profile-state-holder/Cargo.toml
+++ b/crates/system/profile-state-holder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-state-holder"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/sub-systems/Cargo.toml
+++ b/crates/system/sub-systems/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sub-systems"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/transaction/foundation/Cargo.toml
+++ b/crates/transaction/foundation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transaction-foundation"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/transaction/manifests/Cargo.toml
+++ b/crates/transaction/manifests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "manifests"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 

--- a/crates/transaction/models/Cargo.toml
+++ b/crates/transaction/models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transaction-models"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 

--- a/crates/uniffi/conversion-macros/Cargo.toml
+++ b/crates/uniffi/conversion-macros/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "sargon-uniffi-conversion-macros"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 
 [dependencies]

--- a/crates/uniffi/uniffi_SPLIT_ME/Cargo.toml
+++ b/crates/uniffi/uniffi_SPLIT_ME/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-uniffi"
-version = "1.1.105"
+version = "1.1.106"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/uniffi/uniffi_SPLIT_ME/src/system/drivers/event_bus_driver/support/event_kind.rs
+++ b/crates/uniffi/uniffi_SPLIT_ME/src/system/drivers/event_bus_driver/support/event_kind.rs
@@ -55,6 +55,9 @@ pub enum EventKind {
     /// An existing factor source has been updated
     FactorSourceUpdated,
 
+    /// A collection of existing factor sources have been updated
+    FactorSourcesUpdated,
+
     /// Profile updated with a new Security Structure.
     SecurityStructureAdded,
 }

--- a/crates/uniffi/uniffi_SPLIT_ME/src/system/drivers/event_bus_driver/support/event_profile_modified.rs
+++ b/crates/uniffi/uniffi_SPLIT_ME/src/system/drivers/event_bus_driver/support/event_profile_modified.rs
@@ -25,6 +25,9 @@ pub enum EventProfileModified {
     /// An existing factor source has been updated
     FactorSourceUpdated { id: FactorSourceID },
 
+    /// A collection of existing factor sources have been updated
+    FactorSourcesUpdated { ids: Vec<FactorSourceID> },
+
     /// A new persona with `address` was inserted into the active profile
     PersonaAdded { address: IdentityAddress },
 

--- a/crates/uniffi/uniffi_SPLIT_ME/src/system/sargon_os/sargon_os_factors.rs
+++ b/crates/uniffi/uniffi_SPLIT_ME/src/system/sargon_os/sargon_os_factors.rs
@@ -196,7 +196,7 @@ impl SargonOS {
             .into_result()
     }
 
-    /// Set the given `factor_source_id` as the main factor source for the given `kind`.
+    /// Set the given `factor_source` as the main factor source of its kind.
     /// Throws `UpdateFactorSourceMutateFailed` error if the factor source is not found.
     ///
     /// # Emits Event
@@ -207,16 +207,12 @@ impl SargonOS {
     ///
     /// If there is any main `FactorSource` of the given `FactorSourceKind`, such events are emitted also when
     /// removing the flag from the old main factor source.
-    pub async fn set_main_factor_source_of_kind(
+    pub async fn set_main_factor_source(
         &self,
-        factor_source_id: FactorSourceID,
-        kind: FactorSourceKind,
+        factor_source: FactorSource,
     ) -> Result<()> {
         self.wrapped
-            .set_main_factor_source_of_kind(
-                factor_source_id.into_internal(),
-                kind.into_internal(),
-            )
+            .set_main_factor_source(factor_source.into_internal())
             .await
             .into_result()
     }

--- a/crates/uniffi/uniffi_SPLIT_ME/src/system/sargon_os/sargon_os_factors.rs
+++ b/crates/uniffi/uniffi_SPLIT_ME/src/system/sargon_os/sargon_os_factors.rs
@@ -195,4 +195,29 @@ impl SargonOS {
             .await
             .into_result()
     }
+
+    /// Set the given `factor_source_id` as the main factor source for the given `kind`.
+    /// Throws `UpdateFactorSourceMutateFailed` error if the factor source is not found.
+    ///
+    /// # Emits Event
+    /// Emits `Event::ProfileSaved` after having successfully written the JSON
+    /// of the active profile to secure storage.
+    ///
+    /// Also emits `EventNotification::ProfileModified { change: EventProfileModified::FactorSourceUpdated { id } }`
+    ///
+    /// If there is any main `FactorSource` of the given `FactorSourceKind`, such events are emitted also when
+    /// removing the flag from the old main factor source.
+    pub async fn set_main_factor_source_of_kind(
+        &self,
+        factor_source_id: FactorSourceID,
+        kind: FactorSourceKind,
+    ) -> Result<()> {
+        self.wrapped
+            .set_main_factor_source_of_kind(
+                factor_source_id.into_internal(),
+                kind.into_internal(),
+            )
+            .await
+            .into_result()
+    }
 }

--- a/crates/uniffi/uniffi_SPLIT_ME/src/system/sargon_os/sargon_os_factors.rs
+++ b/crates/uniffi/uniffi_SPLIT_ME/src/system/sargon_os/sargon_os_factors.rs
@@ -196,7 +196,7 @@ impl SargonOS {
             .into_result()
     }
 
-    /// Set the given `factor_source` as the main factor source of its kind.
+    /// Set the FactorSource with the given `factor_source_id` as the main factor source of its kind.
     /// Throws `UpdateFactorSourceMutateFailed` error if the factor source is not found.
     ///
     /// # Emits Event
@@ -209,10 +209,10 @@ impl SargonOS {
     /// removing the flag from the old main factor source.
     pub async fn set_main_factor_source(
         &self,
-        factor_source: FactorSource,
+        factor_source_id: FactorSourceID,
     ) -> Result<()> {
         self.wrapped
-            .set_main_factor_source(factor_source.into_internal())
+            .set_main_factor_source(factor_source_id.into_internal())
             .await
             .into_result()
     }


### PR DESCRIPTION
Allows setting a `FactorSource` as main. 
Although it will only be used by hosts for `Device` factor sources, implementation supports one main factor source for any given `FactorSourceKind`.