### PR TITLE
Finish early mono sign when skipping factor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "account-for-display"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "addresses",
  "derive_more",
@@ -49,10 +49,10 @@ dependencies = [
 
 [[package]]
 name = "addresses"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "assert-json",
- "bytes 1.1.110",
+ "bytes 1.1.111",
  "cap26-models",
  "core-utils",
  "derive_more",
@@ -246,7 +246,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "assert-json"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "assert-json-diff",
  "error",
@@ -546,7 +546,7 @@ dependencies = [
 
 [[package]]
 name = "build-info"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "assert-json",
  "cargo_toml",
@@ -573,7 +573,7 @@ checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
 
 [[package]]
 name = "bytes"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "assert-json",
  "delegate",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "cap26-models"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "assert-json",
  "derive_more",
@@ -748,7 +748,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "clients"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -808,7 +808,7 @@ checksum = "0d8a42181e0652c2997ae4d217f25b63c5337a52fd2279736e97b832fa0a3cff"
 
 [[package]]
 name = "core-collections"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "has-sample-values",
  "indexmap 2.7.0",
@@ -835,7 +835,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-misc"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "assert-json",
  "core-utils",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "core-utils"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "error",
  "iso8601-timestamp",
@@ -1084,7 +1084,7 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "drivers"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -1108,10 +1108,10 @@ dependencies = [
 
 [[package]]
 name = "ecc"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "assert-json",
- "bytes 1.1.110",
+ "bytes 1.1.111",
  "derive_more",
  "enum-as-inner",
  "error",
@@ -1210,11 +1210,11 @@ dependencies = [
 
 [[package]]
 name = "encryption"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "aes-gcm",
  "assert-json",
- "bytes 1.1.110",
+ "bytes 1.1.111",
  "derive_more",
  "error",
  "has-sample-values",
@@ -1231,7 +1231,7 @@ dependencies = [
 
 [[package]]
 name = "entity-by-address"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "addresses",
  "error",
@@ -1243,7 +1243,7 @@ dependencies = [
 
 [[package]]
 name = "entity-foundation"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "assert-json",
  "derive_more",
@@ -1318,7 +1318,7 @@ dependencies = [
 
 [[package]]
 name = "error"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "derive_more",
  "log",
@@ -1377,7 +1377,7 @@ dependencies = [
 
 [[package]]
 name = "factor-instances-provider"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -1403,9 +1403,9 @@ dependencies = [
 
 [[package]]
 name = "factors"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
- "bytes 1.1.110",
+ "bytes 1.1.111",
  "cap26-models",
  "core-collections",
  "core-misc",
@@ -1440,7 +1440,7 @@ dependencies = [
 
 [[package]]
 name = "factors-supporting-types"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "async-trait",
  "error",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-client-and-api"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -1613,7 +1613,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-models"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "addresses",
  "assert-json",
@@ -1718,7 +1718,7 @@ dependencies = [
 
 [[package]]
 name = "has-sample-values"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "error",
  "indexmap 2.7.0",
@@ -1729,9 +1729,9 @@ dependencies = [
 
 [[package]]
 name = "hash"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
- "bytes 1.1.110",
+ "bytes 1.1.111",
  "derive_more",
  "prelude",
  "radix-common",
@@ -1795,11 +1795,11 @@ dependencies = [
 
 [[package]]
 name = "hierarchical-deterministic"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "assert-json",
  "bip39",
- "bytes 1.1.110",
+ "bytes 1.1.111",
  "cap26-models",
  "derive_more",
  "ecc",
@@ -1842,13 +1842,13 @@ dependencies = [
 
 [[package]]
 name = "home-cards"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "actix-rt",
  "addresses",
  "async-trait",
  "base64",
- "bytes 1.1.110",
+ "bytes 1.1.111",
  "core-utils",
  "derive_more",
  "drivers",
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "host-info"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "assert-json",
  "derive_more",
@@ -1915,10 +1915,10 @@ dependencies = [
 
 [[package]]
 name = "http-client"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "actix-rt",
- "bytes 1.1.110",
+ "bytes 1.1.111",
  "core-utils",
  "drivers",
  "error",
@@ -2143,7 +2143,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "identified-vec-of"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "assert-json",
  "derive_more",
@@ -2216,7 +2216,7 @@ dependencies = [
 
 [[package]]
 name = "interactors"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -2336,7 +2336,7 @@ dependencies = [
 
 [[package]]
 name = "key-derivation-traits"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "addresses",
  "async-trait",
@@ -2354,7 +2354,7 @@ dependencies = [
 
 [[package]]
 name = "keys-collector"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -2443,7 +2443,7 @@ dependencies = [
 
 [[package]]
 name = "manifests"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "account-for-display",
  "addresses",
@@ -2483,7 +2483,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "metadata"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "derive_more",
  "has-sample-values",
@@ -2583,7 +2583,7 @@ dependencies = [
 
 [[package]]
 name = "network"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "assert-json",
  "enum-iterator",
@@ -2599,7 +2599,7 @@ dependencies = [
 
 [[package]]
 name = "next-derivation-index-ephemeral"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "addresses",
  "assert-json",
@@ -2675,9 +2675,9 @@ dependencies = [
 
 [[package]]
 name = "numeric"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
- "bytes 1.1.110",
+ "bytes 1.1.111",
  "delegate",
  "derive_more",
  "enum-iterator",
@@ -2897,7 +2897,7 @@ dependencies = [
 
 [[package]]
 name = "prelude"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "radix-engine",
  "radix-engine-toolkit",
@@ -2934,7 +2934,7 @@ dependencies = [
 
 [[package]]
 name = "profile"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "account-for-display",
  "addresses",
@@ -2978,7 +2978,7 @@ dependencies = [
 
 [[package]]
 name = "profile-account"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "account-for-display",
  "addresses",
@@ -2998,7 +2998,7 @@ dependencies = [
 
 [[package]]
 name = "profile-account-or-persona"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "cap26-models",
  "derive_more",
@@ -3015,7 +3015,7 @@ dependencies = [
 
 [[package]]
 name = "profile-app-preferences"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "addresses",
  "core-misc",
@@ -3038,7 +3038,7 @@ dependencies = [
 
 [[package]]
 name = "profile-base-entity"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "addresses",
  "derive_more",
@@ -3061,7 +3061,7 @@ dependencies = [
 
 [[package]]
 name = "profile-gateway"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "addresses",
  "assert-json",
@@ -3085,7 +3085,7 @@ dependencies = [
 
 [[package]]
 name = "profile-logic"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "addresses",
  "derive_more",
@@ -3107,7 +3107,7 @@ dependencies = [
 
 [[package]]
 name = "profile-persona"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "addresses",
  "cap26-models",
@@ -3128,7 +3128,7 @@ dependencies = [
 
 [[package]]
 name = "profile-persona-data"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "addresses",
  "assert-json",
@@ -3147,7 +3147,7 @@ dependencies = [
 
 [[package]]
 name = "profile-security-structures"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "addresses",
  "cap26-models",
@@ -3174,7 +3174,7 @@ dependencies = [
 
 [[package]]
 name = "profile-state-holder"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "derive_more",
  "error",
@@ -3189,7 +3189,7 @@ dependencies = [
 
 [[package]]
 name = "profile-supporting-types"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "addresses",
  "derive_more",
@@ -3278,14 +3278,14 @@ dependencies = [
 
 [[package]]
 name = "radix-connect"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "actix-rt",
  "addresses",
  "assert-json",
  "async-trait",
  "base64",
- "bytes 1.1.110",
+ "bytes 1.1.111",
  "core-misc",
  "core-utils",
  "derive_more",
@@ -3313,10 +3313,10 @@ dependencies = [
 
 [[package]]
 name = "radix-connect-models"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "addresses",
- "bytes 1.1.110",
+ "bytes 1.1.111",
  "core-misc",
  "derive_more",
  "error",
@@ -3758,7 +3758,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -3822,7 +3822,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -3849,7 +3849,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-accounts"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -3872,7 +3872,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-factors"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -3895,7 +3895,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-security-center"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "actix-rt",
  "derive_more",
@@ -3911,7 +3911,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-signing"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -3937,7 +3937,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-transaction"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "actix-rt",
  "async-std",
@@ -3966,7 +3966,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-uniffi"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -4023,7 +4023,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-uniffi-conversion-macros"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4196,7 +4196,7 @@ dependencies = [
 
 [[package]]
 name = "security-center"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "addresses",
  "assert-json",
@@ -4364,7 +4364,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "short-string"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "arraystring",
  "assert-json",
@@ -4399,13 +4399,13 @@ dependencies = [
 
 [[package]]
 name = "signing"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "actix-rt",
  "addresses",
  "assert-json",
  "async-trait",
- "bytes 1.1.110",
+ "bytes 1.1.111",
  "cap26-models",
  "core-collections",
  "core-misc",
@@ -4437,10 +4437,10 @@ dependencies = [
 
 [[package]]
 name = "signing-traits"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "async-trait",
- "bytes 1.1.110",
+ "bytes 1.1.111",
  "core-collections",
  "derive_more",
  "ecc",
@@ -4605,7 +4605,7 @@ dependencies = [
 
 [[package]]
 name = "sub-systems"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "derive_more",
  "drivers",
@@ -4764,7 +4764,7 @@ dependencies = [
 
 [[package]]
 name = "time-utils"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "iso8601-timestamp",
  "prelude",
@@ -4914,10 +4914,10 @@ dependencies = [
 
 [[package]]
 name = "transaction-foundation"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "assert-json",
- "bytes 1.1.110",
+ "bytes 1.1.111",
  "derive_more",
  "has-sample-values",
  "paste",
@@ -4929,10 +4929,10 @@ dependencies = [
 
 [[package]]
 name = "transaction-models"
-version = "1.1.110"
+version = "1.1.111"
 dependencies = [
  "addresses",
- "bytes 1.1.110",
+ "bytes 1.1.111",
  "cargo_toml",
  "core-collections",
  "core-misc",

--- a/crates/app/home-cards/Cargo.toml
+++ b/crates/app/home-cards/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "home-cards"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/key-derivation-traits/Cargo.toml
+++ b/crates/app/key-derivation-traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "key-derivation-traits"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/radix-connect-models/Cargo.toml
+++ b/crates/app/radix-connect-models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "radix-connect-models"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/radix-connect/Cargo.toml
+++ b/crates/app/radix-connect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "radix-connect"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 

--- a/crates/app/security-center/Cargo.toml
+++ b/crates/app/security-center/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "security-center"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/signing-traits/Cargo.toml
+++ b/crates/app/signing-traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signing-traits"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/signing/Cargo.toml
+++ b/crates/app/signing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signing"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 

--- a/crates/app/signing/src/collector/signatures_collector.rs
+++ b/crates/app/signing/src/collector/signatures_collector.rs
@@ -246,6 +246,10 @@ impl<S: Signable> SignaturesCollector<S> {
     ) -> Result<()> {
         let factor_sources = factor_sources_of_kind.factor_sources();
         for factor_source in factor_sources {
+            if self.continuation() == FinishEarly {
+                continue;
+            }
+
             // Prepare the request for the interactor
             debug!("Creating mono request for interactor");
             let factor_source_id =

--- a/crates/app/signing/src/tests/test_signatures_collector.rs
+++ b/crates/app/signing/src/tests/test_signatures_collector.rs
@@ -117,6 +117,24 @@ impl<S: Signable + 'static> SignaturesCollector<S> {
         )
     }
 
+    pub(crate) fn test_lazy_skip_some_factors(
+        transactions: impl IntoIterator<Item = SignableWithEntities<S>>,
+        skipping_factors: impl IntoIterator<Item = FactorSourceIDFromHash>,
+    ) -> Self {
+        Self::new_test(
+            SigningFinishEarlyStrategy::default(),
+            FactorSource::sample_all(),
+            transactions,
+            SimulatedUser::new(
+                SimulatedUserMode::Lazy(Laziness::SignMinimum),
+                Some(SimulatedFailures::with_simulated_failures(
+                    skipping_factors,
+                )),
+            ),
+            SigningPurpose::sign_transaction_primary(),
+        )
+    }
+
     pub(crate) fn test_lazy_always_skip(
         transactions: impl IntoIterator<Item = SignableWithEntities<S>>,
     ) -> Self {

--- a/crates/app/signing/src/tests/test_signatures_collector.rs
+++ b/crates/app/signing/src/tests/test_signatures_collector.rs
@@ -90,7 +90,7 @@ impl<S: Signable + 'static> SignaturesCollector<S> {
             SigningFinishEarlyStrategy::default(),
             all_factor_sources_in_profile,
             transactions,
-            SimulatedUser::lazy_sign_minimum([]),
+            SimulatedUser::lazy_sign_minimum([], []),
             SigningPurpose::sign_transaction_primary(),
         )
     }
@@ -113,24 +113,6 @@ impl<S: Signable + 'static> SignaturesCollector<S> {
             all_factor_sources_in_profile,
             transactions,
             SimulatedUser::lazy_always_skip_no_fail(),
-            SigningPurpose::sign_transaction_primary(),
-        )
-    }
-
-    pub(crate) fn test_lazy_skip_some_factors(
-        transactions: impl IntoIterator<Item = SignableWithEntities<S>>,
-        skipping_factors: impl IntoIterator<Item = FactorSourceIDFromHash>,
-    ) -> Self {
-        Self::new_test(
-            SigningFinishEarlyStrategy::default(),
-            FactorSource::sample_all(),
-            transactions,
-            SimulatedUser::new(
-                SimulatedUserMode::Lazy(Laziness::SignMinimum),
-                Some(SimulatedFailures::with_simulated_failures(
-                    skipping_factors,
-                )),
-            ),
             SigningPurpose::sign_transaction_primary(),
         )
     }

--- a/crates/app/signing/src/tests/test_signatures_collector.rs
+++ b/crates/app/signing/src/tests/test_signatures_collector.rs
@@ -90,7 +90,7 @@ impl<S: Signable + 'static> SignaturesCollector<S> {
             SigningFinishEarlyStrategy::default(),
             all_factor_sources_in_profile,
             transactions,
-            SimulatedUser::lazy_sign_minimum([], []),
+            SimulatedUser::lazy_sign_minimum([]),
             SigningPurpose::sign_transaction_primary(),
         )
     }

--- a/crates/common/build-info/Cargo.toml
+++ b/crates/common/build-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "build-info"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/common/bytes/Cargo.toml
+++ b/crates/common/bytes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bytes"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/entity-foundation/Cargo.toml
+++ b/crates/common/entity-foundation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entity-foundation"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/host-info/Cargo.toml
+++ b/crates/common/host-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "host-info"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/identified-vec-of/Cargo.toml
+++ b/crates/common/identified-vec-of/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "identified-vec-of"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/metadata/Cargo.toml
+++ b/crates/common/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metadata"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/network/Cargo.toml
+++ b/crates/common/network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "network"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/numeric/Cargo.toml
+++ b/crates/common/numeric/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numeric"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/short-string/Cargo.toml
+++ b/crates/common/short-string/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "short-string"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/assert-json/Cargo.toml
+++ b/crates/core/assert-json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assert-json"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/collections/Cargo.toml
+++ b/crates/core/collections/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-collections"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/error/Cargo.toml
+++ b/crates/core/error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "error"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/error/src/common_error.rs
+++ b/crates/core/error/src/common_error.rs
@@ -856,6 +856,9 @@ pub enum CommonError {
 
     #[error("Unknown SecurityStructureID {id}")]
     UnknownSecurityStructureID { id: String } = 10246,
+
+    #[error("Signing failed due to too many factor sources were neglected.")]
+    SigningFailedTooManyFactorSourcesNeglected = 10247,
 }
 
 impl CommonError {

--- a/crates/core/has-sample-values/Cargo.toml
+++ b/crates/core/has-sample-values/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "has-sample-values"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/misc/Cargo.toml
+++ b/crates/core/misc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-misc"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/prelude/Cargo.toml
+++ b/crates/core/prelude/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prelude"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/time-utils/Cargo.toml
+++ b/crates/core/time-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "time-utils"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/utils/Cargo.toml
+++ b/crates/core/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-utils"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/addresses/Cargo.toml
+++ b/crates/crypto/addresses/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "addresses"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/cap26-models/Cargo.toml
+++ b/crates/crypto/cap26-models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cap26-models"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/ecc/Cargo.toml
+++ b/crates/crypto/ecc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecc"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/encryption/Cargo.toml
+++ b/crates/crypto/encryption/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "encryption"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/hash/Cargo.toml
+++ b/crates/crypto/hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hash"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/hd/Cargo.toml
+++ b/crates/crypto/hd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hierarchical-deterministic"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/factors/Cargo.toml
+++ b/crates/factors/factors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factors"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/instances-provider/Cargo.toml
+++ b/crates/factors/instances-provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factor-instances-provider"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/keys-collector/Cargo.toml
+++ b/crates/factors/keys-collector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keys-collector"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/next-derivation-index-ephemeral/Cargo.toml
+++ b/crates/factors/next-derivation-index-ephemeral/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "next-derivation-index-ephemeral"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/supporting-types/Cargo.toml
+++ b/crates/factors/supporting-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factors-supporting-types"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/gateway/client-and-api/Cargo.toml
+++ b/crates/gateway/client-and-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gateway-client-and-api"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/gateway/models/Cargo.toml
+++ b/crates/gateway/models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gateway-models"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 

--- a/crates/profile/logic/logic_SPLIT_ME/Cargo.toml
+++ b/crates/profile/logic/logic_SPLIT_ME/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-logic"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/account-for-display/Cargo.toml
+++ b/crates/profile/models/account-for-display/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "account-for-display"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/account-or-persona/Cargo.toml
+++ b/crates/profile/models/account-or-persona/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-account-or-persona"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/account/Cargo.toml
+++ b/crates/profile/models/account/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-account"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/app-preferences/Cargo.toml
+++ b/crates/profile/models/app-preferences/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-app-preferences"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/base-entity/Cargo.toml
+++ b/crates/profile/models/base-entity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-base-entity"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/gateway/Cargo.toml
+++ b/crates/profile/models/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-gateway"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/persona-data/Cargo.toml
+++ b/crates/profile/models/persona-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-persona-data"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/persona/Cargo.toml
+++ b/crates/profile/models/persona/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-persona"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/profile_SPLIT_ME/Cargo.toml
+++ b/crates/profile/models/profile_SPLIT_ME/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 

--- a/crates/profile/models/security-structures/Cargo.toml
+++ b/crates/profile/models/security-structures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-security-structures"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/supporting-types/Cargo.toml
+++ b/crates/profile/models/supporting-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-supporting-types"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/traits/entity-by-address/Cargo.toml
+++ b/crates/profile/traits/entity-by-address/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entity-by-address"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/sargon/Cargo.toml
+++ b/crates/sargon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 resolver = "2" # features enabled in integration test

--- a/crates/sargon/tests/integration/main.rs
+++ b/crates/sargon/tests/integration/main.rs
@@ -1460,7 +1460,7 @@ mod integration_tests {
 
                     // Same result with lazy user, not able to skip without failures.
                     multi_accounts_multi_personas_all_single_factor_controlled_with_sim_user(
-                        SimulatedUser::lazy_sign_minimum([], []),
+                        SimulatedUser::lazy_sign_minimum([]),
                     )
                         .await
                 }
@@ -1489,10 +1489,7 @@ mod integration_tests {
                     .await;
 
                     multi_securified_entities_with_sim_user(Vector {
-                        simulated_user: SimulatedUser::lazy_sign_minimum(
-                            [],
-                            [],
-                        ),
+                        simulated_user: SimulatedUser::lazy_sign_minimum([]),
                         expected: Expected {
                             successful_txs_signature_count: 24,
                             // We always end early, this lazy user was able to skip

--- a/crates/sargon/tests/integration/main.rs
+++ b/crates/sargon/tests/integration/main.rs
@@ -1350,6 +1350,7 @@ mod integration_tests {
                                 SimulatedFailures::with_simulated_failures([
                                     FactorSourceIDFromHash::sample_at(2), // will cause any TX with a7 to fail
                                 ]),
+                                SimulatedSkips::with_simulated_skips([]),
                             ),
                         )),
                         &profile,
@@ -1459,7 +1460,7 @@ mod integration_tests {
 
                     // Same result with lazy user, not able to skip without failures.
                     multi_accounts_multi_personas_all_single_factor_controlled_with_sim_user(
-                        SimulatedUser::lazy_sign_minimum([]),
+                        SimulatedUser::lazy_sign_minimum([], []),
                     )
                         .await
                 }
@@ -1488,7 +1489,10 @@ mod integration_tests {
                     .await;
 
                     multi_securified_entities_with_sim_user(Vector {
-                        simulated_user: SimulatedUser::lazy_sign_minimum([]),
+                        simulated_user: SimulatedUser::lazy_sign_minimum(
+                            [],
+                            [],
+                        ),
                         expected: Expected {
                             successful_txs_signature_count: 24,
                             // We always end early, this lazy user was able to skip

--- a/crates/sargon/tests/integration/main.rs
+++ b/crates/sargon/tests/integration/main.rs
@@ -1350,7 +1350,6 @@ mod integration_tests {
                                 SimulatedFailures::with_simulated_failures([
                                     FactorSourceIDFromHash::sample_at(2), // will cause any TX with a7 to fail
                                 ]),
-                                SimulatedSkips::with_simulated_skips([]),
                             ),
                         )),
                         &profile,

--- a/crates/system/clients/clients/Cargo.toml
+++ b/crates/system/clients/clients/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clients"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 

--- a/crates/system/clients/http/Cargo.toml
+++ b/crates/system/clients/http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http-client"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/drivers/Cargo.toml
+++ b/crates/system/drivers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drivers"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 

--- a/crates/system/interactors/Cargo.toml
+++ b/crates/system/interactors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interactors"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/accounts/Cargo.toml
+++ b/crates/system/os/accounts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-accounts"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/factors/Cargo.toml
+++ b/crates/system/os/factors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-factors"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/os/Cargo.toml
+++ b/crates/system/os/os/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/security-center/Cargo.toml
+++ b/crates/system/os/security-center/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-security-center"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/signing/Cargo.toml
+++ b/crates/system/os/signing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-signing"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/signing/src/sargon_os_signing.rs
+++ b/crates/system/os/signing/src/sargon_os_signing.rs
@@ -99,7 +99,7 @@ impl OsSigning for SargonOS {
 
             signable.signed(signatures_per_owner)
         } else {
-            Err(CommonError::SigningRejected)
+            Err(CommonError::SigningFailedTooManyFactorSourcesNeglected)
         }
     }
 }
@@ -272,7 +272,10 @@ mod test {
             .sign_transaction(signable.clone(), RoleKind::Primary)
             .await;
 
-        assert_eq!(outcome, Err(CommonError::SigningRejected));
+        assert_eq!(
+            outcome,
+            Err(CommonError::SigningFailedTooManyFactorSourcesNeglected)
+        );
     }
 
     #[actix_rt::test]
@@ -348,7 +351,10 @@ mod test {
             .sign_transaction(signable.clone(), RoleKind::Primary)
             .await;
 
-        assert_eq!(outcome, Err(CommonError::SigningRejected));
+        assert_eq!(
+            outcome,
+            Err(CommonError::SigningFailedTooManyFactorSourcesNeglected)
+        );
     }
 
     #[actix_rt::test]
@@ -370,7 +376,10 @@ mod test {
             .sign_subintent(signable.clone(), RoleKind::Primary)
             .await;
 
-        assert_eq!(outcome, Err(CommonError::SigningRejected));
+        assert_eq!(
+            outcome,
+            Err(CommonError::SigningFailedTooManyFactorSourcesNeglected)
+        );
     }
 
     #[actix_rt::test]

--- a/crates/system/os/signing/src/sargon_os_signing.rs
+++ b/crates/system/os/signing/src/sargon_os_signing.rs
@@ -258,7 +258,7 @@ mod test {
         let profile = Profile::sample();
         let sut = boot(
             Some(profile.clone()),
-            Some(SigningFailure::NeglectedFactorSources(vec![
+            Some(SigningFailure::FailingFactorSources(vec![
                 profile.device_factor_sources().first().unwrap().id,
             ])),
         )
@@ -357,7 +357,7 @@ mod test {
         let profile = Profile::sample();
         let sut = boot(
             Some(profile.clone()),
-            Some(SigningFailure::NeglectedFactorSources(vec![
+            Some(SigningFailure::FailingFactorSources(vec![
                 profile.device_factor_sources().first().unwrap().id,
             ])),
         )
@@ -462,7 +462,7 @@ mod test {
         match maybe_signing_failure {
             None => SimulatedUser::<S>::prudent_no_fail(),
             Some(failure) => match failure {
-                SigningFailure::NeglectedFactorSources(factor_sources) => {
+                SigningFailure::FailingFactorSources(factor_sources) => {
                     SimulatedUser::<S>::prudent_with_failures(
                         SimulatedFailures::with_simulated_failures(
                             factor_sources.clone(),
@@ -503,7 +503,7 @@ mod test {
     }
 
     enum SigningFailure {
-        NeglectedFactorSources(Vec<FactorSourceIDFromHash>),
+        FailingFactorSources(Vec<FactorSourceIDFromHash>),
         SkippingFactorSources(Vec<FactorSourceIDFromHash>),
         UserRejected,
     }

--- a/crates/system/os/signing/src/sargon_os_signing.rs
+++ b/crates/system/os/signing/src/sargon_os_signing.rs
@@ -348,8 +348,7 @@ mod test {
             .sign_transaction(signable.clone(), RoleKind::Primary)
             .await;
 
-        println!("{:?}", outcome);
-        //assert_eq!(outcome, Err(CommonError::SigningRejected));
+        assert_eq!(outcome, Err(CommonError::SigningRejected));
     }
 
     #[actix_rt::test]

--- a/crates/system/os/signing/src/sargon_os_signing.rs
+++ b/crates/system/os/signing/src/sargon_os_signing.rs
@@ -480,10 +480,8 @@ mod test {
                 }
                 SigningFailure::UserRejected => SimulatedUser::<S>::rejecting(),
                 SigningFailure::SkippingFactorSources(factor_sources) => {
-                    SimulatedUser::<S>::prudent_with_skips(
-                        SimulatedSkips::with_simulated_skips(
-                            factor_sources.clone(),
-                        ),
+                    SimulatedUser::<S>::skipping_specific(
+                        factor_sources.iter().cloned().collect(),
                     )
                 }
             },

--- a/crates/system/os/signing/src/sargon_os_signing.rs
+++ b/crates/system/os/signing/src/sargon_os_signing.rs
@@ -114,7 +114,7 @@ mod test {
     #[actix_rt::test]
     async fn test_sign_auth_success() {
         let profile = Profile::sample();
-        let sut = boot_with_profile(&profile, None).await;
+        let sut = boot(Some(profile.clone()), None).await;
         let all_accounts = profile.accounts_on_current_network().unwrap();
         let account = all_accounts.first().unwrap();
         let nonce = DappToWalletInteractionAuthChallengeNonce::sample();
@@ -150,7 +150,7 @@ mod test {
         let profile = Profile::sample();
 
         let sut =
-            boot_with_profile(&profile, Some(SigningFailure::UserRejected))
+            boot(Some(profile.clone()), Some(SigningFailure::UserRejected))
                 .await;
 
         let all_accounts = profile.accounts_on_current_network().unwrap();
@@ -178,7 +178,7 @@ mod test {
     #[actix_rt::test]
     async fn test_sign_transaction_intent_success() {
         let profile = Profile::sample();
-        let sut = boot_with_profile(&profile, None).await;
+        let sut = boot(Some(profile.clone()), None).await;
 
         let (signable, entities) = get_signable_with_entities::<
             TransactionIntent,
@@ -196,7 +196,7 @@ mod test {
     #[actix_rt::test]
     async fn test_sign_subintent_success() {
         let profile = Profile::sample();
-        let sut = boot_with_profile(&profile, None).await;
+        let sut = boot(Some(profile.clone()), None).await;
 
         let (signable, entities) =
             get_signable_with_entities::<Subintent>(&sut.profile().unwrap());
@@ -216,7 +216,7 @@ mod test {
     #[actix_rt::test]
     async fn test_sign_transaction_intent_only_with_irrelevant_entity() {
         let profile = Profile::sample();
-        let sut = boot_with_profile(&profile, None).await;
+        let sut = boot(Some(profile.clone()), None).await;
 
         let irrelevant_account = Account::sample_mainnet_third();
         let transaction = TransactionIntent::sample_entities_requiring_auth(
@@ -235,7 +235,7 @@ mod test {
     #[actix_rt::test]
     async fn test_sign_transaction_intent_containing_irrelevant_entity() {
         let profile = Profile::sample();
-        let sut = boot_with_profile(&profile, None).await;
+        let sut = boot(Some(profile.clone()), None).await;
 
         let irrelevant_account = Account::sample_mainnet_third();
         let relevant_account = Account::sample_mainnet();
@@ -256,8 +256,8 @@ mod test {
     async fn test_sign_transaction_intent_rejected_due_to_all_factors_neglected(
     ) {
         let profile = Profile::sample();
-        let sut = boot_with_profile(
-            &profile,
+        let sut = boot(
+            Some(profile.clone()),
             Some(SigningFailure::NeglectedFactorSources(vec![
                 profile.device_factor_sources().first().unwrap().id,
             ])),
@@ -276,11 +276,88 @@ mod test {
     }
 
     #[actix_rt::test]
+    async fn test_sign_transaction_prudent_user_skips_factor() {
+        let device = FactorSource::sample_at(0);
+        let account_device = Account::sample_unsecurified_mainnet(
+            "Device",
+            HierarchicalDeterministicFactorInstance::new_for_entity(
+                device.clone().as_device().unwrap().id,
+                CAP26EntityKind::Account,
+                Hardened::from_local_key_space_unsecurified(0u32).unwrap(),
+            ),
+        );
+        let ledger1 = FactorSource::sample_at(1);
+        let account_ledger1 = Account::sample_unsecurified_mainnet(
+            "Ledger1",
+            HierarchicalDeterministicFactorInstance::new_for_entity(
+                ledger1.clone().as_ledger().unwrap().id,
+                CAP26EntityKind::Account,
+                Hardened::from_local_key_space_unsecurified(0u32).unwrap(),
+            ),
+        );
+        let ledger2 = FactorSource::sample_at(2);
+        let account_ledger2 = Account::sample_unsecurified_mainnet(
+            "Ledger2",
+            HierarchicalDeterministicFactorInstance::new_for_entity(
+                ledger2.clone().as_ledger().unwrap().id,
+                CAP26EntityKind::Account,
+                Hardened::from_local_key_space_unsecurified(0u32).unwrap(),
+            ),
+        );
+
+        let profile = Profile::with(
+            Header::sample(),
+            FactorSources::from_iter([
+                device.clone(),
+                ledger1.clone(),
+                ledger2.clone(),
+            ]),
+            AppPreferences::default(),
+            ProfileNetworks::just(ProfileNetwork::new(
+                NetworkID::Mainnet,
+                [
+                    account_device.clone(),
+                    account_ledger1.clone(),
+                    account_ledger2.clone(),
+                ],
+                [],
+                AuthorizedDapps::new(),
+                ResourcePreferences::new(),
+            )),
+        );
+
+        let sut = boot(
+            Some(profile.clone()),
+            Some(SigningFailure::SkippingFactorSources(vec![
+                ledger1.as_ledger().unwrap().id,
+            ])),
+        )
+        .await;
+
+        let signable =
+            TransactionIntent::sample_entity_addresses_requiring_auth(
+                [
+                    account_device.address.clone(),
+                    account_ledger1.address.clone(),
+                    account_ledger2.address.clone(),
+                ],
+                [],
+            );
+
+        let outcome = sut
+            .sign_transaction(signable.clone(), RoleKind::Primary)
+            .await;
+
+        println!("{:?}", outcome);
+        //assert_eq!(outcome, Err(CommonError::SigningRejected));
+    }
+
+    #[actix_rt::test]
     async fn test_sign_transaction_subintent_rejected_due_to_all_factors_neglected(
     ) {
         let profile = Profile::sample();
-        let sut = boot_with_profile(
-            &profile,
+        let sut = boot(
+            Some(profile.clone()),
             Some(SigningFailure::NeglectedFactorSources(vec![
                 profile.device_factor_sources().first().unwrap().id,
             ])),
@@ -328,7 +405,7 @@ mod test {
     async fn test_sign_fail_due_to_user_rejecting() {
         let profile = Profile::sample();
         let sut =
-            boot_with_profile(&profile, Some(SigningFailure::UserRejected))
+            boot(Some(profile.clone()), Some(SigningFailure::UserRejected))
                 .await;
 
         let (signable, _) =
@@ -341,14 +418,17 @@ mod test {
         assert_eq!(outcome, Err(CommonError::SigningRejected));
     }
 
-    async fn boot_with_profile(
-        profile: &Profile,
+    async fn boot(
+        profile: Option<Profile>,
         maybe_signing_failure: Option<SigningFailure>,
     ) -> Arc<SUT> {
         let secure_storage_driver = EphemeralSecureStorage::new();
-        let secure_storage_client =
-            SecureStorageClient::new(secure_storage_driver.clone());
-        secure_storage_client.save_profile(profile).await.unwrap();
+
+        if let Some(profile) = profile {
+            let secure_storage_client =
+                SecureStorageClient::new(secure_storage_driver.clone());
+            secure_storage_client.save_profile(&profile).await.unwrap();
+        }
 
         let test_drivers = Drivers::with_secure_storage(secure_storage_driver);
         let mut clients = Clients::new(Bios::new(test_drivers));
@@ -391,6 +471,13 @@ mod test {
                     )
                 }
                 SigningFailure::UserRejected => SimulatedUser::<S>::rejecting(),
+                SigningFailure::SkippingFactorSources(factor_sources) => {
+                    SimulatedUser::<S>::prudent_with_skips(
+                        SimulatedSkips::with_simulated_skips(
+                            factor_sources.clone(),
+                        ),
+                    )
+                }
             },
         }
     }
@@ -418,6 +505,7 @@ mod test {
 
     enum SigningFailure {
         NeglectedFactorSources(Vec<FactorSourceIDFromHash>),
+        SkippingFactorSources(Vec<FactorSourceIDFromHash>),
         UserRejected,
     }
 }

--- a/crates/system/os/transaction/Cargo.toml
+++ b/crates/system/os/transaction/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-transaction"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/profile-state-holder/Cargo.toml
+++ b/crates/system/profile-state-holder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-state-holder"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/sub-systems/Cargo.toml
+++ b/crates/system/sub-systems/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sub-systems"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/transaction/foundation/Cargo.toml
+++ b/crates/transaction/foundation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transaction-foundation"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/transaction/manifests/Cargo.toml
+++ b/crates/transaction/manifests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "manifests"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 

--- a/crates/transaction/models/Cargo.toml
+++ b/crates/transaction/models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transaction-models"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 

--- a/crates/uniffi/conversion-macros/Cargo.toml
+++ b/crates/uniffi/conversion-macros/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "sargon-uniffi-conversion-macros"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 
 [dependencies]

--- a/crates/uniffi/uniffi_SPLIT_ME/Cargo.toml
+++ b/crates/uniffi/uniffi_SPLIT_ME/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-uniffi"
-version = "1.1.110"
+version = "1.1.111"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/uniffi/uniffi_SPLIT_ME/src/core/error/common_error.rs
+++ b/crates/uniffi/uniffi_SPLIT_ME/src/core/error/common_error.rs
@@ -858,6 +858,9 @@ pub enum CommonError {
 
     #[error("Unknown SecurityStructureID {id}")]
     UnknownSecurityStructureID { id: String } = 10246,
+
+    #[error("Signing failed due to too many factor sources were neglected.")]
+    SigningFailedTooManyFactorSourcesNeglected = 10247,
 }
 
 #[uniffi::export]

--- a/jvm/sargon-android/build.gradle.kts
+++ b/jvm/sargon-android/build.gradle.kts
@@ -97,7 +97,7 @@ cargoNdk {
     targets = arrayListOf("arm64", "arm")
     module = "../"
     librariesNames = arrayListOf("libsargon_uniffi.so")
-    extraCargoBuildArguments = arrayListOf("--all")
+    extraCargoBuildArguments = arrayListOf("--locked", "--all")
 }
 
 tasks.withType<Test> {


### PR DESCRIPTION
Updated mono sign, to return no request when there are no remaining per transaction requests. When a user skips a factor source, the signature collector will iterate to the next factor source. There if there are no more remaining still to be signed as valid transactions, the iterator continues. This ends up ending the collector's signing process, with an unsuccessful outcome.

* Updated the tests to incorporate skipping of a factor source instead of just failing one.
* Added some missing kotlin extensions needed in host to sign, with a mnemonic, multiple per transaction signables at once and also an extension to derive factor source ids. Both were required for the integration with the host