### PR TITLE
Update shield builder primary role validation

### DIFF
--- a/crates/profile/models/security-structures/src/roles_matrices_structures/matrices/builder/error.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/matrices/builder/error.rs
@@ -25,6 +25,10 @@ pub enum MatrixRolesInCombinationBasicViolation {
 pub enum MatrixRolesInCombinationForeverInvalid {
     #[error("Recovery and confirmation factors overlap. No factor may be used in both the recovery and confirmation roles")]
     RecoveryAndConfirmationFactorsOverlap,
+    #[error("Primary role cannot have multiple devices")]
+    PrimaryCannotHaveMultipleDevices,
+    #[error("Threshold and override factors overlap. No factor may be used in both the threshold and override list kinds")]
+    ThresholdAndOverrideFactorsOverlap,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, thiserror::Error)]

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/matrices/builder/matrix_builder.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/matrices/builder/matrix_builder.rs
@@ -218,7 +218,10 @@ impl MatrixBuilder {
     ) -> MatrixBuilderMutateResult {
         self.primary_role
             .validate_threshold_factors()
-            .into_matrix_err(RoleKind::Primary)
+            .into_matrix_err(RoleKind::Primary)?;
+        Self::validate_primary_list_cannot_have_multiple_devices(
+            self.primary_role.get_threshold_factors().iter().cloned(),
+        )
     }
 
     pub fn validate_recovery_role_in_isolation(
@@ -543,6 +546,52 @@ impl MatrixBuilder {
         Ok(())
     }
 
+    fn validate_primary_cannot_have_multiple_devices(
+        &self,
+    ) -> MatrixBuilderMutateResult {
+        Self::validate_primary_list_cannot_have_multiple_devices(
+            self.primary_role.all_factors().into_iter().cloned(),
+        )
+    }
+
+    fn validate_no_factor_may_be_used_in_both_primary_threshold_and_override(
+        &self,
+    ) -> MatrixBuilderMutateResult {
+        if self
+            .primary_role
+            .has_same_factor_in_both_threshold_and_override()
+        {
+            Err(MatrixBuilderValidation::CombinationViolation(
+                    MatrixRolesInCombinationViolation::ForeverInvalid(
+                        MatrixRolesInCombinationForeverInvalid::ThresholdAndOverrideFactorsOverlap,
+                    ),
+                ))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn validate_primary_list_cannot_have_multiple_devices(
+        factors: impl IntoIterator<Item = FactorSourceID>,
+    ) -> MatrixBuilderMutateResult {
+        let device_count = factors
+            .into_iter()
+            .filter(|fsid| {
+                fsid.get_factor_source_kind() == FactorSourceKind::Device
+            })
+            .count();
+
+        if device_count > 1 {
+            Err(MatrixBuilderValidation::CombinationViolation(
+                MatrixRolesInCombinationViolation::ForeverInvalid(
+                    MatrixRolesInCombinationForeverInvalid::PrimaryCannotHaveMultipleDevices,
+                ),
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
     /// Security Shield Rules
     /// In addition to the factor/role rules above, the wallet must enforce certain rules for combinations of
     /// factors across the three roles. The construction method described in the next section will automatically
@@ -557,13 +606,10 @@ impl MatrixBuilder {
     /// 4. Number of days until auto confirm is greater than zero
     fn validate_combination(&self) -> MatrixBuilderMutateResult {
         self.validate_if_primary_has_single_it_must_not_be_used_by_any_other_role()?;
+        self.validate_primary_cannot_have_multiple_devices()?;
+        self.validate_no_factor_may_be_used_in_both_primary_threshold_and_override()?;
         self.validate_no_factor_may_be_used_in_both_recovery_and_confirmation(
         )?;
-
-        // N.B. the third 3:
-        // "3. No factor may be used in both the `Primary` threshold and `Primary` override"
-        // is already enforced by the RoleBuilder
-
         self.validate_number_of_days_until_auto_confirm()?;
         Ok(())
     }

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/matrices/builder/matrix_builder_unit_tests.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/matrices/builder/matrix_builder_unit_tests.rs
@@ -537,58 +537,6 @@ mod validation_for_addition_of_factor_source_for_each {
         }
 
         #[test]
-        fn device_2x_threshold_override_first_ok_second_not() {
-            let mut sut = make();
-            let xs = sut.validation_for_addition_of_factor_source_to_primary_threshold_for_each(
-                &IndexSet::from_iter([
-                    FactorSourceID::sample_device(),
-                    FactorSourceID::sample_device_other(),
-                ]),
-            );
-            assert_eq!(
-                xs.into_iter().collect::<Vec<_>>(),
-                vec![
-                    FactorSourceInRoleBuilderValidationStatus::ok(
-                        RoleKind::Primary,
-                        FactorSourceID::sample_device()
-                    ),
-                    FactorSourceInRoleBuilderValidationStatus::ok(
-                        RoleKind::Primary,
-                        FactorSourceID::sample_device_other(),
-                    )
-                ]
-            );
-
-            sut.add_factor_source_to_primary_threshold(
-                FactorSourceID::sample_device(),
-            )
-            .unwrap();
-
-            let xs = sut.validation_for_addition_of_factor_source_to_primary_override_for_each(
-                &IndexSet::from_iter([
-                    FactorSourceID::sample_device(),
-                    FactorSourceID::sample_device_other(),
-                ]),
-            );
-
-            pretty_assertions::assert_eq!(
-                xs.into_iter().collect::<Vec<_>>(),
-                vec![
-                    FactorSourceInRoleBuilderValidationStatus::forever_invalid(
-                        RoleKind::Primary,
-                        FactorSourceID::sample_device(),
-                        ForeverInvalidReason::FactorSourceAlreadyPresent
-                    ),
-                    FactorSourceInRoleBuilderValidationStatus::forever_invalid(
-                        RoleKind::Primary,
-                        FactorSourceID::sample_device_other(),
-                        ForeverInvalidReason::PrimaryCannotHaveMultipleDevices
-                    ),
-                ]
-            );
-        }
-
-        #[test]
         fn device_threshold_override_2x_first_ok_second_not() {
             let mut sut = make();
             let xs = sut.validation_for_addition_of_factor_source_to_primary_threshold_for_each(
@@ -617,58 +565,6 @@ mod validation_for_addition_of_factor_source_for_each {
             .unwrap();
 
             let xs = sut.validation_for_addition_of_factor_source_to_primary_override_for_each(
-                &IndexSet::from_iter([
-                    FactorSourceID::sample_device(),
-                    FactorSourceID::sample_device_other(),
-                ]),
-            );
-
-            pretty_assertions::assert_eq!(
-                xs.into_iter().collect::<Vec<_>>(),
-                vec![
-                    FactorSourceInRoleBuilderValidationStatus::forever_invalid(
-                        RoleKind::Primary,
-                        FactorSourceID::sample_device(),
-                        ForeverInvalidReason::FactorSourceAlreadyPresent
-                    ),
-                    FactorSourceInRoleBuilderValidationStatus::forever_invalid(
-                        RoleKind::Primary,
-                        FactorSourceID::sample_device_other(),
-                        ForeverInvalidReason::PrimaryCannotHaveMultipleDevices
-                    ),
-                ]
-            );
-        }
-
-        #[test]
-        fn device_2x_override_threshold_first_ok_second_not() {
-            let mut sut = make();
-            let xs = sut.validation_for_addition_of_factor_source_to_primary_override_for_each(
-                &IndexSet::from_iter([
-                    FactorSourceID::sample_device(),
-                    FactorSourceID::sample_device_other(),
-                ]),
-            );
-            assert_eq!(
-                xs.into_iter().collect::<Vec<_>>(),
-                vec![
-                    FactorSourceInRoleBuilderValidationStatus::ok(
-                        RoleKind::Primary,
-                        FactorSourceID::sample_device()
-                    ),
-                    FactorSourceInRoleBuilderValidationStatus::ok(
-                        RoleKind::Primary,
-                        FactorSourceID::sample_device_other(),
-                    )
-                ]
-            );
-
-            sut.add_factor_source_to_primary_override(
-                FactorSourceID::sample_device(),
-            )
-            .unwrap();
-
-            let xs = sut.validation_for_addition_of_factor_source_to_primary_threshold_for_each(
                 &IndexSet::from_iter([
                     FactorSourceID::sample_device(),
                     FactorSourceID::sample_device_other(),

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/matrices/builder/matrix_builder_unit_tests.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/matrices/builder/matrix_builder_unit_tests.rs
@@ -527,10 +527,9 @@ mod validation_for_addition_of_factor_source_for_each {
                         FactorSourceID::sample_device(),
                         ForeverInvalidReason::FactorSourceAlreadyPresent
                     ),
-                    FactorSourceInRoleBuilderValidationStatus::forever_invalid(
+                    FactorSourceInRoleBuilderValidationStatus::ok(
                         RoleKind::Primary,
                         FactorSourceID::sample_device_other(),
-                        ForeverInvalidReason::PrimaryCannotHaveMultipleDevices
                     ),
                 ]
             );
@@ -579,10 +578,9 @@ mod validation_for_addition_of_factor_source_for_each {
                         FactorSourceID::sample_device(),
                         ForeverInvalidReason::FactorSourceAlreadyPresent
                     ),
-                    FactorSourceInRoleBuilderValidationStatus::forever_invalid(
+                    FactorSourceInRoleBuilderValidationStatus::ok(
                         RoleKind::Primary,
                         FactorSourceID::sample_device_other(),
-                        ForeverInvalidReason::PrimaryCannotHaveMultipleDevices
                     ),
                 ]
             );
@@ -1119,7 +1117,7 @@ mod validation_of_addition_of_kind {
         }
 
         #[test]
-        fn device_is_err_for_second_3x_threshold() {
+        fn device_is_ok_for_second_3x_threshold() {
             let mut sut = make();
             let res = sut.validation_for_addition_of_factor_source_of_kind_to_primary_threshold(
                 FactorSourceKind::Device,
@@ -1132,11 +1130,11 @@ mod validation_of_addition_of_kind {
             let res = sut.validation_for_addition_of_factor_source_of_kind_to_primary_threshold(
                 FactorSourceKind::Device,
             );
-            assert!(res.is_err());
+            assert!(res.is_ok());
         }
 
         #[test]
-        fn device_is_err_for_second_2x_threshold_override() {
+        fn device_is_ok_for_second_2x_threshold_override() {
             let mut sut = make();
             let res = sut.validation_for_addition_of_factor_source_of_kind_to_primary_threshold(
                 FactorSourceKind::Device,
@@ -1149,11 +1147,11 @@ mod validation_of_addition_of_kind {
             let res = sut.validation_for_addition_of_factor_source_of_kind_to_primary_override(
                 FactorSourceKind::Device,
             );
-            assert!(res.is_err());
+            assert!(res.is_ok());
         }
 
         #[test]
-        fn device_is_err_for_second_threshold_override_threshold() {
+        fn device_is_ok_for_second_threshold_override_threshold() {
             let mut sut = make();
             let res = sut.validation_for_addition_of_factor_source_of_kind_to_primary_threshold(
                 FactorSourceKind::Device,
@@ -1166,11 +1164,11 @@ mod validation_of_addition_of_kind {
             let res = sut.validation_for_addition_of_factor_source_of_kind_to_primary_threshold(
                 FactorSourceKind::Device,
             );
-            assert!(res.is_err());
+            assert!(res.is_ok());
         }
 
         #[test]
-        fn device_is_err_for_second_threshold_override_2x() {
+        fn device_is_ok_for_second_threshold_override_2x() {
             let mut sut = make();
             let res = sut.validation_for_addition_of_factor_source_of_kind_to_primary_threshold(
                 FactorSourceKind::Device,
@@ -1183,11 +1181,11 @@ mod validation_of_addition_of_kind {
             let res = sut.validation_for_addition_of_factor_source_of_kind_to_primary_override(
                 FactorSourceKind::Device,
             );
-            assert!(res.is_err());
+            assert!(res.is_ok());
         }
 
         #[test]
-        fn device_is_err_for_second_3x_override() {
+        fn device_is_ok_for_second_3x_override() {
             let mut sut = make();
             let res = sut.validation_for_addition_of_factor_source_of_kind_to_primary_override(
                 FactorSourceKind::Device,
@@ -1200,11 +1198,11 @@ mod validation_of_addition_of_kind {
             let res = sut.validation_for_addition_of_factor_source_of_kind_to_primary_override(
                 FactorSourceKind::Device,
             );
-            assert!(res.is_err());
+            assert!(res.is_ok());
         }
 
         #[test]
-        fn device_is_err_for_second_2x_override_threshold() {
+        fn device_is_ok_for_second_2x_override_threshold() {
             let mut sut = make();
             let res = sut.validation_for_addition_of_factor_source_of_kind_to_primary_override(
                 FactorSourceKind::Device,
@@ -1217,11 +1215,11 @@ mod validation_of_addition_of_kind {
             let res = sut.validation_for_addition_of_factor_source_of_kind_to_primary_threshold(
                 FactorSourceKind::Device,
             );
-            assert!(res.is_err());
+            assert!(res.is_ok());
         }
 
         #[test]
-        fn device_is_err_for_second_override_threshold_2x() {
+        fn device_is_ok_for_second_override_threshold_2x() {
             let mut sut = make();
             let res = sut.validation_for_addition_of_factor_source_of_kind_to_primary_override(
                 FactorSourceKind::Device,
@@ -1234,11 +1232,11 @@ mod validation_of_addition_of_kind {
             let res = sut.validation_for_addition_of_factor_source_of_kind_to_primary_threshold(
                 FactorSourceKind::Device,
             );
-            assert!(res.is_err());
+            assert!(res.is_ok());
         }
 
         #[test]
-        fn device_is_err_for_second_override_threshold_override() {
+        fn device_is_ok_for_second_override_threshold_override() {
             let mut sut = make();
             let res = sut.validation_for_addition_of_factor_source_of_kind_to_primary_override(
                 FactorSourceKind::Device,
@@ -1251,7 +1249,7 @@ mod validation_of_addition_of_kind {
             let res = sut.validation_for_addition_of_factor_source_of_kind_to_primary_override(
                 FactorSourceKind::Device,
             );
-            assert!(res.is_err());
+            assert!(res.is_ok());
         }
     }
 }

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/roles/builder/primary_roles_builder_unit_tests.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/roles/builder/primary_roles_builder_unit_tests.rs
@@ -970,7 +970,7 @@ mod device_factor_source {
         }
 
         #[test]
-        fn two_different_is_err() {
+        fn two_different_is_ok() {
             // Arrange
             let mut sut = make();
 
@@ -980,12 +980,7 @@ mod device_factor_source {
             let res = sut.add_factor_source_to_threshold(sample_other());
 
             // Assert
-            assert!(matches!(
-                res,
-                MutRes::Err(Validation::ForeverInvalid(
-                    ForeverInvalidReason::PrimaryCannotHaveMultipleDevices
-                ))
-            ));
+            assert!(matches!(res, Ok(())));
         }
     }
 

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/roles/builder/roles_builder.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/roles/builder/roles_builder.rs
@@ -643,42 +643,21 @@ impl<const ROLE: u8> RoleBuilder<ROLE> {
             FactorSourceAlreadyPresent,
         );
 
-        match mode {
-            SecurityShieldBuilderMode::Strict => {
-                if self.contains_factor_source(factor_source_id) {
+        match factor_list_kind {
+            Override => {
+                if self.override_contains_factor_source(factor_source_id) {
                     return duplicates_err;
                 }
             }
-            SecurityShieldBuilderMode::Lenient => {
-                match factor_list_kind {
-                    Override => {
-                        if self
-                            .override_contains_factor_source(factor_source_id)
-                        {
-                            return duplicates_err;
-                        }
-                        // but if threshold contains it, we're good (since mode is lenient)
-                    }
-                    Threshold => {
-                        if self
-                            .threshold_contains_factor_source(factor_source_id)
-                        {
-                            return duplicates_err;
-                        }
-                    } // but if override contains it, we're good (since mode is lenient)
+            Threshold => {
+                if self.threshold_contains_factor_source(factor_source_id) {
+                    return duplicates_err;
                 }
             }
         }
+
         let factor_source_kind = factor_source_id.get_factor_source_kind();
         self._validation_add(factor_source_kind, factor_list_kind, mode)
-    }
-
-    fn contains_factor_source(
-        &self,
-        factor_source_id: &FactorSourceID,
-    ) -> bool {
-        self.override_contains_factor_source(factor_source_id)
-            || self.threshold_contains_factor_source(factor_source_id)
     }
 
     fn contains_factor_source_of_kind(

--- a/crates/profile/models/security-structures/src/roles_matrices_structures/security_shield_builder_rule_violation.rs
+++ b/crates/profile/models/security-structures/src/roles_matrices_structures/security_shield_builder_rule_violation.rs
@@ -68,6 +68,12 @@ impl AsShieldBuilderViolation for MatrixRolesInCombinationForeverInvalid {
             RecoveryAndConfirmationFactorsOverlap => {
                 Some(SecurityShieldBuilderRuleViolation::RecoveryAndConfirmationFactorsOverlap)
             }
+            PrimaryCannotHaveMultipleDevices => {
+                Some(SecurityShieldBuilderRuleViolation::PrimaryCannotHaveMultipleDevices)
+            }
+            ThresholdAndOverrideFactorsOverlap => {
+                Some(SecurityShieldBuilderRuleViolation::FactorSourceAlreadyPresent)
+            }
         }
     }
 }
@@ -108,9 +114,8 @@ impl AsShieldBuilderViolation for ForeverInvalidReason {
     ) -> Option<SecurityShieldBuilderRuleViolation> {
         use ForeverInvalidReason::*;
         let reason = match self {
-            FactorSourceAlreadyPresent => SecurityShieldBuilderRuleViolation::FactorSourceAlreadyPresent,
-            PrimaryCannotHaveMultipleDevices => {
-                SecurityShieldBuilderRuleViolation::PrimaryCannotHaveMultipleDevices
+            FactorSourceAlreadyPresent => {
+                SecurityShieldBuilderRuleViolation::FactorSourceAlreadyPresent
             }
             PrimaryCannotHavePasswordInOverrideList => {
                 SecurityShieldBuilderRuleViolation::PrimaryCannotHavePasswordInOverrideList

--- a/crates/system/os/factors/src/sargon_os_security_structures.rs
+++ b/crates/system/os/factors/src/sargon_os_security_structures.rs
@@ -221,14 +221,13 @@ mod tests {
         // ACT
         let structure_factor_id_level =
             SecurityStructureOfFactorSourceIDs::sample();
-        let _ = os
-            .with_timeout(|x| {
-                x.add_security_structure_of_factor_source_ids(
-                    &structure_factor_id_level,
-                )
-            })
-            .await
-            .unwrap();
+        os.with_timeout(|x| {
+            x.add_security_structure_of_factor_source_ids(
+                &structure_factor_id_level,
+            )
+        })
+        .await
+        .unwrap();
 
         // ASSERT
         assert!(os
@@ -322,12 +321,11 @@ mod tests {
         // ACT
         let structure_ids = SecurityStructureOfFactorSourceIDs::sample();
         let id = structure_ids.metadata.id;
-        let _ = os
-            .with_timeout(|x| {
-                x.add_security_structure_of_factor_source_ids(&structure_ids)
-            })
-            .await
-            .unwrap();
+        os.with_timeout(|x| {
+            x.add_security_structure_of_factor_source_ids(&structure_ids)
+        })
+        .await
+        .unwrap();
 
         // ASSERT
         assert!(event_bus_driver.recorded().iter().any(|e| e.event
@@ -350,14 +348,13 @@ mod tests {
             SecurityStructureOfFactorSourceIDs::sample();
         let structure_source_ids_sample_other =
             SecurityStructureOfFactorSourceIDs::sample_other();
-        let _ = os
-            .with_timeout(|x| {
-                x.add_security_structure_of_factor_source_ids(
-                    &structure_source_ids_sample,
-                )
-            })
-            .await
-            .unwrap();
+        os.with_timeout(|x| {
+            x.add_security_structure_of_factor_source_ids(
+                &structure_source_ids_sample,
+            )
+        })
+        .await
+        .unwrap();
 
         let result = os
             .with_timeout(|x| {
@@ -373,14 +370,13 @@ mod tests {
             })
         );
 
-        let _ = os
-            .with_timeout(|x| {
-                x.add_security_structure_of_factor_source_ids(
-                    &structure_source_ids_sample_other,
-                )
-            })
-            .await
-            .unwrap();
+        os.with_timeout(|x| {
+            x.add_security_structure_of_factor_source_ids(
+                &structure_source_ids_sample_other,
+            )
+        })
+        .await
+        .unwrap();
 
         let structure_id_sample = SecurityStructureOfFactorSourceIDs::from(
             structure_source_ids_sample.clone(),

--- a/crates/system/os/signing/src/sargon_os_signing.rs
+++ b/crates/system/os/signing/src/sargon_os_signing.rs
@@ -340,9 +340,9 @@ mod test {
         let signable =
             TransactionIntent::sample_entity_addresses_requiring_auth(
                 [
-                    account_device.address.clone(),
-                    account_ledger1.address.clone(),
-                    account_ledger2.address.clone(),
+                    account_device.address,
+                    account_ledger1.address,
+                    account_ledger2.address,
                 ],
                 [],
             );

--- a/crates/uniffi/uniffi_SPLIT_ME/src/profile/mfa/security_structures/security_shield_builder.rs
+++ b/crates/uniffi/uniffi_SPLIT_ME/src/profile/mfa/security_structures/security_shield_builder.rs
@@ -594,8 +594,10 @@ impl FactorSource {
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
+    use profile_security_structures::prelude::{
+        FactorSourceInRoleBuilderValidationStatus, ForeverInvalidReason,
+    };
 
     #[allow(clippy::upper_case_acronyms)]
     type SUT = SecurityShieldBuilder;
@@ -849,14 +851,14 @@ mod tests {
             ])
         );
 
-        assert_ne!(
+        assert_eq!(
             sim_kind_prim,
             sut.clone().addition_of_factor_source_of_kind_to_primary_override_is_fully_valid(
                 FactorSourceKind::Device,
             )
         );
 
-        assert_ne!(
+        assert_eq!(
             sim_kind_prim_threshold,
             sut.clone().addition_of_factor_source_of_kind_to_primary_threshold_is_fully_valid(
                 FactorSourceKind::Device,
@@ -1030,5 +1032,25 @@ mod tests {
                 ]
             }
         );
+    }
+
+    #[test]
+    fn primary_override_validation_status_trusted_contact() {
+        let sut = SUT::new();
+        let res = sut.validation_for_addition_of_factor_source_to_primary_override_for_each(
+            vec![FactorSourceID::sample_trusted_contact()],
+        );
+        pretty_assertions::assert_eq!(
+            res,
+            vec![
+                FactorSourceValidationStatus {
+                    role: RoleKind::Primary,
+                    factor_source_id: FactorSourceID::sample_trusted_contact(),
+                    reason_if_invalid: Some(FactorSourceValidationStatusReasonIfInvalid::NonBasic(
+                        SecurityShieldBuilderRuleViolation::PrimaryCannotContainTrustedContact
+                    ))
+                }
+            ]
+        )
     }
 }


### PR DESCRIPTION
This PR updates the shield builder validation logic by introducing two key updates:

1. **Factor Source Selection**: It now allows adding the same factor source for both the threshold and override lists in the primary role.
2. **Multiple Device Selection**: It supports adding multiple devices within the primary role.

The `validate()` function has been updated to continue reflecting that these rules violations and therefore making the shield status `Weak` with the corresponding underlying reason.