### PR TITLE
Add UniFFI exported "method" for `DerivationPath` `to_canonical_bip32_string`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1814,7 +1814,6 @@ dependencies = [
  "numeric",
  "paste",
  "prelude",
- "pretty_assertions",
  "radix-common",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1814,6 +1814,7 @@ dependencies = [
  "numeric",
  "paste",
  "prelude",
+ "pretty_assertions",
  "radix-common",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "account-for-display"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "addresses",
  "derive_more",
@@ -49,10 +49,10 @@ dependencies = [
 
 [[package]]
 name = "addresses"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "assert-json",
- "bytes 1.1.113",
+ "bytes 1.1.114",
  "cap26-models",
  "core-utils",
  "derive_more",
@@ -246,7 +246,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "assert-json"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "assert-json-diff",
  "error",
@@ -546,7 +546,7 @@ dependencies = [
 
 [[package]]
 name = "build-info"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "assert-json",
  "cargo_toml",
@@ -573,7 +573,7 @@ checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
 
 [[package]]
 name = "bytes"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "assert-json",
  "delegate",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "cap26-models"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "assert-json",
  "derive_more",
@@ -748,7 +748,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "clients"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -808,7 +808,7 @@ checksum = "0d8a42181e0652c2997ae4d217f25b63c5337a52fd2279736e97b832fa0a3cff"
 
 [[package]]
 name = "core-collections"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "has-sample-values",
  "indexmap 2.7.0",
@@ -835,7 +835,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-misc"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "assert-json",
  "core-utils",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "core-utils"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "error",
  "iso8601-timestamp",
@@ -1084,7 +1084,7 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "drivers"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -1108,10 +1108,10 @@ dependencies = [
 
 [[package]]
 name = "ecc"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "assert-json",
- "bytes 1.1.113",
+ "bytes 1.1.114",
  "derive_more",
  "enum-as-inner",
  "error",
@@ -1210,11 +1210,11 @@ dependencies = [
 
 [[package]]
 name = "encryption"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "aes-gcm",
  "assert-json",
- "bytes 1.1.113",
+ "bytes 1.1.114",
  "derive_more",
  "error",
  "has-sample-values",
@@ -1231,7 +1231,7 @@ dependencies = [
 
 [[package]]
 name = "entity-by-address"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "addresses",
  "error",
@@ -1243,7 +1243,7 @@ dependencies = [
 
 [[package]]
 name = "entity-foundation"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "assert-json",
  "derive_more",
@@ -1318,7 +1318,7 @@ dependencies = [
 
 [[package]]
 name = "error"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "derive_more",
  "log",
@@ -1377,7 +1377,7 @@ dependencies = [
 
 [[package]]
 name = "factor-instances-provider"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -1403,9 +1403,9 @@ dependencies = [
 
 [[package]]
 name = "factors"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
- "bytes 1.1.113",
+ "bytes 1.1.114",
  "cap26-models",
  "core-collections",
  "core-misc",
@@ -1440,7 +1440,7 @@ dependencies = [
 
 [[package]]
 name = "factors-supporting-types"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "async-trait",
  "error",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-client-and-api"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -1613,7 +1613,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-models"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "addresses",
  "assert-json",
@@ -1718,7 +1718,7 @@ dependencies = [
 
 [[package]]
 name = "has-sample-values"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "error",
  "indexmap 2.7.0",
@@ -1729,9 +1729,9 @@ dependencies = [
 
 [[package]]
 name = "hash"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
- "bytes 1.1.113",
+ "bytes 1.1.114",
  "derive_more",
  "prelude",
  "radix-common",
@@ -1795,11 +1795,11 @@ dependencies = [
 
 [[package]]
 name = "hierarchical-deterministic"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "assert-json",
  "bip39",
- "bytes 1.1.113",
+ "bytes 1.1.114",
  "cap26-models",
  "derive_more",
  "ecc",
@@ -1842,13 +1842,13 @@ dependencies = [
 
 [[package]]
 name = "home-cards"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "actix-rt",
  "addresses",
  "async-trait",
  "base64",
- "bytes 1.1.113",
+ "bytes 1.1.114",
  "core-utils",
  "derive_more",
  "drivers",
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "host-info"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "assert-json",
  "derive_more",
@@ -1915,10 +1915,10 @@ dependencies = [
 
 [[package]]
 name = "http-client"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "actix-rt",
- "bytes 1.1.113",
+ "bytes 1.1.114",
  "core-utils",
  "drivers",
  "error",
@@ -2143,7 +2143,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "identified-vec-of"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "assert-json",
  "derive_more",
@@ -2216,7 +2216,7 @@ dependencies = [
 
 [[package]]
 name = "interactors"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -2336,7 +2336,7 @@ dependencies = [
 
 [[package]]
 name = "key-derivation-traits"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "addresses",
  "async-trait",
@@ -2354,7 +2354,7 @@ dependencies = [
 
 [[package]]
 name = "keys-collector"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -2443,7 +2443,7 @@ dependencies = [
 
 [[package]]
 name = "manifests"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "account-for-display",
  "addresses",
@@ -2483,7 +2483,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "metadata"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "derive_more",
  "has-sample-values",
@@ -2583,7 +2583,7 @@ dependencies = [
 
 [[package]]
 name = "network"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "assert-json",
  "enum-iterator",
@@ -2599,7 +2599,7 @@ dependencies = [
 
 [[package]]
 name = "next-derivation-index-ephemeral"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "addresses",
  "assert-json",
@@ -2675,9 +2675,9 @@ dependencies = [
 
 [[package]]
 name = "numeric"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
- "bytes 1.1.113",
+ "bytes 1.1.114",
  "delegate",
  "derive_more",
  "enum-iterator",
@@ -2897,7 +2897,7 @@ dependencies = [
 
 [[package]]
 name = "prelude"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "radix-engine",
  "radix-engine-toolkit",
@@ -2934,7 +2934,7 @@ dependencies = [
 
 [[package]]
 name = "profile"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "account-for-display",
  "addresses",
@@ -2978,7 +2978,7 @@ dependencies = [
 
 [[package]]
 name = "profile-account"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "account-for-display",
  "addresses",
@@ -2998,7 +2998,7 @@ dependencies = [
 
 [[package]]
 name = "profile-account-or-persona"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "cap26-models",
  "derive_more",
@@ -3015,7 +3015,7 @@ dependencies = [
 
 [[package]]
 name = "profile-app-preferences"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "addresses",
  "core-misc",
@@ -3038,7 +3038,7 @@ dependencies = [
 
 [[package]]
 name = "profile-base-entity"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "addresses",
  "derive_more",
@@ -3061,7 +3061,7 @@ dependencies = [
 
 [[package]]
 name = "profile-gateway"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "addresses",
  "assert-json",
@@ -3085,7 +3085,7 @@ dependencies = [
 
 [[package]]
 name = "profile-logic"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "addresses",
  "derive_more",
@@ -3107,7 +3107,7 @@ dependencies = [
 
 [[package]]
 name = "profile-persona"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "addresses",
  "cap26-models",
@@ -3128,7 +3128,7 @@ dependencies = [
 
 [[package]]
 name = "profile-persona-data"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "addresses",
  "assert-json",
@@ -3147,7 +3147,7 @@ dependencies = [
 
 [[package]]
 name = "profile-security-structures"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "addresses",
  "cap26-models",
@@ -3175,7 +3175,7 @@ dependencies = [
 
 [[package]]
 name = "profile-state-holder"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "derive_more",
  "error",
@@ -3190,7 +3190,7 @@ dependencies = [
 
 [[package]]
 name = "profile-supporting-types"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "addresses",
  "derive_more",
@@ -3279,14 +3279,14 @@ dependencies = [
 
 [[package]]
 name = "radix-connect"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "actix-rt",
  "addresses",
  "assert-json",
  "async-trait",
  "base64",
- "bytes 1.1.113",
+ "bytes 1.1.114",
  "core-misc",
  "core-utils",
  "derive_more",
@@ -3314,10 +3314,10 @@ dependencies = [
 
 [[package]]
 name = "radix-connect-models"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "addresses",
- "bytes 1.1.113",
+ "bytes 1.1.114",
  "core-misc",
  "derive_more",
  "error",
@@ -3759,7 +3759,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -3823,7 +3823,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -3850,7 +3850,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-accounts"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -3873,7 +3873,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-factors"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -3896,7 +3896,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-security-center"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "actix-rt",
  "derive_more",
@@ -3912,7 +3912,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-signing"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -3938,7 +3938,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-transaction"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "actix-rt",
  "async-std",
@@ -3967,7 +3967,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-uniffi"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -4024,7 +4024,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-uniffi-conversion-macros"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4197,7 +4197,7 @@ dependencies = [
 
 [[package]]
 name = "security-center"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "addresses",
  "assert-json",
@@ -4365,7 +4365,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "short-string"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "arraystring",
  "assert-json",
@@ -4400,13 +4400,13 @@ dependencies = [
 
 [[package]]
 name = "signing"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "actix-rt",
  "addresses",
  "assert-json",
  "async-trait",
- "bytes 1.1.113",
+ "bytes 1.1.114",
  "cap26-models",
  "core-collections",
  "core-misc",
@@ -4438,10 +4438,10 @@ dependencies = [
 
 [[package]]
 name = "signing-traits"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "async-trait",
- "bytes 1.1.113",
+ "bytes 1.1.114",
  "core-collections",
  "derive_more",
  "ecc",
@@ -4606,7 +4606,7 @@ dependencies = [
 
 [[package]]
 name = "sub-systems"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "derive_more",
  "drivers",
@@ -4765,7 +4765,7 @@ dependencies = [
 
 [[package]]
 name = "time-utils"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "iso8601-timestamp",
  "prelude",
@@ -4915,10 +4915,10 @@ dependencies = [
 
 [[package]]
 name = "transaction-foundation"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "assert-json",
- "bytes 1.1.113",
+ "bytes 1.1.114",
  "derive_more",
  "has-sample-values",
  "paste",
@@ -4930,10 +4930,10 @@ dependencies = [
 
 [[package]]
 name = "transaction-models"
-version = "1.1.113"
+version = "1.1.114"
 dependencies = [
  "addresses",
- "bytes 1.1.113",
+ "bytes 1.1.114",
  "cargo_toml",
  "core-collections",
  "core-misc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "account-for-display"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "addresses",
  "derive_more",
@@ -49,10 +49,10 @@ dependencies = [
 
 [[package]]
 name = "addresses"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "assert-json",
- "bytes 1.1.114",
+ "bytes 1.1.115",
  "cap26-models",
  "core-utils",
  "derive_more",
@@ -246,7 +246,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "assert-json"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "assert-json-diff",
  "error",
@@ -546,7 +546,7 @@ dependencies = [
 
 [[package]]
 name = "build-info"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "assert-json",
  "cargo_toml",
@@ -573,7 +573,7 @@ checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
 
 [[package]]
 name = "bytes"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "assert-json",
  "delegate",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "cap26-models"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "assert-json",
  "derive_more",
@@ -748,7 +748,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "clients"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -808,7 +808,7 @@ checksum = "0d8a42181e0652c2997ae4d217f25b63c5337a52fd2279736e97b832fa0a3cff"
 
 [[package]]
 name = "core-collections"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "has-sample-values",
  "indexmap 2.7.0",
@@ -835,7 +835,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-misc"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "assert-json",
  "core-utils",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "core-utils"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "error",
  "iso8601-timestamp",
@@ -1084,7 +1084,7 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "drivers"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -1108,10 +1108,10 @@ dependencies = [
 
 [[package]]
 name = "ecc"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "assert-json",
- "bytes 1.1.114",
+ "bytes 1.1.115",
  "derive_more",
  "enum-as-inner",
  "error",
@@ -1210,11 +1210,11 @@ dependencies = [
 
 [[package]]
 name = "encryption"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "aes-gcm",
  "assert-json",
- "bytes 1.1.114",
+ "bytes 1.1.115",
  "derive_more",
  "error",
  "has-sample-values",
@@ -1231,7 +1231,7 @@ dependencies = [
 
 [[package]]
 name = "entity-by-address"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "addresses",
  "error",
@@ -1243,7 +1243,7 @@ dependencies = [
 
 [[package]]
 name = "entity-foundation"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "assert-json",
  "derive_more",
@@ -1318,7 +1318,7 @@ dependencies = [
 
 [[package]]
 name = "error"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "derive_more",
  "log",
@@ -1377,7 +1377,7 @@ dependencies = [
 
 [[package]]
 name = "factor-instances-provider"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -1403,9 +1403,9 @@ dependencies = [
 
 [[package]]
 name = "factors"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
- "bytes 1.1.114",
+ "bytes 1.1.115",
  "cap26-models",
  "core-collections",
  "core-misc",
@@ -1440,7 +1440,7 @@ dependencies = [
 
 [[package]]
 name = "factors-supporting-types"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "async-trait",
  "error",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-client-and-api"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -1613,7 +1613,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-models"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "addresses",
  "assert-json",
@@ -1718,7 +1718,7 @@ dependencies = [
 
 [[package]]
 name = "has-sample-values"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "error",
  "indexmap 2.7.0",
@@ -1729,9 +1729,9 @@ dependencies = [
 
 [[package]]
 name = "hash"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
- "bytes 1.1.114",
+ "bytes 1.1.115",
  "derive_more",
  "prelude",
  "radix-common",
@@ -1795,11 +1795,11 @@ dependencies = [
 
 [[package]]
 name = "hierarchical-deterministic"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "assert-json",
  "bip39",
- "bytes 1.1.114",
+ "bytes 1.1.115",
  "cap26-models",
  "derive_more",
  "ecc",
@@ -1842,13 +1842,13 @@ dependencies = [
 
 [[package]]
 name = "home-cards"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "actix-rt",
  "addresses",
  "async-trait",
  "base64",
- "bytes 1.1.114",
+ "bytes 1.1.115",
  "core-utils",
  "derive_more",
  "drivers",
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "host-info"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "assert-json",
  "derive_more",
@@ -1915,10 +1915,10 @@ dependencies = [
 
 [[package]]
 name = "http-client"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "actix-rt",
- "bytes 1.1.114",
+ "bytes 1.1.115",
  "core-utils",
  "drivers",
  "error",
@@ -2143,7 +2143,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "identified-vec-of"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "assert-json",
  "derive_more",
@@ -2216,7 +2216,7 @@ dependencies = [
 
 [[package]]
 name = "interactors"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -2336,7 +2336,7 @@ dependencies = [
 
 [[package]]
 name = "key-derivation-traits"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "addresses",
  "async-trait",
@@ -2354,7 +2354,7 @@ dependencies = [
 
 [[package]]
 name = "keys-collector"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -2443,7 +2443,7 @@ dependencies = [
 
 [[package]]
 name = "manifests"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "account-for-display",
  "addresses",
@@ -2483,7 +2483,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "metadata"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "derive_more",
  "has-sample-values",
@@ -2583,7 +2583,7 @@ dependencies = [
 
 [[package]]
 name = "network"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "assert-json",
  "enum-iterator",
@@ -2599,7 +2599,7 @@ dependencies = [
 
 [[package]]
 name = "next-derivation-index-ephemeral"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "addresses",
  "assert-json",
@@ -2675,9 +2675,9 @@ dependencies = [
 
 [[package]]
 name = "numeric"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
- "bytes 1.1.114",
+ "bytes 1.1.115",
  "delegate",
  "derive_more",
  "enum-iterator",
@@ -2897,7 +2897,7 @@ dependencies = [
 
 [[package]]
 name = "prelude"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "radix-engine",
  "radix-engine-toolkit",
@@ -2934,7 +2934,7 @@ dependencies = [
 
 [[package]]
 name = "profile"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "account-for-display",
  "addresses",
@@ -2978,7 +2978,7 @@ dependencies = [
 
 [[package]]
 name = "profile-account"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "account-for-display",
  "addresses",
@@ -2998,7 +2998,7 @@ dependencies = [
 
 [[package]]
 name = "profile-account-or-persona"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "cap26-models",
  "derive_more",
@@ -3015,7 +3015,7 @@ dependencies = [
 
 [[package]]
 name = "profile-app-preferences"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "addresses",
  "core-misc",
@@ -3038,7 +3038,7 @@ dependencies = [
 
 [[package]]
 name = "profile-base-entity"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "addresses",
  "derive_more",
@@ -3061,7 +3061,7 @@ dependencies = [
 
 [[package]]
 name = "profile-gateway"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "addresses",
  "assert-json",
@@ -3085,7 +3085,7 @@ dependencies = [
 
 [[package]]
 name = "profile-logic"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "addresses",
  "derive_more",
@@ -3107,7 +3107,7 @@ dependencies = [
 
 [[package]]
 name = "profile-persona"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "addresses",
  "cap26-models",
@@ -3128,7 +3128,7 @@ dependencies = [
 
 [[package]]
 name = "profile-persona-data"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "addresses",
  "assert-json",
@@ -3147,7 +3147,7 @@ dependencies = [
 
 [[package]]
 name = "profile-security-structures"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "addresses",
  "cap26-models",
@@ -3175,7 +3175,7 @@ dependencies = [
 
 [[package]]
 name = "profile-state-holder"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "derive_more",
  "error",
@@ -3190,7 +3190,7 @@ dependencies = [
 
 [[package]]
 name = "profile-supporting-types"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "addresses",
  "derive_more",
@@ -3279,14 +3279,14 @@ dependencies = [
 
 [[package]]
 name = "radix-connect"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "actix-rt",
  "addresses",
  "assert-json",
  "async-trait",
  "base64",
- "bytes 1.1.114",
+ "bytes 1.1.115",
  "core-misc",
  "core-utils",
  "derive_more",
@@ -3314,10 +3314,10 @@ dependencies = [
 
 [[package]]
 name = "radix-connect-models"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "addresses",
- "bytes 1.1.114",
+ "bytes 1.1.115",
  "core-misc",
  "derive_more",
  "error",
@@ -3759,7 +3759,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -3823,7 +3823,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -3850,7 +3850,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-accounts"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -3873,7 +3873,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-factors"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -3896,7 +3896,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-security-center"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "actix-rt",
  "derive_more",
@@ -3912,7 +3912,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-signing"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -3938,7 +3938,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-transaction"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "actix-rt",
  "async-std",
@@ -3967,7 +3967,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-uniffi"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -4024,7 +4024,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-uniffi-conversion-macros"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4197,7 +4197,7 @@ dependencies = [
 
 [[package]]
 name = "security-center"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "addresses",
  "assert-json",
@@ -4365,7 +4365,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "short-string"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "arraystring",
  "assert-json",
@@ -4400,13 +4400,13 @@ dependencies = [
 
 [[package]]
 name = "signing"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "actix-rt",
  "addresses",
  "assert-json",
  "async-trait",
- "bytes 1.1.114",
+ "bytes 1.1.115",
  "cap26-models",
  "core-collections",
  "core-misc",
@@ -4438,10 +4438,10 @@ dependencies = [
 
 [[package]]
 name = "signing-traits"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "async-trait",
- "bytes 1.1.114",
+ "bytes 1.1.115",
  "core-collections",
  "derive_more",
  "ecc",
@@ -4606,7 +4606,7 @@ dependencies = [
 
 [[package]]
 name = "sub-systems"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "derive_more",
  "drivers",
@@ -4765,7 +4765,7 @@ dependencies = [
 
 [[package]]
 name = "time-utils"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "iso8601-timestamp",
  "prelude",
@@ -4915,10 +4915,10 @@ dependencies = [
 
 [[package]]
 name = "transaction-foundation"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "assert-json",
- "bytes 1.1.114",
+ "bytes 1.1.115",
  "derive_more",
  "has-sample-values",
  "paste",
@@ -4930,10 +4930,10 @@ dependencies = [
 
 [[package]]
 name = "transaction-models"
-version = "1.1.114"
+version = "1.1.115"
 dependencies = [
  "addresses",
- "bytes 1.1.114",
+ "bytes 1.1.115",
  "cargo_toml",
  "core-collections",
  "core-misc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,6 +184,9 @@ default-members = [
     # or cargo test --workspace to test it.
 ]
 
+[profile.dev]
+opt-level = 0
+
 [profile.release]
 incremental = false
 panic = 'unwind'
@@ -309,7 +312,9 @@ sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v1.3.0" }
 
 
 # ==== EXTERNAL DEPENDENCIES ====
-actix-rt = { version = "2.10.0", default-features = false, features = ["macros"] }
+actix-rt = { version = "2.10.0", default-features = false, features = [
+    "macros",
+] }
 aes-gcm = { version = "=0.10.3", default-features = false, features = [
     "aes",
     "alloc",
@@ -331,7 +336,7 @@ bip39 = { version = "=2.0.0", default-features = true, features = [
 
 camino = { version = "1.0.8", default-features = false }
 cargo_toml = { version = "0.15.3", default-features = false }
-clap = { version =  "4.5.1", default-features = false, features = [
+clap = { version = "4.5.1", default-features = false, features = [
     "std",
     "derive",
 ] }
@@ -370,7 +375,9 @@ log = { version = "0.4.20", default-features = false }
 once_cell = { version = "1.19.0", default-features = false }
 paste = { version = "1.0.14", default-features = false }
 preinterpret = { version = "0.2.0", default-features = false }
-pretty_assertions = { version = "1.4.0", default-features = false, features = ["std"] }
+pretty_assertions = { version = "1.4.0", default-features = false, features = [
+    "std",
+] }
 pretty_env_logger = { version = "0.5.0", default-features = false }
 rand = { version = "0.8.5", default-features = false, features = ["getrandom"] }
 regex = { version = "1.9.3", default-features = false }
@@ -378,14 +385,16 @@ reqwest = { version = "0.12.3", default-features = false, features = [
     "native-tls-vendored",
 ] }
 serde_with = { version = "3.4.0", default-features = false }
-serde = { version = "1.0.193", default-features = false, features = ["derive", "rc", "std"] }
+serde = { version = "1.0.193", default-features = false, features = [
+    "derive",
+    "rc",
+    "std",
+] }
 serde_json = { version = "1.0.108", default-features = false, features = [
     "preserve_order",
 ] }
 serde_repr = { version = "0.1.17", default-features = false }
-strum = { version = "0.26.1", default-features = false, features = [
-    "derive",
-] }
+strum = { version = "0.26.1", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.50", default-features = false }
 url = { version = "2.5.0", default-features = false, features = ["serde"] }
 uniffi = { git = "https://github.com/mozilla/uniffi-rs/", rev = "9127d4d9cfb8ff8372e70f2e4e0eb36bc06f146d", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,9 +184,6 @@ default-members = [
     # or cargo test --workspace to test it.
 ]
 
-[profile.dev]
-opt-level = 0
-
 [profile.release]
 incremental = false
 panic = 'unwind'

--- a/crates/app/home-cards/Cargo.toml
+++ b/crates/app/home-cards/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "home-cards"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/home-cards/Cargo.toml
+++ b/crates/app/home-cards/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "home-cards"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/key-derivation-traits/Cargo.toml
+++ b/crates/app/key-derivation-traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "key-derivation-traits"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/key-derivation-traits/Cargo.toml
+++ b/crates/app/key-derivation-traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "key-derivation-traits"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/radix-connect-models/Cargo.toml
+++ b/crates/app/radix-connect-models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "radix-connect-models"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/radix-connect-models/Cargo.toml
+++ b/crates/app/radix-connect-models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "radix-connect-models"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/radix-connect/Cargo.toml
+++ b/crates/app/radix-connect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "radix-connect"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 

--- a/crates/app/radix-connect/Cargo.toml
+++ b/crates/app/radix-connect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "radix-connect"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 

--- a/crates/app/security-center/Cargo.toml
+++ b/crates/app/security-center/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "security-center"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/security-center/Cargo.toml
+++ b/crates/app/security-center/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "security-center"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/signing-traits/Cargo.toml
+++ b/crates/app/signing-traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signing-traits"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/signing-traits/Cargo.toml
+++ b/crates/app/signing-traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signing-traits"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/signing/Cargo.toml
+++ b/crates/app/signing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signing"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 

--- a/crates/app/signing/Cargo.toml
+++ b/crates/app/signing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signing"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 

--- a/crates/common/build-info/Cargo.toml
+++ b/crates/common/build-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "build-info"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/common/build-info/Cargo.toml
+++ b/crates/common/build-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "build-info"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/common/bytes/Cargo.toml
+++ b/crates/common/bytes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bytes"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/bytes/Cargo.toml
+++ b/crates/common/bytes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bytes"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/entity-foundation/Cargo.toml
+++ b/crates/common/entity-foundation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entity-foundation"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/entity-foundation/Cargo.toml
+++ b/crates/common/entity-foundation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entity-foundation"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/host-info/Cargo.toml
+++ b/crates/common/host-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "host-info"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/host-info/Cargo.toml
+++ b/crates/common/host-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "host-info"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/identified-vec-of/Cargo.toml
+++ b/crates/common/identified-vec-of/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "identified-vec-of"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/identified-vec-of/Cargo.toml
+++ b/crates/common/identified-vec-of/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "identified-vec-of"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/metadata/Cargo.toml
+++ b/crates/common/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metadata"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/metadata/Cargo.toml
+++ b/crates/common/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metadata"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/network/Cargo.toml
+++ b/crates/common/network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "network"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/network/Cargo.toml
+++ b/crates/common/network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "network"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/numeric/Cargo.toml
+++ b/crates/common/numeric/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numeric"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/numeric/Cargo.toml
+++ b/crates/common/numeric/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numeric"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/short-string/Cargo.toml
+++ b/crates/common/short-string/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "short-string"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/short-string/Cargo.toml
+++ b/crates/common/short-string/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "short-string"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/assert-json/Cargo.toml
+++ b/crates/core/assert-json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assert-json"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/assert-json/Cargo.toml
+++ b/crates/core/assert-json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assert-json"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/collections/Cargo.toml
+++ b/crates/core/collections/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-collections"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/collections/Cargo.toml
+++ b/crates/core/collections/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-collections"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/error/Cargo.toml
+++ b/crates/core/error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "error"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/error/Cargo.toml
+++ b/crates/core/error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "error"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/has-sample-values/Cargo.toml
+++ b/crates/core/has-sample-values/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "has-sample-values"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/has-sample-values/Cargo.toml
+++ b/crates/core/has-sample-values/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "has-sample-values"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/misc/Cargo.toml
+++ b/crates/core/misc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-misc"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/misc/Cargo.toml
+++ b/crates/core/misc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-misc"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/prelude/Cargo.toml
+++ b/crates/core/prelude/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prelude"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/prelude/Cargo.toml
+++ b/crates/core/prelude/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prelude"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/time-utils/Cargo.toml
+++ b/crates/core/time-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "time-utils"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/time-utils/Cargo.toml
+++ b/crates/core/time-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "time-utils"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/utils/Cargo.toml
+++ b/crates/core/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-utils"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/utils/Cargo.toml
+++ b/crates/core/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-utils"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/addresses/Cargo.toml
+++ b/crates/crypto/addresses/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "addresses"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/addresses/Cargo.toml
+++ b/crates/crypto/addresses/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "addresses"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/cap26-models/Cargo.toml
+++ b/crates/crypto/cap26-models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cap26-models"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/cap26-models/Cargo.toml
+++ b/crates/crypto/cap26-models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cap26-models"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/ecc/Cargo.toml
+++ b/crates/crypto/ecc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecc"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/ecc/Cargo.toml
+++ b/crates/crypto/ecc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecc"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/encryption/Cargo.toml
+++ b/crates/crypto/encryption/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "encryption"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/encryption/Cargo.toml
+++ b/crates/crypto/encryption/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "encryption"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/hash/Cargo.toml
+++ b/crates/crypto/hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hash"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/hash/Cargo.toml
+++ b/crates/crypto/hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hash"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/hd/Cargo.toml
+++ b/crates/crypto/hd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hierarchical-deterministic"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/hd/Cargo.toml
+++ b/crates/crypto/hd/Cargo.toml
@@ -26,7 +26,6 @@ enum-as-inner = { workspace = true }
 enum-iterator = { workspace = true }
 iota-crypto = { workspace = true }
 itertools = { workspace = true }
-pretty_assertions = { workspace = true }
 paste = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/crypto/hd/Cargo.toml
+++ b/crates/crypto/hd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hierarchical-deterministic"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/hd/Cargo.toml
+++ b/crates/crypto/hd/Cargo.toml
@@ -26,6 +26,7 @@ enum-as-inner = { workspace = true }
 enum-iterator = { workspace = true }
 iota-crypto = { workspace = true }
 itertools = { workspace = true }
+pretty_assertions = { workspace = true }
 paste = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/crypto/hd/src/bip32/hd_path.rs
+++ b/crates/crypto/hd/src/bip32/hd_path.rs
@@ -77,10 +77,8 @@ impl HDPath {
                 && c.is_securified()
             {
                 let securified = c.as_securified().unwrap();
-                let global = u32::from(securified.index_in_local_key_space());
-                let without_securified =
-                    global + RELATIVELY_LOCAL_OFFSET_SECURIFIED;
-                format!("{}H", without_securified)
+                let local = u32::from(securified.index_in_local_key_space());
+                format!("{}H", local + RELATIVELY_LOCAL_OFFSET_SECURIFIED)
             } else {
                 format!("{}", c)
             }
@@ -93,8 +91,14 @@ impl HDPath {
 
     /// This method returns the canonical bip32 representation of the path.
     /// In sargon, paths in the securified space are printed with the `S` notation after the index,
-    /// for readability purposes. Such paths need to be canonicalized in bip32 notation meaning that
-    /// an index of `i S` => `i + 2^31 + 2^30 H` for communication with other external APIs.
+    /// for readability purposes.
+    ///
+    /// The notation `{i}S` means `{i + 2^30}H`, and since `H` means `+ 2^31` we can
+    /// verbosely express `{i}S` as `{i + 2^30 + 2^31} (without the H)
+    ///
+    /// Such paths need to be canonicalized in bip32 notation meaning that
+    /// an index of `"{i}S"` => `"{i + 2^30}H"` when communication with other external APIs,
+    /// e.g. using Ledger hardware wallet or Arculus.
     pub fn to_canonical_bip32_string(&self) -> String {
         self.to_bip32_string_with(true, true)
     }

--- a/crates/crypto/hd/src/bip32/hd_path.rs
+++ b/crates/crypto/hd/src/bip32/hd_path.rs
@@ -78,7 +78,8 @@ impl HDPath {
             {
                 let securified = c.as_securified().unwrap();
                 let global = u32::from(securified.index_in_local_key_space());
-                let without_securified = global + U30_MAX;
+                let without_securified =
+                    global + RELATIVELY_LOCAL_OFFSET_SECURIFIED;
                 format!("{}H", without_securified)
             } else {
                 format!("{}", c)

--- a/crates/crypto/hd/src/bip32/hd_path.rs
+++ b/crates/crypto/hd/src/bip32/hd_path.rs
@@ -77,9 +77,8 @@ impl HDPath {
                 && c.is_securified()
             {
                 let securified = c.as_securified().unwrap();
-                let global = securified.map_to_global_key_space();
-                let without_securified =
-                    global - RELATIVELY_LOCAL_OFFSET_SECURIFIED;
+                let global = u32::from(securified.index_in_local_key_space());
+                let without_securified = global + U30_MAX;
                 format!("{}H", without_securified)
             } else {
                 format!("{}", c)

--- a/crates/crypto/hd/src/cap26/paths/unvalidated_cap26_path.rs
+++ b/crates/crypto/hd/src/cap26/paths/unvalidated_cap26_path.rs
@@ -22,6 +22,8 @@ impl TryFrom<HDPathComponent> for NetworkID {
     }
 }
 
+pub const CAP26_PATH_ENTITY_INDEX_POS: usize = 5;
+
 impl TryFrom<HDPath> for UnvalidatedCAP26Path {
     type Error = CommonError;
 
@@ -51,7 +53,8 @@ impl TryFrom<HDPath> for UnvalidatedCAP26Path {
         let entity_kind = CAP26EntityKind::try_from(components[3])?;
         let key_kind = CAP26KeyKind::try_from(components[4])?;
 
-        let hardened = Hardened::try_from(components[5])?;
+        let hardened =
+            Hardened::try_from(components[CAP26_PATH_ENTITY_INDEX_POS])?;
 
         Ok(UnvalidatedCAP26Path {
             network_id,

--- a/crates/crypto/hd/src/derivation/derivation_path.rs
+++ b/crates/crypto/hd/src/derivation/derivation_path.rs
@@ -58,6 +58,10 @@ macro_rules! path_union {
                         )+
                     }
                 }
+
+                pub fn to_canonical_bip32_string(&self) -> String {
+                    self.to_hd_path().to_canonical_bip32_string()
+                }
             }
             impl From<$union_name> for HDPath {
                 fn from(value: $union_name) -> Self {
@@ -330,6 +334,40 @@ mod tests {
         let s = sut.to_bip32_string();
         let value = BIP44LikePath::from_bip32_string(&s).unwrap();
         assert_eq!(SUT::Bip44Like { value }, sut)
+    }
+
+    #[test]
+    fn string_representation_of_canonical_and_non_canonical_for_securified_derivation_path(
+    ) {
+        let sut = SUT::Account {
+            value: AccountPath::new(
+                NetworkID::Mainnet,
+                CAP26KeyKind::TransactionSigning,
+                Hardened::from_local_key_space(U31::ZERO, IsSecurified(true))
+                    .unwrap(),
+            ),
+        };
+
+        assert_eq!(sut.to_bip32_string(), "m/44H/1022H/1H/525H/1460H/0S");
+        assert_eq!(
+            sut.to_canonical_bip32_string(),
+            "m/44H/1022H/1H/525H/1460H/2147483648H"
+        )
+    }
+
+    #[test]
+    fn string_representation_of_canonical_and_non_canonical_for_unsecurified_derivation_path(
+    ) {
+        let sut = SUT::Account {
+            value: AccountPath::new(
+                NetworkID::Mainnet,
+                CAP26KeyKind::TransactionSigning,
+                Hardened::from_local_key_space(U31::ZERO, IsSecurified(false))
+                    .unwrap(),
+            ),
+        };
+
+        assert_eq!(sut.to_bip32_string(), sut.to_canonical_bip32_string());
     }
 
     #[test]

--- a/crates/crypto/hd/src/derivation/derivation_path.rs
+++ b/crates/crypto/hd/src/derivation/derivation_path.rs
@@ -349,9 +349,9 @@ mod tests {
         };
 
         assert_eq!(sut.to_bip32_string(), "m/44H/1022H/1H/525H/1460H/3S");
-        assert_eq!(
+        pretty_assertions::assert_eq!(
             sut.to_canonical_bip32_string(),
-            "m/44H/1022H/1H/525H/1460H/2147483651H"
+            format!("m/44H/1022H/1H/525H/1460H/{}H", U30::MAX + 3)
         )
     }
 

--- a/crates/crypto/hd/src/derivation/derivation_path.rs
+++ b/crates/crypto/hd/src/derivation/derivation_path.rs
@@ -343,15 +343,15 @@ mod tests {
             value: AccountPath::new(
                 NetworkID::Mainnet,
                 CAP26KeyKind::TransactionSigning,
-                Hardened::from_local_key_space(U31::ZERO, IsSecurified(true))
+                Hardened::from_local_key_space(U31::new(3), IsSecurified(true))
                     .unwrap(),
             ),
         };
 
-        assert_eq!(sut.to_bip32_string(), "m/44H/1022H/1H/525H/1460H/0S");
+        assert_eq!(sut.to_bip32_string(), "m/44H/1022H/1H/525H/1460H/3S");
         assert_eq!(
             sut.to_canonical_bip32_string(),
-            "m/44H/1022H/1H/525H/1460H/2147483648H"
+            "m/44H/1022H/1H/525H/1460H/2147483651H"
         )
     }
 

--- a/crates/crypto/hd/src/derivation/derivation_path.rs
+++ b/crates/crypto/hd/src/derivation/derivation_path.rs
@@ -337,7 +337,54 @@ mod tests {
     }
 
     #[test]
-    fn string_representation_of_canonical_and_non_canonical_for_securified_derivation_path(
+    fn string_representation_of_canonical_and_non_canonical_for_unsecurified_derivation_path_last(
+    ) {
+        let sut = SUT::Account {
+            value: AccountPath::new(
+                NetworkID::Mainnet,
+                CAP26KeyKind::TransactionSigning,
+                Hardened::from_global_key_space(
+                    2u32.pow(30) - 1 + GLOBAL_OFFSET_HARDENED,
+                )
+                .unwrap(),
+            ),
+        };
+
+        assert_eq!(
+            sut.to_bip32_string(),
+            "m/44H/1022H/1H/525H/1460H/1073741823H"
+        );
+        assert_eq!(
+            sut.to_canonical_bip32_string(),
+            "m/44H/1022H/1H/525H/1460H/1073741823H"
+        );
+    }
+
+    #[test]
+    fn string_representation_of_canonical_and_non_canonical_for_securified_derivation_path_zero(
+    ) {
+        let sut = SUT::Account {
+            value: AccountPath::new(
+                NetworkID::Mainnet,
+                CAP26KeyKind::TransactionSigning,
+                Hardened::from_local_key_space(U31::ZERO, IsSecurified(true))
+                    .unwrap(),
+            ),
+        };
+
+        assert_eq!(sut.to_bip32_string(), "m/44H/1022H/1H/525H/1460H/0S");
+        assert_eq!(
+            sut.to_canonical_bip32_string(),
+            "m/44H/1022H/1H/525H/1460H/1073741824H"
+        );
+        assert_eq!(
+            sut.to_canonical_bip32_string(),
+            format!("m/44H/1022H/1H/525H/1460H/{}H", 2u32.pow(30))
+        );
+    }
+
+    #[test]
+    fn string_representation_of_canonical_and_non_canonical_for_securified_derivation_path_2(
     ) {
         let sut = SUT::Account {
             value: AccountPath::new(

--- a/crates/crypto/hd/src/derivation/derivation_path.rs
+++ b/crates/crypto/hd/src/derivation/derivation_path.rs
@@ -343,15 +343,15 @@ mod tests {
             value: AccountPath::new(
                 NetworkID::Mainnet,
                 CAP26KeyKind::TransactionSigning,
-                Hardened::from_local_key_space(U31::new(3), IsSecurified(true))
+                Hardened::from_local_key_space(U31::new(2), IsSecurified(true))
                     .unwrap(),
             ),
         };
 
-        assert_eq!(sut.to_bip32_string(), "m/44H/1022H/1H/525H/1460H/3S");
-        pretty_assertions::assert_eq!(
+        assert_eq!(sut.to_bip32_string(), "m/44H/1022H/1H/525H/1460H/2S");
+        assert_eq!(
             sut.to_canonical_bip32_string(),
-            format!("m/44H/1022H/1H/525H/1460H/{}H", U30::MAX + 3)
+            "m/44H/1022H/1H/525H/1460H/1073741826H"
         )
     }
 

--- a/crates/crypto/hd/src/derivation/mnemonic_with_passphrase.rs
+++ b/crates/crypto/hd/src/derivation/mnemonic_with_passphrase.rs
@@ -397,31 +397,30 @@ mod tests {
         );
     }
 
-     /// Test vector: https://github.com/radixdlt/babylon-wallet-ios/blob/99161cbbb11a78f36db6991e5d5c5f092678d5fa/RadixWalletTests/CryptographyTests/SLIP10Tests/TestVectors/cap26_curve25519.json#L8
-     #[test]
-     fn derive_a_curve25519_key_with_cap26_in_securified_space() {
-         let mwp = SUT::with_passphrase(
+    /// Test vector: https://github.com/radixdlt/babylon-wallet-ios/blob/99161cbbb11a78f36db6991e5d5c5f092678d5fa/RadixWalletTests/CryptographyTests/SLIP10Tests/TestVectors/cap26_curve25519.json#L8
+    #[test]
+    fn derive_a_curve25519_key_with_cap26_in_securified_space() {
+        let mwp = SUT::with_passphrase(
              Mnemonic::from_phrase(
                  "equip will roof matter pink blind book anxiety banner elbow sun young",
              )
              .unwrap(),
              BIP39Passphrase::default(),
          );
-         let seed = mwp.to_seed();
-         let private_key = seed.derive_private_key(
-             &AccountPath::from_str("m/44H/1022H/12H/525H/1460H/3S").unwrap(),
-         );
- 
-         assert_eq!(
-             "13e971fb16cb2c816d6b9f12176e9b8ab9af1831d006114d344d119ab2715506",
-             private_key.to_hex()
-         );
-         assert_eq!(
-             "451152a1cef7be603205086d4ebac0a0b78fda2ff4684b9dea5ca9ef003d4e7d",
-             private_key.public_key().to_hex()
-         );
-     }
- 
+        let seed = mwp.to_seed();
+        let private_key = seed.derive_private_key(
+            &AccountPath::from_str("m/44H/1022H/12H/525H/1460H/3S").unwrap(),
+        );
+
+        assert_eq!(
+            "13e971fb16cb2c816d6b9f12176e9b8ab9af1831d006114d344d119ab2715506",
+            private_key.to_hex()
+        );
+        assert_eq!(
+            "451152a1cef7be603205086d4ebac0a0b78fda2ff4684b9dea5ca9ef003d4e7d",
+            private_key.public_key().to_hex()
+        );
+    }
 
     /// Test vector: https://github.com/radixdlt/babylon-wallet-ios/blob/99161cbbb11a78f36db6991e5d5c5f092678d5fa/RadixWalletTests/CryptographyTests/SLIP10Tests/TestVectors/bip44_secp256k1.json#L288
     #[test]

--- a/crates/crypto/hd/src/derivation/mnemonic_with_passphrase.rs
+++ b/crates/crypto/hd/src/derivation/mnemonic_with_passphrase.rs
@@ -397,6 +397,32 @@ mod tests {
         );
     }
 
+     /// Test vector: https://github.com/radixdlt/babylon-wallet-ios/blob/99161cbbb11a78f36db6991e5d5c5f092678d5fa/RadixWalletTests/CryptographyTests/SLIP10Tests/TestVectors/cap26_curve25519.json#L8
+     #[test]
+     fn derive_a_curve25519_key_with_cap26_in_securified_space() {
+         let mwp = SUT::with_passphrase(
+             Mnemonic::from_phrase(
+                 "equip will roof matter pink blind book anxiety banner elbow sun young",
+             )
+             .unwrap(),
+             BIP39Passphrase::default(),
+         );
+         let seed = mwp.to_seed();
+         let private_key = seed.derive_private_key(
+             &AccountPath::from_str("m/44H/1022H/12H/525H/1460H/3S").unwrap(),
+         );
+ 
+         assert_eq!(
+             "13e971fb16cb2c816d6b9f12176e9b8ab9af1831d006114d344d119ab2715506",
+             private_key.to_hex()
+         );
+         assert_eq!(
+             "451152a1cef7be603205086d4ebac0a0b78fda2ff4684b9dea5ca9ef003d4e7d",
+             private_key.public_key().to_hex()
+         );
+     }
+ 
+
     /// Test vector: https://github.com/radixdlt/babylon-wallet-ios/blob/99161cbbb11a78f36db6991e5d5c5f092678d5fa/RadixWalletTests/CryptographyTests/SLIP10Tests/TestVectors/bip44_secp256k1.json#L288
     #[test]
     fn derive_a_secp256k1_key_with_bip44_olympia() {

--- a/crates/crypto/hd/src/derivation/mnemonic_with_passphrase.rs
+++ b/crates/crypto/hd/src/derivation/mnemonic_with_passphrase.rs
@@ -397,31 +397,6 @@ mod tests {
         );
     }
 
-    /// Test vector: https://github.com/radixdlt/babylon-wallet-ios/blob/99161cbbb11a78f36db6991e5d5c5f092678d5fa/RadixWalletTests/CryptographyTests/SLIP10Tests/TestVectors/cap26_curve25519.json#L8
-    #[test]
-    fn derive_a_curve25519_key_with_cap26_in_securified_space() {
-        let mwp = SUT::with_passphrase(
-             Mnemonic::from_phrase(
-                 "equip will roof matter pink blind book anxiety banner elbow sun young",
-             )
-             .unwrap(),
-             BIP39Passphrase::default(),
-         );
-        let seed = mwp.to_seed();
-        let private_key = seed.derive_private_key(
-            &AccountPath::from_str("m/44H/1022H/12H/525H/1460H/3S").unwrap(),
-        );
-
-        assert_eq!(
-            "13e971fb16cb2c816d6b9f12176e9b8ab9af1831d006114d344d119ab2715506",
-            private_key.to_hex()
-        );
-        assert_eq!(
-            "451152a1cef7be603205086d4ebac0a0b78fda2ff4684b9dea5ca9ef003d4e7d",
-            private_key.public_key().to_hex()
-        );
-    }
-
     /// Test vector: https://github.com/radixdlt/babylon-wallet-ios/blob/99161cbbb11a78f36db6991e5d5c5f092678d5fa/RadixWalletTests/CryptographyTests/SLIP10Tests/TestVectors/bip44_secp256k1.json#L288
     #[test]
     fn derive_a_secp256k1_key_with_bip44_olympia() {

--- a/crates/factors/factors/Cargo.toml
+++ b/crates/factors/factors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factors"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/factors/Cargo.toml
+++ b/crates/factors/factors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factors"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/instances-provider/Cargo.toml
+++ b/crates/factors/instances-provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factor-instances-provider"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/instances-provider/Cargo.toml
+++ b/crates/factors/instances-provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factor-instances-provider"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/keys-collector/Cargo.toml
+++ b/crates/factors/keys-collector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keys-collector"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/keys-collector/Cargo.toml
+++ b/crates/factors/keys-collector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keys-collector"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/next-derivation-index-ephemeral/Cargo.toml
+++ b/crates/factors/next-derivation-index-ephemeral/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "next-derivation-index-ephemeral"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/next-derivation-index-ephemeral/Cargo.toml
+++ b/crates/factors/next-derivation-index-ephemeral/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "next-derivation-index-ephemeral"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/next-derivation-index-ephemeral/src/agnostic_paths/index_agnostic_path.rs
+++ b/crates/factors/next-derivation-index-ephemeral/src/agnostic_paths/index_agnostic_path.rs
@@ -73,7 +73,7 @@ impl IndexAgnosticPath {
     }
 
     fn _to_str(&self) -> String {
-        let base = self._to_hd_path().to_bip32_string_with(false);
+        let base = self._to_hd_path().to_bip32_string_with(false, false);
         format!("{}/{}{}", base, self.key_space, Self::COMPONENT_SUFFIX)
     }
 }

--- a/crates/factors/supporting-types/Cargo.toml
+++ b/crates/factors/supporting-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factors-supporting-types"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/supporting-types/Cargo.toml
+++ b/crates/factors/supporting-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factors-supporting-types"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/gateway/client-and-api/Cargo.toml
+++ b/crates/gateway/client-and-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gateway-client-and-api"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/gateway/client-and-api/Cargo.toml
+++ b/crates/gateway/client-and-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gateway-client-and-api"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/gateway/models/Cargo.toml
+++ b/crates/gateway/models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gateway-models"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 

--- a/crates/gateway/models/Cargo.toml
+++ b/crates/gateway/models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gateway-models"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 

--- a/crates/profile/logic/logic_SPLIT_ME/Cargo.toml
+++ b/crates/profile/logic/logic_SPLIT_ME/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-logic"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/logic/logic_SPLIT_ME/Cargo.toml
+++ b/crates/profile/logic/logic_SPLIT_ME/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-logic"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/account-for-display/Cargo.toml
+++ b/crates/profile/models/account-for-display/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "account-for-display"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/account-for-display/Cargo.toml
+++ b/crates/profile/models/account-for-display/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "account-for-display"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/account-or-persona/Cargo.toml
+++ b/crates/profile/models/account-or-persona/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-account-or-persona"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/account-or-persona/Cargo.toml
+++ b/crates/profile/models/account-or-persona/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-account-or-persona"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/account/Cargo.toml
+++ b/crates/profile/models/account/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-account"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/account/Cargo.toml
+++ b/crates/profile/models/account/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-account"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/app-preferences/Cargo.toml
+++ b/crates/profile/models/app-preferences/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-app-preferences"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/app-preferences/Cargo.toml
+++ b/crates/profile/models/app-preferences/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-app-preferences"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/base-entity/Cargo.toml
+++ b/crates/profile/models/base-entity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-base-entity"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/base-entity/Cargo.toml
+++ b/crates/profile/models/base-entity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-base-entity"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/gateway/Cargo.toml
+++ b/crates/profile/models/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-gateway"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/gateway/Cargo.toml
+++ b/crates/profile/models/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-gateway"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/persona-data/Cargo.toml
+++ b/crates/profile/models/persona-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-persona-data"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/persona-data/Cargo.toml
+++ b/crates/profile/models/persona-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-persona-data"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/persona/Cargo.toml
+++ b/crates/profile/models/persona/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-persona"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/persona/Cargo.toml
+++ b/crates/profile/models/persona/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-persona"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/profile_SPLIT_ME/Cargo.toml
+++ b/crates/profile/models/profile_SPLIT_ME/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 

--- a/crates/profile/models/profile_SPLIT_ME/Cargo.toml
+++ b/crates/profile/models/profile_SPLIT_ME/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 

--- a/crates/profile/models/security-structures/Cargo.toml
+++ b/crates/profile/models/security-structures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-security-structures"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/security-structures/Cargo.toml
+++ b/crates/profile/models/security-structures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-security-structures"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/supporting-types/Cargo.toml
+++ b/crates/profile/models/supporting-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-supporting-types"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/supporting-types/Cargo.toml
+++ b/crates/profile/models/supporting-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-supporting-types"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/traits/entity-by-address/Cargo.toml
+++ b/crates/profile/traits/entity-by-address/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entity-by-address"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/traits/entity-by-address/Cargo.toml
+++ b/crates/profile/traits/entity-by-address/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entity-by-address"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/sargon/Cargo.toml
+++ b/crates/sargon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 resolver = "2" # features enabled in integration test

--- a/crates/sargon/Cargo.toml
+++ b/crates/sargon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 resolver = "2" # features enabled in integration test

--- a/crates/sargon/tests/vectors/main.rs
+++ b/crates/sargon/tests/vectors/main.rs
@@ -110,6 +110,261 @@ mod cap26_tests {
         secp256k1.test::<Secp256k1PrivateKey, Secp256k1PublicKey>();
         curve25519.test::<Ed25519PrivateKey, Ed25519PublicKey>();
     }
+
+    // ========= SECURIFIED KEY SPACE =========
+    // Higher part of the 2^31-1 key space
+    // These values have been cross references
+    // using this Python script:
+    // https://gist.github.com/Sajjon/060c5747c6ffead12f78645b623a8164
+    // Which is based on the SLIP10 reference implementation:
+    // https://github.com/satoshilabs/slips/blob/master/slip-0010/testvectors.py
+    // ========================================
+    fn test(
+        mnemonic: Mnemonic,
+        passphrase: impl AsRef<str>,
+        network_id: NetworkID,
+        index: u32,
+        path: impl AsRef<str>,
+        private_key_hex: impl AsRef<str>,
+        public_key_hex: impl AsRef<str>,
+        factor_source_id_str: impl AsRef<str>,
+        address: impl AsRef<str>,
+    ) {
+        let path = path.as_ref();
+        let account_path = AccountPath::new(
+            network_id,
+            CAP26KeyKind::TransactionSigning,
+            Hardened::from_global_key_space(index).unwrap(),
+        );
+        assert_eq!(account_path.to_string(), path); // test Display
+        assert_eq!(path.parse::<AccountPath>().unwrap(), account_path); // test FromStr
+        let private_key = mnemonic.to_seed("").derive_private_key(&account_path);
+        let public_key = private_key.public_key();
+        // let account = Account::derive(&mnemoas_ref(), &account_path);
+        assert_eq!(private_key.to_hex(), private_key.as_ref());
+        assert_eq!(public_key.to_hex(), public_key.as_ref());
+        let account = AccountAddress::new(public_key, network_id);
+        let factor_source_id = FactorSourceIDFromHash::new_for_device(&MnemonicWithPassphrase::new(mnemonic))
+        assert_eq!(
+            factor_source_id.to_string(),
+            factor_source_id_str.as_ref()
+        );
+        assert_eq!(account.address, address.as_ref());
+        assert_eq!(account.network_id, network_id);
+        assert_eq!(account.path, account_path);
+        assert_eq!(account.index, index);
+    }
+
+    #[test]
+    fn derive_account_mnemonic_2_with_passphrase_mainnet_index_0() {
+        test(
+            Mnemonic::sample_device_other(),
+            "",
+            NetworkID::Mainnet,
+            0,
+            "m/44H/1022H/1H/525H/1460H/0H",
+            "5b82120ec4763f8bacff71c8e529894fea1e735a5698ff400364a913f7b20c00",
+            "f3d0210f6c2cecbdc977b7aae19d468a6c363e73a055bc877248f8318f0122e8",
+            "5255999c65076ce9ced5a1881f1a621bba1ce3f1f68a61df462d96822a5190cd",
+            "account_rdx12xek3geay25lktmk5zyplc7z7mg5xe8ldh48ta4mkcd9q0v0q6l8y6",
+        );
+    }
+
+    #[test]
+    fn derive_account_mnemonic_2_with_passphrase_mainnet_index_1() {
+        test(
+            Mnemonic::sample_device_other(),
+            "",
+            NetworkID::Mainnet,
+            1,
+            "m/44H/1022H/1H/525H/1460H/1H",
+            "da5e924c716a05b616940dd7828e3020de4dc09c371ab03966e00e95c68cb439",
+            "df49129a10aa88c76837611a4ecda794ac5f650e4401037e1ff275e52bc784c5",
+            "5255999c65076ce9ced5a1881f1a621bba1ce3f1f68a61df462d96822a5190cd",
+            "account_rdx128mh2ae9dsrwa0t8l37ayjrxxf0p84e6qm227ytxtcu447f5uw5m8w",
+        );
+    }
+
+    #[test]
+    fn derive_account_mnemonic_2_with_passphrase_mainnet_index_2pow30_minus_3_hardened(
+    ) {
+        test(
+            Mnemonic::sample_device_other(),
+            "",
+            NetworkID::Mainnet,
+            (2i32.pow(30) - 3) as u32,
+            "m/44H/1022H/1H/525H/1460H/1073741821H",
+            "d9e0394b67affb91b5acdc3ecf6786a6628892ffd605291c853568cbed498afa",
+            "a484112bcd119488f13191a6ec57ff27606ea041537662730e60580cdb679616",
+            "5255999c65076ce9ced5a1881f1a621bba1ce3f1f68a61df462d96822a5190cd",
+            "account_rdx12yxslky3ye2rdtcv439s7l8hw2pm7sp6g3e537dsuk6558z66yteu5",
+        );
+    }
+
+    #[test]
+    fn derive_account_mnemonic_2_with_passphrase_mainnet_index_2pow30_minus_2_hardened(
+    ) {
+        test(
+            Mnemonic::sample_device_other(),
+            "",
+            NetworkID::Mainnet,
+            (2i32.pow(30) - 2) as u32,
+            "m/44H/1022H/1H/525H/1460H/1073741822H",
+            "5218159039d5c639ae4e0b6b351b821e3687aa44768230c4f06a13ae0c78715c",
+            "2155707a3cebd7788dc83113174d30e2c29abae34f399c27a6caa8c6f5ae543e",
+            "5255999c65076ce9ced5a1881f1a621bba1ce3f1f68a61df462d96822a5190cd",
+            "account_rdx1299mrqwvhy6cka9vsvjddqhttm9qckk08w32kp6nrnzrwaclqelp4x",
+        );
+    }
+
+    #[test]
+    fn derive_account_mnemonic_2_with_passphrase_mainnet_index_2pow30_minus_1_hardened(
+    ) {
+        test(
+            Mnemonic::sample_device_other(),
+            "",
+            NetworkID::Mainnet,
+            (2i32.pow(30) - 1) as u32,
+            "m/44H/1022H/1H/525H/1460H/1073741823H",
+            "5c5adfebe650684e3cc20e4dba49e1447d7ac12f63ae1bd8723554d0a95aaf38",
+            "f4f43daaedc3603b3dc6b92a2014630a96ca2a20cc14d2dcaa71f49c30789689",
+            "5255999c65076ce9ced5a1881f1a621bba1ce3f1f68a61df462d96822a5190cd",
+            "account_rdx129zmjv05ljhm3tc3f5nayvfgym69fu6zlajt6xp2jj900c5qt76m6v",
+        );
+    }
+
+    #[test]
+    fn derive_account_mnemonic_2_with_passphrase_mainnet_index_2pow30_hardened()
+    {
+        test(
+            Mnemonic::sample_device_other(),
+            "",
+            NetworkID::Mainnet,
+            2u32.pow(30),
+            "m/44H/1022H/1H/525H/1460H/1073741824H", // Sargon securified notation: "/0S"
+            "b0b9180f7c96778cffba7af2ef1ddf4705fca21b965e8a722ccf2ec403c35950",
+            "e0293d4979bc303ea4fe361a62baf9c060c7d90267972b05c61eead9ef3eed3e",
+            "5255999c65076ce9ced5a1881f1a621bba1ce3f1f68a61df462d96822a5190cd",
+            "account_rdx128znphf3gxek50qyxjcuels6xtulum3g46vhr43ryavj7zr53xxded",
+        );
+    }
+
+    #[test]
+    fn derive_account_mnemonic_2_with_passphrase_mainnet_index_2pow30_plus_1_hardened(
+    ) {
+        test(
+            Mnemonic::sample_device_other(),
+            "",
+            NetworkID::Mainnet,
+            2u32.pow(30) + 1,
+            "m/44H/1022H/1H/525H/1460H/1073741825H", // Sargon securified notation: "/1S"
+            "c1880587c727f2f01dfdf61d19b44283d311b31c12e8898b774b73e8067d25b1",
+            "c6aaee6fa60d73a17989ce2a2a5db5a88cd696aef61d2f298262fae189dff04e",
+            "5255999c65076ce9ced5a1881f1a621bba1ce3f1f68a61df462d96822a5190cd",
+            "account_rdx12y8gd9dyz9mhg3jv5p9md5gvuzc34m0p90te0hx7aqgsvuy5g2p09s",
+        );
+    }
+
+    #[test]
+    fn derive_account_mnemonic_2_with_passphrase_mainnet_index_2pow30_plus_2_hardened(
+    ) {
+        test(
+            Mnemonic::sample_device_other(),
+            "",
+            NetworkID::Mainnet,
+            2u32.pow(30) + 2,
+            "m/44H/1022H/1H/525H/1460H/1073741826H", // Sargon securified notation: "/2S"
+            "837bc77bb29e4702be39c69fbade7d350bc23f6daddf68a64474984e899a97a3",
+            "6a92b3338dc74a50e8b3fff896a7e0f43c42742544af52de20353675d8bc7907",
+            "5255999c65076ce9ced5a1881f1a621bba1ce3f1f68a61df462d96822a5190cd",
+            "account_rdx12xluhgaw3vcyskpsmswu279jlysmrdjuk23erjcx8s83kcgx3r4zvn",
+        );
+    }
+
+    #[test]
+    fn derive_account_mnemonic_2_with_passphrase_mainnet_index_2pow31_minus_5()
+    {
+        let idx = 2u32.pow(31u32) - 5;
+        test(
+            Mnemonic::sample_device_other(),
+            "",
+            NetworkID::Mainnet,
+            idx,
+            "m/44H/1022H/1H/525H/1460H/2147483643H",
+            "8371cdce66f0733cf1f8a07235825267e8e650f9bf194dfe82992c8ae77faa84",
+            "9bce7e1a1d724b2013add0697e4133e2affc93b806793ee6709dfdc242738e19",
+            "5255999c65076ce9ced5a1881f1a621bba1ce3f1f68a61df462d96822a5190cd",
+            "account_rdx12x0z0sm5qpp9gmuah7nnpkkkk2zn2r8tvpd9w64097949mcs7jm960",
+        );
+    }
+
+    #[test]
+    fn derive_account_mnemonic_2_with_passphrase_mainnet_index_2pow31_minus_4()
+    {
+        let idx = 2u32.pow(31u32) - 4;
+        test(
+            Mnemonic::sample_device_other(),
+            "",
+            NetworkID::Mainnet,
+            idx,
+            "m/44H/1022H/1H/525H/1460H/2147483644H", // Sargon securified notation: "/1073741820S"
+            "361126bd7947254c49b83c23bbb557219cfa2ac5e5a4551501f18236ffa4eb17",
+            "481b737f5baaf52520612e70858ffa72a3624d5a050da5748844ac14036c8b17",
+            "5255999c65076ce9ced5a1881f1a621bba1ce3f1f68a61df462d96822a5190cd",
+            "account_rdx12y27yrwuqmec5saaykp82098nykpeqentzt3syt4dfdyuq0ckkc07u",
+        );
+    }
+
+    #[test]
+    fn derive_account_mnemonic_2_with_passphrase_mainnet_index_2pow31_minus_3()
+    {
+        let idx = 2u32.pow(31u32) - 3;
+        test(
+            Mnemonic::sample_device_other(),
+            "",
+            NetworkID::Mainnet,
+            idx,
+            "m/44H/1022H/1H/525H/1460H/2147483645H", // Sargon securified notation: "/1073741821S"
+            "f63fe429c5723448dfb8d1f3eda88a659473b4c38960a09bb20efe546fac95ee",
+            "b2819057da648f36eadb59f60b732d4ae7fb22a207acf214e0271d3c587afd54",
+            "5255999c65076ce9ced5a1881f1a621bba1ce3f1f68a61df462d96822a5190cd",
+            "account_rdx12x9mszdtxacj5trw78g2ndvc54wtxg9mxx982w2p8vnv7jes7nvc40",
+        );
+    }
+
+    #[test]
+    fn derive_account_mnemonic_2_with_passphrase_mainnet_index_2pow31_minus_2()
+    {
+        let idx = 2u32.pow(31u32) - 2;
+        test(
+            Mnemonic::sample_device_other(),
+            "",
+            NetworkID::Mainnet,
+            idx,
+            "m/44H/1022H/1H/525H/1460H/2147483646H", // Sargon securified notation: "/1073741822S"
+            "5a8b6327942ca8fc5b30fb5b0c1fa53e97362d514ff4f2c281060b9d51f7fc88",
+            "932123e6c46af8ebde7a96bee4563e09bbf41b28eae9d6ba1c667a2f490a1fcf",
+            "5255999c65076ce9ced5a1881f1a621bba1ce3f1f68a61df462d96822a5190cd",
+            "account_rdx12ysf5nesz5h3wk8aypyn83e9752mal8q545epwykq6nr8k8aavyu7d",
+        );
+    }
+
+    #[test]
+    fn derive_account_mnemonic_2_with_passphrase_mainnet_index_2pow31_minus_1()
+    {
+        let idx = 2u32.pow(31u32) - 1;
+        test(
+            Mnemonic::sample_device_other(),
+            "",
+            NetworkID::Mainnet,
+            idx,
+            "m/44H/1022H/1H/525H/1460H/2147483647H", // Sargon securified notation: "/1073741823S"
+            "7eae6f235206329561b09fc2235d35e017c3f28b54fd3b4f6525e601257c4ce7",
+            "87a2f84f826da0c62052fbe7b385ab78883c02d1fa5472c55a06aa529a0701e9",
+            "5255999c65076ce9ced5a1881f1a621bba1ce3f1f68a61df462d96822a5190cd",
+            "account_rdx128258pxhges8rmva0a2egr0tzqd8x8clsl5d90a8qv3zqggc4jr2ss",
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/system/clients/clients/Cargo.toml
+++ b/crates/system/clients/clients/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clients"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 

--- a/crates/system/clients/clients/Cargo.toml
+++ b/crates/system/clients/clients/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clients"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 

--- a/crates/system/clients/http/Cargo.toml
+++ b/crates/system/clients/http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http-client"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/clients/http/Cargo.toml
+++ b/crates/system/clients/http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http-client"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/drivers/Cargo.toml
+++ b/crates/system/drivers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drivers"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 

--- a/crates/system/drivers/Cargo.toml
+++ b/crates/system/drivers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drivers"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 

--- a/crates/system/interactors/Cargo.toml
+++ b/crates/system/interactors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interactors"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/interactors/Cargo.toml
+++ b/crates/system/interactors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interactors"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/accounts/Cargo.toml
+++ b/crates/system/os/accounts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-accounts"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/accounts/Cargo.toml
+++ b/crates/system/os/accounts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-accounts"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/factors/Cargo.toml
+++ b/crates/system/os/factors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-factors"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/factors/Cargo.toml
+++ b/crates/system/os/factors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-factors"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/os/Cargo.toml
+++ b/crates/system/os/os/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/os/Cargo.toml
+++ b/crates/system/os/os/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/security-center/Cargo.toml
+++ b/crates/system/os/security-center/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-security-center"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/security-center/Cargo.toml
+++ b/crates/system/os/security-center/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-security-center"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/signing/Cargo.toml
+++ b/crates/system/os/signing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-signing"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/signing/Cargo.toml
+++ b/crates/system/os/signing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-signing"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/transaction/Cargo.toml
+++ b/crates/system/os/transaction/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-transaction"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/transaction/Cargo.toml
+++ b/crates/system/os/transaction/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-transaction"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/profile-state-holder/Cargo.toml
+++ b/crates/system/profile-state-holder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-state-holder"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/profile-state-holder/Cargo.toml
+++ b/crates/system/profile-state-holder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-state-holder"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/sub-systems/Cargo.toml
+++ b/crates/system/sub-systems/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sub-systems"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/sub-systems/Cargo.toml
+++ b/crates/system/sub-systems/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sub-systems"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/transaction/foundation/Cargo.toml
+++ b/crates/transaction/foundation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transaction-foundation"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/transaction/foundation/Cargo.toml
+++ b/crates/transaction/foundation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transaction-foundation"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/transaction/manifests/Cargo.toml
+++ b/crates/transaction/manifests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "manifests"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 

--- a/crates/transaction/manifests/Cargo.toml
+++ b/crates/transaction/manifests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "manifests"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 

--- a/crates/transaction/models/Cargo.toml
+++ b/crates/transaction/models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transaction-models"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 

--- a/crates/transaction/models/Cargo.toml
+++ b/crates/transaction/models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transaction-models"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 

--- a/crates/uniffi/conversion-macros/Cargo.toml
+++ b/crates/uniffi/conversion-macros/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "sargon-uniffi-conversion-macros"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 
 [dependencies]

--- a/crates/uniffi/conversion-macros/Cargo.toml
+++ b/crates/uniffi/conversion-macros/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "sargon-uniffi-conversion-macros"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 
 [dependencies]

--- a/crates/uniffi/uniffi_SPLIT_ME/Cargo.toml
+++ b/crates/uniffi/uniffi_SPLIT_ME/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-uniffi"
-version = "1.1.114"
+version = "1.1.115"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/uniffi/uniffi_SPLIT_ME/Cargo.toml
+++ b/crates/uniffi/uniffi_SPLIT_ME/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-uniffi"
-version = "1.1.113"
+version = "1.1.114"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/uniffi/uniffi_SPLIT_ME/src/hierarchical_deterministic/derivation/derivation_path.rs
+++ b/crates/uniffi/uniffi_SPLIT_ME/src/hierarchical_deterministic/derivation/derivation_path.rs
@@ -35,3 +35,10 @@ pub fn derivation_path_to_hd_path(path: &DerivationPath) -> HDPath {
 pub fn derivation_path_to_string(path: &DerivationPath) -> String {
     path.into_internal().to_string()
 }
+
+#[uniffi::export]
+pub fn derivation_path_to_canonical_bip32_string(
+    path: &DerivationPath,
+) -> String {
+    path.into_internal().to_canonical_bip32_string()
+}

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/AccountPath.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/AccountPath.kt
@@ -19,14 +19,4 @@ fun AccountPath.Companion.init(
     index = index
 )
 
-@Throws(SargonException::class)
-fun AccountPath.Companion.init(path: String): AccountPath =
-    when (val derivationPath = DerivationPath.init(path)) {
-        is DerivationPath.Account -> derivationPath.value
-        is DerivationPath.Bip44Like, is DerivationPath.Identity -> throw CommonException.WrongEntityKind(
-            expected = Cap26EntityKind.ACCOUNT.discriminant(),
-            found = Cap26EntityKind.IDENTITY.discriminant()
-        )
-    }
-
 fun AccountPath.asGeneral(): DerivationPath = DerivationPath.Account(value = this)

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/BIP44LikePath.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/BIP44LikePath.kt
@@ -9,12 +9,9 @@ import com.radixdlt.sargon.newBip44LikePathFromIndex
 import com.radixdlt.sargon.newBip44LikePathFromString
 import kotlin.jvm.Throws
 
-@Throws(SargonException::class)
-fun Bip44LikePath.Companion.init(path: String) = newBip44LikePathFromString(string = path)
-
 fun Bip44LikePath.Companion.init(index: HdPathComponent) = newBip44LikePathFromIndex(index = index)
 
-val Bip44LikePath.string: String
+val Bip44LikePath.displayString: String
     get() = bip44LikePathToString(path = this)
 
 val Bip44LikePath.addressIndex: HdPathComponent

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/DerivationPath.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/DerivationPath.kt
@@ -10,6 +10,7 @@ import com.radixdlt.sargon.HdPathComponent
 import com.radixdlt.sargon.IdentityPath
 import com.radixdlt.sargon.NetworkId
 import com.radixdlt.sargon.Slip10Curve
+import com.radixdlt.sargon.derivationPathToCanonicalBip32String
 import com.radixdlt.sargon.derivationPathToHdPath
 import com.radixdlt.sargon.derivationPathToString
 import com.radixdlt.sargon.newDerivationPathFromString
@@ -33,11 +34,11 @@ fun DerivationPath.Companion.initForEntity(
     ).asGeneral()
 }
 
-@Throws(SargonException::class)
-fun DerivationPath.Companion.init(path: String) = newDerivationPathFromString(string = path)
-
-val DerivationPath.string
+val DerivationPath.displayString
     get() = derivationPathToString(path = this)
+
+val DerivationPath.bip32CanonicalString: String
+    get() = derivationPathToCanonicalBip32String(path = this)
 
 val DerivationPath.path: HdPath
     get() = derivationPathToHdPath(path = this)

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/IdentityPath.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/IdentityPath.kt
@@ -22,14 +22,4 @@ fun IdentityPath.Companion.init(
 
 public fun Cap26EntityKind.discriminant(): String = cap26EntityKindToString(kind = this)
 
-@Throws(SargonException::class)
-fun IdentityPath.Companion.init(path: String): IdentityPath =
-    when (val derivationPath = DerivationPath.init(path)) {
-        is DerivationPath.Identity -> derivationPath.value
-        is DerivationPath.Bip44Like, is DerivationPath.Account -> throw CommonException.WrongEntityKind(
-            expected = Cap26EntityKind.IDENTITY.discriminant(),
-            found = Cap26EntityKind.ACCOUNT.discriminant()
-        )
-    }
-
 fun IdentityPath.asGeneral(): DerivationPath = DerivationPath.Identity(value = this)

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/BIP44LikePathTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/BIP44LikePathTest.kt
@@ -3,7 +3,6 @@ package com.radixdlt.sargon
 import com.radixdlt.sargon.extensions.addressIndex
 import com.radixdlt.sargon.extensions.asGeneral
 import com.radixdlt.sargon.extensions.init
-import com.radixdlt.sargon.extensions.string
 import com.radixdlt.sargon.samples.Sample
 import com.radixdlt.sargon.samples.sample
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -17,7 +16,7 @@ class BIP44LikePathTest: SampleTestable<Bip44LikePath> {
     fun testRoundtrip() {
         assertEquals(
             Bip44LikePath.sample(),
-            Bip44LikePath.init(Bip44LikePath.sample().string)
+            Bip44LikePath.init(Bip44LikePath.sample().addressIndex)
         )
 
         assertEquals(

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/DerivationPathTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/DerivationPathTest.kt
@@ -1,7 +1,9 @@
 package com.radixdlt.sargon
 
 import com.radixdlt.sargon.extensions.asGeneral
+import com.radixdlt.sargon.extensions.bip32CanonicalString
 import com.radixdlt.sargon.extensions.curve
+import com.radixdlt.sargon.extensions.displayString
 import com.radixdlt.sargon.extensions.init
 import com.radixdlt.sargon.extensions.initForEntity
 import com.radixdlt.sargon.extensions.initFromLocal
@@ -39,53 +41,6 @@ class DerivationPathTest: SampleTestable<DerivationPath> {
     }
 
     @Test
-    fun testInitFromPath() {
-        assertEquals(
-            DerivationPath.init("m/44H/1022H/1H/525H/1460H/0H"),
-            AccountPath.init(
-                networkId = NetworkId.MAINNET,
-                keyKind = Cap26KeyKind.TRANSACTION_SIGNING,
-                index = Hardened.Unsecurified(UnsecurifiedHardened.initFromLocal(0u))
-            ).asGeneral()
-        )
-
-        assertEquals(
-            DerivationPath.init("m/44H/1022H/1H/525H/1460H/0H"),
-            AccountPath.init("m/44H/1022H/1H/525H/1460H/0H").asGeneral()
-        )
-
-        assertThrows<CommonException> {
-            AccountPath.init("m/44H/1022H/1H/618H/1460H/0H")
-        }
-
-        assertThrows<CommonException> {
-            AccountPath.init(Bip44LikePath.sample().string)
-        }
-
-        assertEquals(
-            DerivationPath.init("m/44H/1022H/1H/618H/1460H/0H"),
-            IdentityPath.init(
-                networkId = NetworkId.MAINNET,
-                keyKind = Cap26KeyKind.TRANSACTION_SIGNING,
-                index = Hardened.Unsecurified(UnsecurifiedHardened.initFromLocal(0u))
-            ).asGeneral()
-        )
-
-        assertEquals(
-            DerivationPath.init("m/44H/1022H/1H/618H/1460H/0H"),
-            IdentityPath.init("m/44H/1022H/1H/618H/1460H/0H").asGeneral()
-        )
-
-        assertThrows<CommonException> {
-            IdentityPath.init("m/44H/1022H/1H/525H/1460H/0H")
-        }
-
-        assertThrows<CommonException> {
-            IdentityPath.init(Bip44LikePath.sample().string)
-        }
-    }
-
-    @Test
     fun testCurve() {
         assertEquals(
             Slip10Curve.CURVE25519,
@@ -105,9 +60,34 @@ class DerivationPathTest: SampleTestable<DerivationPath> {
 
     @Test
     fun testString() {
+        val accountPathInSecurifiedSpace = AccountPath.init(
+            networkId = NetworkId.MAINNET,
+            keyKind = Cap26KeyKind.TRANSACTION_SIGNING,
+            index = Hardened.Securified(SecurifiedU30.initFromLocal(0u))
+        ).asGeneral()
+
         assertEquals(
-            Bip44LikePath.sample().string,
-            Bip44LikePath.sample().asGeneral().string
+            "m/44H/1022H/1H/525H/1460H/0S",
+            accountPathInSecurifiedSpace.displayString
+        )
+        assertEquals(
+            "m/44H/1022H/1H/525H/1460H/2147483648H",
+            accountPathInSecurifiedSpace.bip32CanonicalString
+        )
+
+        val accountPathInUnsecurifiedSpace = AccountPath.init(
+            networkId = NetworkId.MAINNET,
+            keyKind = Cap26KeyKind.TRANSACTION_SIGNING,
+            index = Hardened.Unsecurified(UnsecurifiedHardened(U30.init(0u)))
+        ).asGeneral()
+
+        assertEquals(
+            "m/44H/1022H/1H/525H/1460H/0H",
+            accountPathInUnsecurifiedSpace.displayString
+        )
+        assertEquals(
+            "m/44H/1022H/1H/525H/1460H/0H",
+            accountPathInUnsecurifiedSpace.bip32CanonicalString
         )
     }
 

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/DerivationPathTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/DerivationPathTest.kt
@@ -71,7 +71,7 @@ class DerivationPathTest: SampleTestable<DerivationPath> {
             accountPathInSecurifiedSpace.displayString
         )
         assertEquals(
-            "m/44H/1022H/1H/525H/1460H/2147483648H",
+            "m/44H/1022H/1H/525H/1460H/1073741824H",
             accountPathInSecurifiedSpace.bip32CanonicalString
         )
 


### PR DESCRIPTION
Cyon: UniFFI export `to_canonical_bip32_string` which we will use before we send DerivationPaths to Arculus/Ledger or otherwise signers which are **unaware of our custom `S` notation for indices in the "Securified KeySpace".**