### PR TITLE
Allow canonical BIP32 string in `FromStr`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "account-for-display"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "addresses",
  "derive_more",
@@ -49,10 +49,10 @@ dependencies = [
 
 [[package]]
 name = "addresses"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "assert-json",
- "bytes 1.1.118",
+ "bytes 1.1.119",
  "cap26-models",
  "core-utils",
  "derive_more",
@@ -246,7 +246,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "assert-json"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "assert-json-diff",
  "error",
@@ -546,7 +546,7 @@ dependencies = [
 
 [[package]]
 name = "build-info"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "assert-json",
  "cargo_toml",
@@ -573,7 +573,7 @@ checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
 
 [[package]]
 name = "bytes"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "assert-json",
  "delegate",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "cap26-models"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "assert-json",
  "derive_more",
@@ -748,7 +748,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "clients"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -808,7 +808,7 @@ checksum = "0d8a42181e0652c2997ae4d217f25b63c5337a52fd2279736e97b832fa0a3cff"
 
 [[package]]
 name = "core-collections"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "has-sample-values",
  "indexmap 2.7.0",
@@ -835,7 +835,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-misc"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "assert-json",
  "core-utils",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "core-utils"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "error",
  "iso8601-timestamp",
@@ -1084,7 +1084,7 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "drivers"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -1108,10 +1108,10 @@ dependencies = [
 
 [[package]]
 name = "ecc"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "assert-json",
- "bytes 1.1.118",
+ "bytes 1.1.119",
  "derive_more",
  "enum-as-inner",
  "error",
@@ -1210,11 +1210,11 @@ dependencies = [
 
 [[package]]
 name = "encryption"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "aes-gcm",
  "assert-json",
- "bytes 1.1.118",
+ "bytes 1.1.119",
  "derive_more",
  "error",
  "has-sample-values",
@@ -1231,7 +1231,7 @@ dependencies = [
 
 [[package]]
 name = "entity-by-address"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "addresses",
  "error",
@@ -1243,7 +1243,7 @@ dependencies = [
 
 [[package]]
 name = "entity-foundation"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "assert-json",
  "derive_more",
@@ -1318,7 +1318,7 @@ dependencies = [
 
 [[package]]
 name = "error"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "derive_more",
  "log",
@@ -1377,7 +1377,7 @@ dependencies = [
 
 [[package]]
 name = "factor-instances-provider"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -1403,9 +1403,9 @@ dependencies = [
 
 [[package]]
 name = "factors"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
- "bytes 1.1.118",
+ "bytes 1.1.119",
  "cap26-models",
  "core-collections",
  "core-misc",
@@ -1440,7 +1440,7 @@ dependencies = [
 
 [[package]]
 name = "factors-supporting-types"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "async-trait",
  "error",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-client-and-api"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -1613,7 +1613,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-models"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "addresses",
  "assert-json",
@@ -1718,7 +1718,7 @@ dependencies = [
 
 [[package]]
 name = "has-sample-values"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "error",
  "indexmap 2.7.0",
@@ -1729,9 +1729,9 @@ dependencies = [
 
 [[package]]
 name = "hash"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
- "bytes 1.1.118",
+ "bytes 1.1.119",
  "derive_more",
  "prelude",
  "radix-common",
@@ -1795,11 +1795,11 @@ dependencies = [
 
 [[package]]
 name = "hierarchical-deterministic"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "assert-json",
  "bip39",
- "bytes 1.1.118",
+ "bytes 1.1.119",
  "cap26-models",
  "derive_more",
  "ecc",
@@ -1842,13 +1842,13 @@ dependencies = [
 
 [[package]]
 name = "home-cards"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "actix-rt",
  "addresses",
  "async-trait",
  "base64",
- "bytes 1.1.118",
+ "bytes 1.1.119",
  "core-utils",
  "derive_more",
  "drivers",
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "host-info"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "assert-json",
  "derive_more",
@@ -1915,10 +1915,10 @@ dependencies = [
 
 [[package]]
 name = "http-client"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "actix-rt",
- "bytes 1.1.118",
+ "bytes 1.1.119",
  "core-utils",
  "drivers",
  "error",
@@ -2143,7 +2143,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "identified-vec-of"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "assert-json",
  "derive_more",
@@ -2216,7 +2216,7 @@ dependencies = [
 
 [[package]]
 name = "interactors"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -2336,7 +2336,7 @@ dependencies = [
 
 [[package]]
 name = "key-derivation-traits"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "addresses",
  "async-trait",
@@ -2354,7 +2354,7 @@ dependencies = [
 
 [[package]]
 name = "keys-collector"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -2443,7 +2443,7 @@ dependencies = [
 
 [[package]]
 name = "manifests"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "account-for-display",
  "addresses",
@@ -2484,7 +2484,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "metadata"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "derive_more",
  "has-sample-values",
@@ -2584,7 +2584,7 @@ dependencies = [
 
 [[package]]
 name = "network"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "assert-json",
  "enum-iterator",
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "next-derivation-index-ephemeral"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "addresses",
  "assert-json",
@@ -2676,9 +2676,9 @@ dependencies = [
 
 [[package]]
 name = "numeric"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
- "bytes 1.1.118",
+ "bytes 1.1.119",
  "delegate",
  "derive_more",
  "enum-iterator",
@@ -2898,7 +2898,7 @@ dependencies = [
 
 [[package]]
 name = "prelude"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "radix-engine",
  "radix-engine-toolkit",
@@ -2935,7 +2935,7 @@ dependencies = [
 
 [[package]]
 name = "profile"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "account-for-display",
  "addresses",
@@ -2979,7 +2979,7 @@ dependencies = [
 
 [[package]]
 name = "profile-account"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "account-for-display",
  "addresses",
@@ -2999,7 +2999,7 @@ dependencies = [
 
 [[package]]
 name = "profile-account-or-persona"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "cap26-models",
  "derive_more",
@@ -3016,7 +3016,7 @@ dependencies = [
 
 [[package]]
 name = "profile-app-preferences"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "addresses",
  "core-misc",
@@ -3039,7 +3039,7 @@ dependencies = [
 
 [[package]]
 name = "profile-base-entity"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "addresses",
  "derive_more",
@@ -3062,7 +3062,7 @@ dependencies = [
 
 [[package]]
 name = "profile-gateway"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "addresses",
  "assert-json",
@@ -3086,7 +3086,7 @@ dependencies = [
 
 [[package]]
 name = "profile-logic"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "addresses",
  "derive_more",
@@ -3108,7 +3108,7 @@ dependencies = [
 
 [[package]]
 name = "profile-persona"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "addresses",
  "cap26-models",
@@ -3129,7 +3129,7 @@ dependencies = [
 
 [[package]]
 name = "profile-persona-data"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "addresses",
  "assert-json",
@@ -3148,7 +3148,7 @@ dependencies = [
 
 [[package]]
 name = "profile-security-structures"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "addresses",
  "cap26-models",
@@ -3176,7 +3176,7 @@ dependencies = [
 
 [[package]]
 name = "profile-state-holder"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "derive_more",
  "error",
@@ -3191,7 +3191,7 @@ dependencies = [
 
 [[package]]
 name = "profile-supporting-types"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "addresses",
  "derive_more",
@@ -3280,14 +3280,14 @@ dependencies = [
 
 [[package]]
 name = "radix-connect"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "actix-rt",
  "addresses",
  "assert-json",
  "async-trait",
  "base64",
- "bytes 1.1.118",
+ "bytes 1.1.119",
  "core-misc",
  "core-utils",
  "derive_more",
@@ -3315,10 +3315,10 @@ dependencies = [
 
 [[package]]
 name = "radix-connect-models"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "addresses",
- "bytes 1.1.118",
+ "bytes 1.1.119",
  "core-misc",
  "derive_more",
  "error",
@@ -3760,7 +3760,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -3825,7 +3825,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -3852,7 +3852,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-accounts"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -3875,7 +3875,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-derive-public-keys"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -3894,7 +3894,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-factors"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -3922,7 +3922,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-security-center"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "actix-rt",
  "derive_more",
@@ -3938,7 +3938,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-signing"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -3964,7 +3964,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-transaction"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "actix-rt",
  "async-std",
@@ -3993,7 +3993,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-uniffi"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -4050,7 +4050,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-uniffi-conversion-macros"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4223,7 +4223,7 @@ dependencies = [
 
 [[package]]
 name = "security-center"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "addresses",
  "assert-json",
@@ -4391,7 +4391,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "short-string"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "arraystring",
  "assert-json",
@@ -4426,13 +4426,13 @@ dependencies = [
 
 [[package]]
 name = "signing"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "actix-rt",
  "addresses",
  "assert-json",
  "async-trait",
- "bytes 1.1.118",
+ "bytes 1.1.119",
  "cap26-models",
  "core-collections",
  "core-misc",
@@ -4464,10 +4464,10 @@ dependencies = [
 
 [[package]]
 name = "signing-traits"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "async-trait",
- "bytes 1.1.118",
+ "bytes 1.1.119",
  "core-collections",
  "derive_more",
  "ecc",
@@ -4632,7 +4632,7 @@ dependencies = [
 
 [[package]]
 name = "sub-systems"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "derive_more",
  "drivers",
@@ -4791,7 +4791,7 @@ dependencies = [
 
 [[package]]
 name = "time-utils"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "iso8601-timestamp",
  "prelude",
@@ -4941,10 +4941,10 @@ dependencies = [
 
 [[package]]
 name = "transaction-foundation"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "assert-json",
- "bytes 1.1.118",
+ "bytes 1.1.119",
  "derive_more",
  "has-sample-values",
  "paste",
@@ -4956,10 +4956,10 @@ dependencies = [
 
 [[package]]
 name = "transaction-models"
-version = "1.1.118"
+version = "1.1.119"
 dependencies = [
  "addresses",
- "bytes 1.1.118",
+ "bytes 1.1.119",
  "cargo_toml",
  "core-collections",
  "core-misc",

--- a/apple/Sources/Sargon/Extensions/Methods/Crypto/Derivation/DerivationPath+Wrap+Functions.swift
+++ b/apple/Sources/Sargon/Extensions/Methods/Crypto/Derivation/DerivationPath+Wrap+Functions.swift
@@ -6,10 +6,20 @@ extension DerivationPath {
 		derivationPathToHdPath(path: self)
 	}
 
+	/// Returns a CAP 43 String representation of this `DerivationPath`.
+	/// Useful when we need to log or debug, but should **never** be used when communicating with external APIs.
 	public func toString() -> String {
 		derivationPathToString(path: self)
 	}
 
+	/// Returns a BIP 32 String representation of this `DerivationPath`.
+	/// Needed to communicate with external APIs such as Arculus or Ledger.
+	public func toBip32String() -> String {
+		derivationPathToBip32String(path: self)
+	}
+
+	/// Attempts to build a DerivationPath from a CAP 43 or BIP 32 representation.
+	/// The initializer is lenient, so it will attempt with the latter if the first fails
 	public init(string: String) throws {
 		self = try newDerivationPathFromString(string: string)
 	}

--- a/apple/Tests/TestCases/Crypto/DerivationPathTests.swift
+++ b/apple/Tests/TestCases/Crypto/DerivationPathTests.swift
@@ -78,4 +78,24 @@ final class DerivationPathTests: HDPathProtocolTest<DerivationPath> {
 			"m/44H/1022H/2H/618H/1460H/42H"
 		)
 	}
+
+	func test_to_bip32() throws {
+		// Build from CAP43 syntax
+		var sut = try SUT(string: "m/44H/1022H/1H/525H/1460H/0S")
+		XCTAssertEqual(sut.toBip32String(), "m/44H/1022H/1H/525H/1460H/1073741824H")
+
+		// Build from BIP32 syntax
+		sut = try SUT(string: "m/44H/1022H/1H/525H/1460H/2H")
+		XCTAssertEqual(sut.toBip32String(), "m/44H/1022H/1H/525H/1460H/2H")
+	}
+
+	func test_to_string() throws {
+		// Build from CAP43 syntax
+		var sut = try SUT(string: "m/44H/1022H/1H/525H/1460H/0S")
+		XCTAssertEqual(sut.toString(), "m/44H/1022H/1H/525H/1460H/0S")
+
+		// Build from BIP32 syntax
+		sut = try SUT(string: "m/44H/1022H/1H/525H/1460H/2H")
+		XCTAssertEqual(sut.toString(), "m/44H/1022H/1H/525H/1460H/2H")
+	}
 }

--- a/crates/app/home-cards/Cargo.toml
+++ b/crates/app/home-cards/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "home-cards"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/key-derivation-traits/Cargo.toml
+++ b/crates/app/key-derivation-traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "key-derivation-traits"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/radix-connect-models/Cargo.toml
+++ b/crates/app/radix-connect-models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "radix-connect-models"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/radix-connect/Cargo.toml
+++ b/crates/app/radix-connect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "radix-connect"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 

--- a/crates/app/security-center/Cargo.toml
+++ b/crates/app/security-center/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "security-center"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/signing-traits/Cargo.toml
+++ b/crates/app/signing-traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signing-traits"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/signing/Cargo.toml
+++ b/crates/app/signing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signing"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 

--- a/crates/common/build-info/Cargo.toml
+++ b/crates/common/build-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "build-info"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/common/bytes/Cargo.toml
+++ b/crates/common/bytes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bytes"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/entity-foundation/Cargo.toml
+++ b/crates/common/entity-foundation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entity-foundation"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/host-info/Cargo.toml
+++ b/crates/common/host-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "host-info"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/identified-vec-of/Cargo.toml
+++ b/crates/common/identified-vec-of/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "identified-vec-of"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/metadata/Cargo.toml
+++ b/crates/common/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metadata"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/network/Cargo.toml
+++ b/crates/common/network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "network"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/numeric/Cargo.toml
+++ b/crates/common/numeric/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numeric"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/short-string/Cargo.toml
+++ b/crates/common/short-string/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "short-string"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/assert-json/Cargo.toml
+++ b/crates/core/assert-json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assert-json"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/collections/Cargo.toml
+++ b/crates/core/collections/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-collections"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/error/Cargo.toml
+++ b/crates/core/error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "error"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/has-sample-values/Cargo.toml
+++ b/crates/core/has-sample-values/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "has-sample-values"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/misc/Cargo.toml
+++ b/crates/core/misc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-misc"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/prelude/Cargo.toml
+++ b/crates/core/prelude/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prelude"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/time-utils/Cargo.toml
+++ b/crates/core/time-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "time-utils"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/utils/Cargo.toml
+++ b/crates/core/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-utils"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/addresses/Cargo.toml
+++ b/crates/crypto/addresses/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "addresses"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/cap26-models/Cargo.toml
+++ b/crates/crypto/cap26-models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cap26-models"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/ecc/Cargo.toml
+++ b/crates/crypto/ecc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecc"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/encryption/Cargo.toml
+++ b/crates/crypto/encryption/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "encryption"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/hash/Cargo.toml
+++ b/crates/crypto/hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hash"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/hd/Cargo.toml
+++ b/crates/crypto/hd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hierarchical-deterministic"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/hd/src/bip32/hd_path.rs
+++ b/crates/crypto/hd/src/bip32/hd_path.rs
@@ -15,8 +15,8 @@ use crate::prelude::*;
     DeserializeFromStr,
     SerializeDisplay,
 )]
-#[display("{}", self.to_bip32_string())]
-#[debug("{}", self.to_bip32_string_debug())]
+#[display("{}", self.to_cap43_string())]
+#[debug("{}", self.to_cap43_string_debug())]
 pub struct HDPath {
     pub components: Vec<HDPathComponent>,
 }
@@ -29,8 +29,8 @@ impl HDPath {
     }
 }
 
-impl FromBIP32Str for HDPath {
-    fn from_bip32_string(s: impl AsRef<str>) -> Result<Self> {
+impl FromCAP43String for HDPath {
+    fn from_cap43_string(s: impl AsRef<str>) -> Result<Self> {
         let s = s.as_ref();
         let mut s = s;
         if s.starts_with(&format!("m{}", Self::SEPARATOR)) {
@@ -45,7 +45,7 @@ impl FromBIP32Str for HDPath {
         let components = s
             .split(Self::SEPARATOR)
             .filter(|s| !s.is_empty())
-            .map(HDPathComponent::from_bip32_string)
+            .map(HDPathComponent::from_cap43_string)
             .collect::<Result<Vec<_>>>()?;
         Ok(Self::new(components))
     }
@@ -66,7 +66,7 @@ impl HDPath {
         path.into_iter().join(Self::SEPARATOR)
     }
 
-    pub fn to_bip32_string_with(
+    pub fn to_cap43_string_with(
         &self,
         include_head: bool,
         canonicalize_entity_index: bool,
@@ -85,30 +85,30 @@ impl HDPath {
         })
     }
 
-    pub fn to_bip32_string_debug_with(&self, include_head: bool) -> String {
+    pub fn to_cap43_string_debug_with(&self, include_head: bool) -> String {
         self.to_string_map_with(include_head, |(_, c)| format!("{:?}", c))
     }
 
-    /// This method returns the canonical bip32 representation of the path.
+    /// String representation of the path using BIP32 notation.
     /// In sargon, paths in the securified space are printed with the `S` notation after the index,
     /// for readability purposes.
     ///
     /// The notation `{i}S` means `{i + 2^30}H`, and since `H` means `+ 2^31` we can
     /// verbosely express `{i}S` as `{i + 2^30 + 2^31} (without the H)
     ///
-    /// Such paths need to be canonicalized in bip32 notation meaning that
+    /// Such paths need to be on BIP32 notation meaning that
     /// an index of `"{i}S"` => `"{i + 2^30}H"` when communication with other external APIs,
     /// e.g. using Ledger hardware wallet or Arculus.
-    pub fn to_canonical_bip32_string(&self) -> String {
-        self.to_bip32_string_with(true, true)
+    pub fn to_bip32_string(&self) -> String {
+        self.to_cap43_string_with(true, true)
     }
 }
-impl ToBIP32Str for HDPath {
-    fn to_bip32_string(&self) -> String {
-        self.to_bip32_string_with(true, false)
+impl ToCAP43String for HDPath {
+    fn to_cap43_string(&self) -> String {
+        self.to_cap43_string_with(true, false)
     }
-    fn to_bip32_string_debug(&self) -> String {
-        self.to_bip32_string_debug_with(true)
+    fn to_cap43_string_debug(&self) -> String {
+        self.to_cap43_string_debug_with(true)
     }
 }
 
@@ -116,7 +116,7 @@ impl FromStr for HDPath {
     type Err = CommonError;
 
     fn from_str(s: &str) -> Result<Self> {
-        Self::from_bip32_string(s)
+        Self::from_cap43_string(s)
     }
 }
 
@@ -237,14 +237,14 @@ mod tests {
     }
 
     #[test]
-    fn from_canonical_bip32_str() {
+    fn from_bip32_str() {
         let canonical = "m/44H/1022H/1H/525H/1460H/1073741824H";
         let sut = SUT::from_str(canonical).unwrap();
         assert_eq!(
             DerivationPath::from(AccountPath::try_from(sut.clone()).unwrap())
-                .to_canonical_bip32_string(),
+                .to_bip32_string(),
             canonical
         );
-        assert_eq!(sut.to_bip32_string(), "m/44H/1022H/1H/525H/1460H/0S");
+        assert_eq!(sut.to_cap43_string(), "m/44H/1022H/1H/525H/1460H/0S");
     }
 }

--- a/crates/crypto/hd/src/bip32/hd_path.rs
+++ b/crates/crypto/hd/src/bip32/hd_path.rs
@@ -235,4 +235,16 @@ mod tests {
         assert_json_value_fails::<HDPath>(json!("m/44X"));
         assert_json_value_fails::<HDPath>(json!("super invalid path"));
     }
+
+    #[test]
+    fn from_canonical_bip32_str() {
+        let canonical = "m/44H/1022H/1H/525H/1460H/1073741824H";
+        let sut = SUT::from_str(canonical).unwrap();
+        assert_eq!(
+            DerivationPath::from(AccountPath::try_from(sut.clone()).unwrap())
+                .to_canonical_bip32_string(),
+            canonical
+        );
+        assert_eq!(sut.to_bip32_string(), "m/44H/1022H/1H/525H/1460H/0S");
+    }
 }

--- a/crates/crypto/hd/src/bip32/hd_path_component.rs
+++ b/crates/crypto/hd/src/bip32/hd_path_component.rs
@@ -71,12 +71,12 @@ impl Ord for HDPathComponent {
     }
 }
 
-impl ToBIP32Str for HDPathComponent {
-    fn to_bip32_string(&self) -> String {
+impl ToCAP43String for HDPathComponent {
+    fn to_cap43_string(&self) -> String {
         format!("{}", self)
     }
 
-    fn to_bip32_string_debug(&self) -> String {
+    fn to_cap43_string_debug(&self) -> String {
         format!("{:?}", self)
     }
 }
@@ -168,13 +168,13 @@ impl HDPathComponent {
     }
 }
 
-impl FromBIP32Str for HDPathComponent {
-    fn from_bip32_string(s: impl AsRef<str>) -> Result<Self> {
+impl FromCAP43String for HDPathComponent {
+    fn from_cap43_string(s: impl AsRef<str>) -> Result<Self> {
         let s = s.as_ref();
-        SecurifiedU30::from_lenient_bip32_string(s)
+        SecurifiedU30::from_string_lenient(s)
             .map(Self::securified)
             .or_else(|_| {
-                Unsecurified::from_bip32_string(s).map(Self::Unsecurified)
+                Unsecurified::from_cap43_string(s).map(Self::Unsecurified)
             })
     }
 }
@@ -182,7 +182,7 @@ impl FromBIP32Str for HDPathComponent {
 impl FromStr for HDPathComponent {
     type Err = CommonError;
     fn from_str(s: &str) -> Result<Self> {
-        Self::from_bip32_string(s)
+        Self::from_cap43_string(s)
     }
 }
 
@@ -517,7 +517,7 @@ mod tests {
         assert_eq!(
             SUT::from_global_key_space(0)
                 .unwrap()
-                .to_bip32_string_debug(),
+                .to_cap43_string_debug(),
             "0"
         );
     }
@@ -531,7 +531,7 @@ mod tests {
         assert_eq!(
             SUT::from_global_key_space(U30_MAX)
                 .unwrap()
-                .to_bip32_string(),
+                .to_cap43_string(),
             "1073741823"
         );
     }

--- a/crates/crypto/hd/src/bip32/hd_path_component.rs
+++ b/crates/crypto/hd/src/bip32/hd_path_component.rs
@@ -171,9 +171,11 @@ impl HDPathComponent {
 impl FromBIP32Str for HDPathComponent {
     fn from_bip32_string(s: impl AsRef<str>) -> Result<Self> {
         let s = s.as_ref();
-        SecurifiedU30::from_bip32_string(s)
+        SecurifiedU30::from_lenient_bip32_string(s)
             .map(Self::securified)
-            .or(Unsecurified::from_bip32_string(s).map(Self::Unsecurified))
+            .or_else(|_| {
+                Unsecurified::from_bip32_string(s).map(Self::Unsecurified)
+            })
     }
 }
 
@@ -462,7 +464,7 @@ mod tests {
     }
 
     #[test]
-    fn from_str_valid_0_hardened_canonical() {
+    fn from_str_valid_0_hardened_verbose_syntax() {
         assert_eq!(
             "0H".parse::<SUT>().unwrap(),
             SUT::from_global_key_space(GLOBAL_OFFSET_HARDENED).unwrap()
@@ -470,7 +472,7 @@ mod tests {
     }
 
     #[test]
-    fn from_str_valid_1_hardened_canonical() {
+    fn from_str_valid_1_hardened_verbose_syntax() {
         assert_eq!(
             "1H".parse::<SUT>().unwrap(),
             SUT::from_global_key_space(1 + GLOBAL_OFFSET_HARDENED).unwrap()
@@ -478,7 +480,7 @@ mod tests {
     }
 
     #[test]
-    fn from_str_valid_2_hardened_non_canonical() {
+    fn from_str_valid_2_hardened_non_verbose_syntax() {
         assert_eq!(
             "2'".parse::<SUT>().unwrap(),
             SUT::from_global_key_space(2 + GLOBAL_OFFSET_HARDENED).unwrap()
@@ -486,7 +488,7 @@ mod tests {
     }
 
     #[test]
-    fn from_str_valid_3_hardened_non_canonical() {
+    fn from_str_valid_3_hardened_non_verbose_syntax() {
         assert_eq!(
             "3'".parse::<SUT>().unwrap(),
             SUT::from_global_key_space(3 + GLOBAL_OFFSET_HARDENED).unwrap()

--- a/crates/crypto/hd/src/bip32/key_space/components/hardened.rs
+++ b/crates/crypto/hd/src/bip32/key_space/components/hardened.rs
@@ -151,12 +151,12 @@ impl FromGlobalKeySpace for Hardened {
 pub const HARDENED_SUFFIX_BIP32: &str = "H";
 pub const HARDENED_SUFFIX_BIP44: &str = "'";
 
-impl FromBIP32Str for Hardened {
-    fn from_bip32_string(s: impl AsRef<str>) -> Result<Self> {
+impl FromCAP43String for Hardened {
+    fn from_cap43_string(s: impl AsRef<str>) -> Result<Self> {
         let s = s.as_ref();
-        SecurifiedU30::from_bip32_string(s)
+        SecurifiedU30::from_cap43_string(s)
             .map(Self::Securified)
-            .or(UnsecurifiedHardened::from_bip32_string(s)
+            .or(UnsecurifiedHardened::from_cap43_string(s)
                 .map(Self::Unsecurified))
     }
 }
@@ -198,7 +198,7 @@ impl TryFrom<HDPathComponent> for Hardened {
 impl FromStr for Hardened {
     type Err = CommonError;
     fn from_str(s: &str) -> Result<Self> {
-        Self::from_bip32_string(s)
+        Self::from_cap43_string(s)
     }
 }
 

--- a/crates/crypto/hd/src/bip32/key_space/components/hardened.rs
+++ b/crates/crypto/hd/src/bip32/key_space/components/hardened.rs
@@ -148,6 +148,9 @@ impl FromGlobalKeySpace for Hardened {
     }
 }
 
+pub const HARDENED_SUFFIX_BIP32: &str = "H";
+pub const HARDENED_SUFFIX_BIP44: &str = "'";
+
 impl FromBIP32Str for Hardened {
     fn from_bip32_string(s: impl AsRef<str>) -> Result<Self> {
         let s = s.as_ref();

--- a/crates/crypto/hd/src/bip32/key_space/components/hardened.rs
+++ b/crates/crypto/hd/src/bip32/key_space/components/hardened.rs
@@ -283,7 +283,7 @@ mod tests {
     }
 
     #[test]
-    fn from_str_valid_1_securified_canonical() {
+    fn from_str_valid_1_securified_verbose_syntax() {
         assert_eq!(
             "1S".parse::<SUT>().unwrap(),
             SUT::from_global_key_space(1 + GLOBAL_OFFSET_HARDENED_SECURIFIED)
@@ -291,7 +291,7 @@ mod tests {
         );
     }
     #[test]
-    fn from_str_valid_1_securified_non_canonical() {
+    fn from_str_valid_1_securified_shorthand_syntax() {
         assert_eq!(
             "1^".parse::<SUT>().unwrap(),
             SUT::from_global_key_space(1 + GLOBAL_OFFSET_HARDENED_SECURIFIED)
@@ -300,7 +300,7 @@ mod tests {
     }
 
     #[test]
-    fn from_str_valid_1_hardened_canonical() {
+    fn from_str_valid_1_hardened_verbose_syntax() {
         assert_eq!(
             "1H".parse::<SUT>().unwrap(),
             SUT::from_global_key_space(1 + GLOBAL_OFFSET_HARDENED).unwrap()
@@ -308,7 +308,7 @@ mod tests {
     }
 
     #[test]
-    fn from_str_valid_2_hardened_non_canonical() {
+    fn from_str_valid_2_hardened_shorthand_syntax() {
         assert_eq!(
             "2'".parse::<SUT>().unwrap(),
             SUT::from_global_key_space(2 + GLOBAL_OFFSET_HARDENED).unwrap()
@@ -316,7 +316,7 @@ mod tests {
     }
 
     #[test]
-    fn from_str_valid_3_hardened_non_canonical() {
+    fn from_str_valid_3_hardened_shorthand_syntax() {
         assert_eq!(
             "3'".parse::<SUT>().unwrap(),
             SUT::from_global_key_space(3 + GLOBAL_OFFSET_HARDENED).unwrap()

--- a/crates/crypto/hd/src/bip32/key_space/components/securified.rs
+++ b/crates/crypto/hd/src/bip32/key_space/components/securified.rs
@@ -133,13 +133,40 @@ impl TryFrom<HDPathComponent> for SecurifiedU30 {
     }
 }
 impl IsPathComponentStringConvertible for SecurifiedU30 {
-    const CANONICAL_SUFFIX: &'static str = "S";
-    const NON_CANONICAL_SUFFIX: &'static str = "^";
+    const VERBOSE_SYNTAX_SUFFIX: &'static str = "S";
+    const SHORTHAND_SYNTAX_SUFFIX: &'static str = "^";
+}
+
+impl SecurifiedU30 {
+    /// Accepts `1073741824H` which will be interpreted as `0S`
+    /// and `1073741825H` which will be interpreted as `1S` etc.
+    fn from_canonical_bip32_str(s: &str) -> Result<Self> {
+        let offsetted = Self::value_in_local_keyspace_from_bip32_string_with_acceptable_suffixes(s,
+            vec![
+                Self::VERBOSE_SYNTAX_SUFFIX,
+                Self::SHORTHAND_SYNTAX_SUFFIX,
+                // We allow the unsecurified syntax as well - since that
+                // is what we get from the canonical BIP32 strings
+                UnsecurifiedHardened::VERBOSE_SYNTAX_SUFFIX,
+                UnsecurifiedHardened::SHORTHAND_SYNTAX_SUFFIX,
+            ])?;
+        let unoffsetted = offsetted
+            .checked_sub(RELATIVELY_LOCAL_OFFSET_SECURIFIED)
+            .ok_or(CommonError::IndexOverflow)?;
+        Self::from_local_key_space(unoffsetted)
+    }
+
+    /// Tries to parse a strict Radix HDPath string (using securified notation)
+    /// and if that fails, tries to parse a canonical BIP32 string.
+    pub(crate) fn from_lenient_bip32_string(s: &str) -> Result<Self> {
+        Self::from_bip32_string(s)
+            .or_else(|_| Self::from_canonical_bip32_str(s))
+    }
 }
 impl FromStr for SecurifiedU30 {
     type Err = CommonError;
     fn from_str(s: &str) -> Result<Self> {
-        Self::from_bip32_string(s)
+        Self::from_lenient_bip32_string(s)
     }
 }
 
@@ -166,6 +193,14 @@ mod tests {
     #[test]
     fn ord() {
         assert!(SUT::sample() < SUT::sample_other());
+    }
+
+    #[test]
+    fn from_canonical_bip32() {
+        assert_eq!(
+            SUT::from_canonical_bip32_str("1073741825H").unwrap(),
+            SUT::from_local_key_space(U31::ONE).unwrap()
+        );
     }
 
     #[test]
@@ -196,7 +231,7 @@ mod tests {
     }
 
     #[test]
-    fn from_str_valid_canonical_0() {
+    fn from_str_valid_verbose_syntax_0() {
         assert_eq!(
             "0S".parse::<SUT>().unwrap(),
             SUT::from_local_key_space(U31::ZERO).unwrap()
@@ -204,7 +239,7 @@ mod tests {
     }
 
     #[test]
-    fn from_str_valid_canonical_1() {
+    fn from_str_valid_verbose_syntax_1() {
         assert_eq!(
             "1S".parse::<SUT>().unwrap(),
             SUT::from_local_key_space(U31::ONE).unwrap()
@@ -212,7 +247,7 @@ mod tests {
     }
 
     #[test]
-    fn from_str_valid_canonical_max() {
+    fn from_str_valid_verbose_syntax_max() {
         assert_eq!(
             "1073741823S".parse::<SUT>().unwrap(),
             SUT::from_local_key_space(U30_MAX).unwrap()
@@ -220,7 +255,7 @@ mod tests {
     }
 
     #[test]
-    fn from_str_valid_uncanonical_0() {
+    fn from_str_valid_shorthand_syntax_0() {
         assert_eq!(
             "0^".parse::<SUT>().unwrap(),
             SUT::from_local_key_space(U31::ZERO).unwrap()
@@ -228,7 +263,7 @@ mod tests {
     }
 
     #[test]
-    fn from_str_valid_uncanonical_1() {
+    fn from_str_valid_shorthand_syntax_1() {
         assert_eq!(
             "1^".parse::<SUT>().unwrap(),
             SUT::from_local_key_space(U31::ONE).unwrap()
@@ -236,7 +271,7 @@ mod tests {
     }
 
     #[test]
-    fn from_str_valid_uncanonical_max() {
+    fn from_str_valid_shorthand_syntax_max() {
         assert_eq!(
             "1073741823^".parse::<SUT>().unwrap(),
             SUT::from_local_key_space(U30_MAX).unwrap()
@@ -377,7 +412,6 @@ mod tests {
         assert_json_value_fails::<SUT>(json!("^"));
         assert_json_value_fails::<SUT>(json!("S"));
         assert_json_value_fails::<SUT>(json!("2"));
-        assert_json_value_fails::<SUT>(json!("2'"));
         assert_json_value_fails::<SUT>(json!("2X"));
         assert_json_value_fails::<SUT>(json!("   "));
     }

--- a/crates/crypto/hd/src/bip32/key_space/components/securified.rs
+++ b/crates/crypto/hd/src/bip32/key_space/components/securified.rs
@@ -147,8 +147,8 @@ impl SecurifiedU30 {
                 Self::SHORTHAND_SYNTAX_SUFFIX,
                 // We allow the unsecurified syntax as well - since that
                 // is what we get from the canonical BIP32 strings
-                UnsecurifiedHardened::VERBOSE_SYNTAX_SUFFIX,
-                UnsecurifiedHardened::SHORTHAND_SYNTAX_SUFFIX,
+                HARDENED_SUFFIX_BIP32,
+                HARDENED_SUFFIX_BIP44,
             ])?;
         let unoffsetted = offsetted
             .checked_sub(RELATIVELY_LOCAL_OFFSET_SECURIFIED)

--- a/crates/crypto/hd/src/bip32/key_space/components/unhardened.rs
+++ b/crates/crypto/hd/src/bip32/key_space/components/unhardened.rs
@@ -45,8 +45,8 @@ use crate::prelude::*;
     derive_more::Debug,
 )]
 #[deref(forward)]
-#[display("{}", self.to_bip32_string())]
-#[debug("{}", self.to_bip32_string_debug())]
+#[display("{}", self.to_cap43_string())]
+#[debug("{}", self.to_cap43_string_debug())]
 pub struct Unhardened(pub U31);
 
 impl Unhardened {
@@ -127,7 +127,7 @@ impl IsPathComponentStringConvertible for Unhardened {
 impl FromStr for Unhardened {
     type Err = CommonError;
     fn from_str(s: &str) -> Result<Self> {
-        Self::from_bip32_string(s)
+        Self::from_cap43_string(s)
     }
 }
 

--- a/crates/crypto/hd/src/bip32/key_space/components/unhardened.rs
+++ b/crates/crypto/hd/src/bip32/key_space/components/unhardened.rs
@@ -120,8 +120,8 @@ impl TryFrom<u32> for Unhardened {
 }
 
 impl IsPathComponentStringConvertible for Unhardened {
-    const CANONICAL_SUFFIX: &'static str = "";
-    const NON_CANONICAL_SUFFIX: &'static str = "";
+    const VERBOSE_SYNTAX_SUFFIX: &'static str = "";
+    const SHORTHAND_SYNTAX_SUFFIX: &'static str = "";
 }
 
 impl FromStr for Unhardened {

--- a/crates/crypto/hd/src/bip32/key_space/components/unsecurified.rs
+++ b/crates/crypto/hd/src/bip32/key_space/components/unsecurified.rs
@@ -303,7 +303,7 @@ mod tests {
     }
 
     #[test]
-    fn from_str_valid_0_hardened_canonical() {
+    fn from_str_valid_0_hardened_verbose_syntax() {
         assert_eq!(
             "0H".parse::<SUT>().unwrap(),
             SUT::from_global_key_space(GLOBAL_OFFSET_HARDENED).unwrap()
@@ -311,7 +311,7 @@ mod tests {
     }
 
     #[test]
-    fn from_str_valid_1_hardened_canonical() {
+    fn from_str_valid_1_hardened_verbose_syntax() {
         assert_eq!(
             "1H".parse::<SUT>().unwrap(),
             SUT::from_global_key_space(1 + GLOBAL_OFFSET_HARDENED).unwrap()
@@ -319,7 +319,7 @@ mod tests {
     }
 
     #[test]
-    fn from_str_valid_2_hardened_non_canonical() {
+    fn from_str_valid_2_hardened_shorthand_syntax() {
         assert_eq!(
             "2'".parse::<SUT>().unwrap(),
             SUT::from_global_key_space(2 + GLOBAL_OFFSET_HARDENED).unwrap()
@@ -327,7 +327,7 @@ mod tests {
     }
 
     #[test]
-    fn from_str_valid_3_hardened_non_canonical() {
+    fn from_str_valid_3_hardened_shorthand_syntax() {
         assert_eq!(
             "3'".parse::<SUT>().unwrap(),
             SUT::from_global_key_space(3 + GLOBAL_OFFSET_HARDENED).unwrap()

--- a/crates/crypto/hd/src/bip32/key_space/components/unsecurified.rs
+++ b/crates/crypto/hd/src/bip32/key_space/components/unsecurified.rs
@@ -153,19 +153,19 @@ impl TryFrom<HDPathComponent> for Unsecurified {
     }
 }
 
-impl FromBIP32Str for Unsecurified {
-    fn from_bip32_string(s: impl AsRef<str>) -> Result<Self> {
+impl FromCAP43String for Unsecurified {
+    fn from_cap43_string(s: impl AsRef<str>) -> Result<Self> {
         let s = s.as_ref();
-        UnsecurifiedHardened::from_bip32_string(s)
+        UnsecurifiedHardened::from_cap43_string(s)
             .map(Self::Hardened)
-            .or(Unhardened::from_bip32_string(s).map(Self::Unhardened))
+            .or(Unhardened::from_cap43_string(s).map(Self::Unhardened))
     }
 }
 
 impl FromStr for Unsecurified {
     type Err = CommonError;
     fn from_str(s: &str) -> Result<Self> {
-        Self::from_bip32_string(s)
+        Self::from_cap43_string(s)
     }
 }
 

--- a/crates/crypto/hd/src/bip32/key_space/components/unsecurified_hardened.rs
+++ b/crates/crypto/hd/src/bip32/key_space/components/unsecurified_hardened.rs
@@ -45,8 +45,8 @@ use crate::prelude::*;
     derive_more::Debug,
 )]
 #[deref(forward)]
-#[display("{}", self.to_bip32_string())]
-#[debug("{}", self.to_bip32_string_debug())]
+#[display("{}", self.to_cap43_string())]
+#[debug("{}", self.to_cap43_string_debug())]
 pub struct UnsecurifiedHardened(pub U30);
 
 impl UnsecurifiedHardened {
@@ -141,7 +141,7 @@ impl TryFrom<Unsecurified> for UnsecurifiedHardened {
 impl FromStr for UnsecurifiedHardened {
     type Err = CommonError;
     fn from_str(s: &str) -> Result<Self> {
-        Self::from_bip32_string(s)
+        Self::from_cap43_string(s)
     }
 }
 

--- a/crates/crypto/hd/src/bip32/key_space/components/unsecurified_hardened.rs
+++ b/crates/crypto/hd/src/bip32/key_space/components/unsecurified_hardened.rs
@@ -103,13 +103,9 @@ impl TryFrom<u32> for UnsecurifiedHardened {
     }
 }
 
-pub const UNSECURIFIED_HARDENED_CANONICAL_SUFFIX: &str = "H";
-pub const UNSECURIFIED_HARDENED_NON_CANONICAL_SUFFIX: &str = "'";
 impl IsPathComponentStringConvertible for UnsecurifiedHardened {
-    const CANONICAL_SUFFIX: &'static str =
-        UNSECURIFIED_HARDENED_CANONICAL_SUFFIX;
-    const NON_CANONICAL_SUFFIX: &'static str =
-        UNSECURIFIED_HARDENED_NON_CANONICAL_SUFFIX;
+    const VERBOSE_SYNTAX_SUFFIX: &'static str = "H";
+    const SHORTHAND_SYNTAX_SUFFIX: &'static str = "'";
 }
 
 impl HasIndexInLocalKeySpace for UnsecurifiedHardened {
@@ -189,7 +185,7 @@ mod tests {
     }
 
     #[test]
-    fn from_str_valid_canonical_0() {
+    fn from_str_valid_verbose_syntax_0() {
         assert_eq!(
             "0H".parse::<SUT>().unwrap(),
             SUT::from_local_key_space(U31::ZERO).unwrap()
@@ -197,7 +193,7 @@ mod tests {
     }
 
     #[test]
-    fn from_str_valid_canonical_1() {
+    fn from_str_valid_verbose_syntax_1() {
         assert_eq!(
             "1H".parse::<SUT>().unwrap(),
             SUT::from_local_key_space(U31::ONE).unwrap()
@@ -205,7 +201,7 @@ mod tests {
     }
 
     #[test]
-    fn from_str_valid_canonical_max() {
+    fn from_str_valid_verbose_syntax_max() {
         assert_eq!(
             "1073741823H".parse::<SUT>().unwrap(),
             SUT::from_local_key_space(U30_MAX).unwrap()

--- a/crates/crypto/hd/src/bip32/key_space/components/unsecurified_hardened.rs
+++ b/crates/crypto/hd/src/bip32/key_space/components/unsecurified_hardened.rs
@@ -104,8 +104,8 @@ impl TryFrom<u32> for UnsecurifiedHardened {
 }
 
 impl IsPathComponentStringConvertible for UnsecurifiedHardened {
-    const VERBOSE_SYNTAX_SUFFIX: &'static str = "H";
-    const SHORTHAND_SYNTAX_SUFFIX: &'static str = "'";
+    const VERBOSE_SYNTAX_SUFFIX: &'static str = HARDENED_SUFFIX_BIP32;
+    const SHORTHAND_SYNTAX_SUFFIX: &'static str = HARDENED_SUFFIX_BIP44;
 }
 
 impl HasIndexInLocalKeySpace for UnsecurifiedHardened {

--- a/crates/crypto/hd/src/bip32/key_space/key_space.rs
+++ b/crates/crypto/hd/src/bip32/key_space/key_space.rs
@@ -13,12 +13,12 @@ use crate::prelude::*;
     derive_more::Display,
 )]
 pub enum KeySpace {
-    #[debug("{}", if *is_hardened { UnsecurifiedHardened::NON_CANONICAL_SUFFIX } else { "" })]
-    #[display("{}", if *is_hardened { UnsecurifiedHardened::CANONICAL_SUFFIX } else { "" })]
+    #[debug("{}", if *is_hardened { UnsecurifiedHardened::SHORTHAND_SYNTAX_SUFFIX } else { "" })]
+    #[display("{}", if *is_hardened { UnsecurifiedHardened::VERBOSE_SYNTAX_SUFFIX } else { "" })]
     Unsecurified { is_hardened: bool },
 
-    #[debug("{}", SecurifiedU30::NON_CANONICAL_SUFFIX)]
-    #[display("{}", SecurifiedU30::CANONICAL_SUFFIX)]
+    #[debug("{}", SecurifiedU30::SHORTHAND_SYNTAX_SUFFIX)]
+    #[display("{}", SecurifiedU30::VERBOSE_SYNTAX_SUFFIX)]
     Securified,
 }
 

--- a/crates/crypto/hd/src/bip32/traits/from_bip32_str.rs
+++ b/crates/crypto/hd/src/bip32/traits/from_bip32_str.rs
@@ -1,27 +1,24 @@
 use crate::prelude::*;
 
-pub trait FromBIP32Str: Sized {
-    fn from_bip32_string(s: impl AsRef<str>) -> Result<Self>;
-}
+pub trait ValueInLocalKeyspaceFromBIP32Str: Sized {
+    fn value_in_local_keyspace_from_bip32_string(
+        s: impl AsRef<str>,
+    ) -> Result<u32>;
 
-impl<T: IsPathComponentStringConvertible + FromLocalKeySpace> FromBIP32Str
-    for T
-{
-    /// Parse a BIP32 path string into a `T`.
-    ///
-    /// e.g:
-    /// ```
-    /// extern crate sargon;
-    /// use sargon::prelude::*;
-    ///
-    /// assert!(AccountPath::from_bip32_string("m/44'/1022'/1'/525'/1460'/1'").is_ok());
-    /// ```
-    fn from_bip32_string(s: impl AsRef<str>) -> Result<T> {
+    fn value_in_local_keyspace_from_bip32_string_with_acceptable_suffixes(
+        s: impl AsRef<str>,
+        acceptable_suffixes: Vec<&str>,
+    ) -> Result<u32> {
+        assert!(!acceptable_suffixes.is_empty());
+
         let s = s.as_ref();
-        let suffix_min_len = std::cmp::min(
-            T::CANONICAL_SUFFIX.len(),
-            T::NON_CANONICAL_SUFFIX.len(),
-        );
+
+        let suffix_min_len = acceptable_suffixes
+            .iter()
+            .map(|s| s.len())
+            .min()
+            .expect("at least one suffix");
+
         let min_len = suffix_min_len + 1;
         let e = CommonError::InvalidBIP32Path {
             bad_value: s.to_string(),
@@ -31,12 +28,54 @@ impl<T: IsPathComponentStringConvertible + FromLocalKeySpace> FromBIP32Str
         }
         if suffix_min_len > 0 {
             let suffix = &s[s.len() - suffix_min_len..];
-            if !T::ACCEPTABLE_SUFFIXES.contains(&suffix) {
+            if !acceptable_suffixes.contains(&suffix) {
                 return Err(e);
             }
         }
-        let value: u32 =
-            s[..s.len() - suffix_min_len].parse().map_err(|_| e)?;
-        T::from_local_key_space(value)
+        s[..s.len() - suffix_min_len].parse().map_err(|_| e)
+    }
+}
+
+pub trait FromBIP32Str: Sized {
+    fn from_bip32_string(s: impl AsRef<str>) -> Result<Self>;
+}
+
+impl<T: ValueInLocalKeyspaceFromBIP32Str + FromLocalKeySpace> FromBIP32Str
+    for T
+{
+    /// Parse a BIP32 path string into a `Self`.
+    ///
+    /// e.g:
+    /// ```
+    /// extern crate sargon;
+    /// use sargon::prelude::*;
+    ///
+    /// assert!(AccountPath::from_bip32_string("m/44'/1022'/1'/525'/1460'/1'").is_ok());
+    /// ```
+    fn from_bip32_string(s: impl AsRef<str>) -> Result<Self> {
+        let value = Self::value_in_local_keyspace_from_bip32_string(s)?;
+        Self::from_local_key_space(value)
+    }
+}
+
+impl<T: IsPathComponentStringConvertible> ValueInLocalKeyspaceFromBIP32Str
+    for T
+{
+    /// Parse a BIP32 path string into a `u32` raw value without any offsets.
+    ///
+    /// e.g:
+    /// ```
+    /// extern crate sargon;
+    /// use sargon::prelude::*;
+    ///
+    /// assert!(AccountPath::from_bip32_string("m/44'/1022'/1'/525'/1460'/1'").is_ok());
+    /// ```
+    fn value_in_local_keyspace_from_bip32_string(
+        s: impl AsRef<str>,
+    ) -> Result<u32> {
+        Self::value_in_local_keyspace_from_bip32_string_with_acceptable_suffixes(
+            s,
+            T::ACCEPTABLE_SUFFIXES.to_vec(),
+        )
     }
 }

--- a/crates/crypto/hd/src/bip32/traits/from_bip32_str.rs
+++ b/crates/crypto/hd/src/bip32/traits/from_bip32_str.rs
@@ -1,11 +1,11 @@
 use crate::prelude::*;
 
 pub trait ValueInLocalKeyspaceFromBIP32Str: Sized {
-    fn value_in_local_keyspace_from_bip32_string(
+    fn value_in_local_keyspace_from_cap43_string(
         s: impl AsRef<str>,
     ) -> Result<u32>;
 
-    fn value_in_local_keyspace_from_bip32_string_with_acceptable_suffixes(
+    fn value_in_local_keyspace_from_cap43_string_with_acceptable_suffixes(
         s: impl AsRef<str>,
         acceptable_suffixes: Vec<&str>,
     ) -> Result<u32> {
@@ -36,11 +36,14 @@ pub trait ValueInLocalKeyspaceFromBIP32Str: Sized {
     }
 }
 
-pub trait FromBIP32Str: Sized {
-    fn from_bip32_string(s: impl AsRef<str>) -> Result<Self>;
+/// CAP43 string [described here][doc]
+///
+/// [doc]: https://radixdlt.atlassian.net/wiki/spaces/AT/pages/3880058888/CAP-43+Sargon+HD+Path+string+notation
+pub trait FromCAP43String: Sized {
+    fn from_cap43_string(s: impl AsRef<str>) -> Result<Self>;
 }
 
-impl<T: ValueInLocalKeyspaceFromBIP32Str + FromLocalKeySpace> FromBIP32Str
+impl<T: ValueInLocalKeyspaceFromBIP32Str + FromLocalKeySpace> FromCAP43String
     for T
 {
     /// Parse a BIP32 path string into a `Self`.
@@ -50,10 +53,10 @@ impl<T: ValueInLocalKeyspaceFromBIP32Str + FromLocalKeySpace> FromBIP32Str
     /// extern crate sargon;
     /// use sargon::prelude::*;
     ///
-    /// assert!(AccountPath::from_bip32_string("m/44'/1022'/1'/525'/1460'/1'").is_ok());
+    /// assert!(AccountPath::from_cap43_string("m/44'/1022'/1'/525'/1460'/1'").is_ok());
     /// ```
-    fn from_bip32_string(s: impl AsRef<str>) -> Result<Self> {
-        let value = Self::value_in_local_keyspace_from_bip32_string(s)?;
+    fn from_cap43_string(s: impl AsRef<str>) -> Result<Self> {
+        let value = Self::value_in_local_keyspace_from_cap43_string(s)?;
         Self::from_local_key_space(value)
     }
 }
@@ -68,12 +71,12 @@ impl<T: IsPathComponentStringConvertible> ValueInLocalKeyspaceFromBIP32Str
     /// extern crate sargon;
     /// use sargon::prelude::*;
     ///
-    /// assert!(AccountPath::from_bip32_string("m/44'/1022'/1'/525'/1460'/1'").is_ok());
+    /// assert!(AccountPath::from_cap43_string("m/44'/1022'/1'/525'/1460'/1'").is_ok());
     /// ```
-    fn value_in_local_keyspace_from_bip32_string(
+    fn value_in_local_keyspace_from_cap43_string(
         s: impl AsRef<str>,
     ) -> Result<u32> {
-        Self::value_in_local_keyspace_from_bip32_string_with_acceptable_suffixes(
+        Self::value_in_local_keyspace_from_cap43_string_with_acceptable_suffixes(
             s,
             T::ACCEPTABLE_SUFFIXES.to_vec(),
         )

--- a/crates/crypto/hd/src/bip32/traits/is_path_component_string_convertible.rs
+++ b/crates/crypto/hd/src/bip32/traits/is_path_component_string_convertible.rs
@@ -1,6 +1,6 @@
 pub trait IsPathComponentStringConvertible {
-    const CANONICAL_SUFFIX: &'static str;
-    const NON_CANONICAL_SUFFIX: &'static str;
+    const VERBOSE_SYNTAX_SUFFIX: &'static str;
+    const SHORTHAND_SYNTAX_SUFFIX: &'static str;
     const ACCEPTABLE_SUFFIXES: [&'static str; 2] =
-        [Self::CANONICAL_SUFFIX, Self::NON_CANONICAL_SUFFIX];
+        [Self::VERBOSE_SYNTAX_SUFFIX, Self::SHORTHAND_SYNTAX_SUFFIX];
 }

--- a/crates/crypto/hd/src/bip32/traits/to_bip32_str.rs
+++ b/crates/crypto/hd/src/bip32/traits/to_bip32_str.rs
@@ -13,14 +13,14 @@ where
         format!(
             "{}{}",
             u32::from(self.index_in_local_key_space()),
-            T::CANONICAL_SUFFIX
+            T::VERBOSE_SYNTAX_SUFFIX
         )
     }
     fn to_bip32_string_debug(&self) -> String {
         format!(
             "{}{}",
             u32::from(self.index_in_local_key_space()),
-            T::NON_CANONICAL_SUFFIX
+            T::SHORTHAND_SYNTAX_SUFFIX
         )
     }
 }

--- a/crates/crypto/hd/src/bip32/traits/to_bip32_str.rs
+++ b/crates/crypto/hd/src/bip32/traits/to_bip32_str.rs
@@ -1,22 +1,25 @@
 use crate::prelude::*;
 
-pub trait ToBIP32Str: Sized {
-    fn to_bip32_string(&self) -> String;
-    fn to_bip32_string_debug(&self) -> String;
+/// [CAP43][doc] uses `iS` instead of `{i+2^30}H` - for values in securified key space.
+///
+/// [doc]: https://radixdlt.atlassian.net/wiki/spaces/AT/pages/3880058888/CAP-43+Sargon+HD+Path+string+notation
+pub trait ToCAP43String: Sized {
+    fn to_cap43_string(&self) -> String;
+    fn to_cap43_string_debug(&self) -> String;
 }
 
-impl<T> ToBIP32Str for T
+impl<T> ToCAP43String for T
 where
     T: IsPathComponentStringConvertible + IsInLocalKeySpace,
 {
-    fn to_bip32_string(&self) -> String {
+    fn to_cap43_string(&self) -> String {
         format!(
             "{}{}",
             u32::from(self.index_in_local_key_space()),
             T::VERBOSE_SYNTAX_SUFFIX
         )
     }
-    fn to_bip32_string_debug(&self) -> String {
+    fn to_cap43_string_debug(&self) -> String {
         format!(
             "{}{}",
             u32::from(self.index_in_local_key_space()),

--- a/crates/crypto/hd/src/bip44/bip44_like_path.rs
+++ b/crates/crypto/hd/src/bip44/bip44_like_path.rs
@@ -38,8 +38,8 @@ use crate::prelude::*;
     derive_more::Debug,
     derive_more::Display,
 )]
-#[display("{}", self.to_bip32_string())]
-#[debug("{}", self.to_bip32_string_debug())]
+#[display("{}", self.to_cap43_string())]
+#[debug("{}", self.to_cap43_string_debug())]
 pub struct BIP44LikePath {
     pub account: HDPathComponent,
     pub change: HDPathComponent,
@@ -150,24 +150,24 @@ impl TryFrom<HDPath> for BIP44LikePath {
     }
 }
 
-impl ToBIP32Str for BIP44LikePath {
-    fn to_bip32_string(&self) -> String {
-        self.to_hd_path().to_bip32_string()
+impl ToCAP43String for BIP44LikePath {
+    fn to_cap43_string(&self) -> String {
+        self.to_hd_path().to_cap43_string()
     }
-    fn to_bip32_string_debug(&self) -> String {
-        self.to_hd_path().to_bip32_string_debug()
+    fn to_cap43_string_debug(&self) -> String {
+        self.to_hd_path().to_cap43_string_debug()
     }
 }
-impl FromBIP32Str for BIP44LikePath {
-    fn from_bip32_string(s: impl AsRef<str>) -> Result<Self> {
-        HDPath::from_bip32_string(s).and_then(Self::try_from)
+impl FromCAP43String for BIP44LikePath {
+    fn from_cap43_string(s: impl AsRef<str>) -> Result<Self> {
+        HDPath::from_cap43_string(s).and_then(Self::try_from)
     }
 }
 impl FromStr for BIP44LikePath {
     type Err = CommonError;
 
     fn from_str(s: &str) -> Result<Self> {
-        Self::from_bip32_string(s)
+        Self::from_cap43_string(s)
     }
 }
 

--- a/crates/crypto/hd/src/bip44/bip44_like_path.rs
+++ b/crates/crypto/hd/src/bip44/bip44_like_path.rs
@@ -243,7 +243,7 @@ mod tests {
     }
 
     #[test]
-    fn from_str_hardened_non_canonical() {
+    fn from_str_hardened_shorthand_syntax() {
         let sut = SUT::from_str("m/44'/1022'/0'/0/8'").unwrap();
         assert_eq!(
             sut.index,
@@ -265,7 +265,7 @@ mod tests {
     }
 
     #[test]
-    fn from_str_unhardened_non_canonical() {
+    fn from_str_unhardened_shorthand_syntax() {
         let sut = SUT::from_str("m/44'/1022'/0'/0/6").unwrap();
         assert_eq!(
             sut.index,

--- a/crates/crypto/hd/src/cap26/paths/account_path.rs
+++ b/crates/crypto/hd/src/cap26/paths/account_path.rs
@@ -437,4 +437,15 @@ mod tests {
         let b: AccountPath = "m/44H/1022H/1H/525H/1678H/0H".parse().unwrap();
         assert_ne!(a, b);
     }
+
+    #[test]
+    fn from_canonical_bip32_str() {
+        let canonical = "m/44H/1022H/1H/525H/1460H/1073741824H";
+        let sut = SUT::from_str(canonical).unwrap();
+        assert_eq!(
+            DerivationPath::from(sut.clone()).to_canonical_bip32_string(),
+            canonical
+        );
+        assert_eq!(sut.to_bip32_string(), "m/44H/1022H/1H/525H/1460H/0S");
+    }
 }

--- a/crates/crypto/hd/src/cap26/paths/account_path.rs
+++ b/crates/crypto/hd/src/cap26/paths/account_path.rs
@@ -62,8 +62,8 @@ use crate::prelude::*;
     DeserializeFromStr,
     derive_more::Display,
 )]
-#[display("{}", self.to_bip32_string())]
-#[debug("{}", self.to_bip32_string_debug())]
+#[display("{}", self.to_cap43_string())]
+#[debug("{}", self.to_cap43_string_debug())]
 pub struct AccountPath {
     pub network_id: NetworkID,
     pub key_kind: CAP26KeyKind,
@@ -144,25 +144,25 @@ impl HasEntityKind for AccountPath {
     }
 }
 
-impl ToBIP32Str for AccountPath {
-    fn to_bip32_string(&self) -> String {
-        self.to_hd_path().to_bip32_string()
+impl ToCAP43String for AccountPath {
+    fn to_cap43_string(&self) -> String {
+        self.to_hd_path().to_cap43_string()
     }
-    fn to_bip32_string_debug(&self) -> String {
-        self.to_hd_path().to_bip32_string_debug()
+    fn to_cap43_string_debug(&self) -> String {
+        self.to_hd_path().to_cap43_string_debug()
     }
 }
 
-impl FromBIP32Str for AccountPath {
-    fn from_bip32_string(s: impl AsRef<str>) -> Result<Self> {
-        HDPath::from_bip32_string(s).and_then(Self::try_from)
+impl FromCAP43String for AccountPath {
+    fn from_cap43_string(s: impl AsRef<str>) -> Result<Self> {
+        HDPath::from_cap43_string(s).and_then(Self::try_from)
     }
 }
 impl FromStr for AccountPath {
     type Err = CommonError;
 
     fn from_str(s: &str) -> Result<Self> {
-        Self::from_bip32_string(s)
+        Self::from_cap43_string(s)
     }
 }
 
@@ -439,13 +439,13 @@ mod tests {
     }
 
     #[test]
-    fn from_canonical_bip32_str() {
+    fn from_bip32_str() {
         let canonical = "m/44H/1022H/1H/525H/1460H/1073741824H";
         let sut = SUT::from_str(canonical).unwrap();
         assert_eq!(
-            DerivationPath::from(sut.clone()).to_canonical_bip32_string(),
+            DerivationPath::from(sut.clone()).to_bip32_string(),
             canonical
         );
-        assert_eq!(sut.to_bip32_string(), "m/44H/1022H/1H/525H/1460H/0S");
+        assert_eq!(sut.to_cap43_string(), "m/44H/1022H/1H/525H/1460H/0S");
     }
 }

--- a/crates/crypto/hd/src/cap26/paths/get_id_path.rs
+++ b/crates/crypto/hd/src/cap26/paths/get_id_path.rs
@@ -1,8 +1,8 @@
 use crate::prelude::*;
 
 #[derive(Clone, Default, derive_more::Debug, derive_more::Display)]
-#[display("{}", self.to_bip32_string())]
-#[debug("{}", self.to_bip32_string_debug())]
+#[display("{}", self.to_cap43_string())]
+#[debug("{}", self.to_cap43_string_debug())]
 pub struct GetIDPath;
 
 impl GetIDPath {
@@ -21,12 +21,12 @@ impl GetIDPath {
     }
 }
 
-impl ToBIP32Str for GetIDPath {
-    fn to_bip32_string(&self) -> String {
-        self.to_hd_path().to_bip32_string()
+impl ToCAP43String for GetIDPath {
+    fn to_cap43_string(&self) -> String {
+        self.to_hd_path().to_cap43_string()
     }
-    fn to_bip32_string_debug(&self) -> String {
-        self.to_hd_path().to_bip32_string_debug()
+    fn to_cap43_string_debug(&self) -> String {
+        self.to_hd_path().to_cap43_string_debug()
     }
 }
 

--- a/crates/crypto/hd/src/cap26/paths/identity_path.rs
+++ b/crates/crypto/hd/src/cap26/paths/identity_path.rs
@@ -62,8 +62,8 @@ use crate::prelude::*;
     DeserializeFromStr,
     derive_more::Display,
 )]
-#[display("{}", self.to_bip32_string())]
-#[debug("{}", self.to_bip32_string_debug())]
+#[display("{}", self.to_cap43_string())]
+#[debug("{}", self.to_cap43_string_debug())]
 pub struct IdentityPath {
     pub network_id: NetworkID,
     pub key_kind: CAP26KeyKind,
@@ -145,25 +145,25 @@ impl HasEntityKind for IdentityPath {
     }
 }
 
-impl ToBIP32Str for IdentityPath {
-    fn to_bip32_string(&self) -> String {
-        self.to_hd_path().to_bip32_string()
+impl ToCAP43String for IdentityPath {
+    fn to_cap43_string(&self) -> String {
+        self.to_hd_path().to_cap43_string()
     }
-    fn to_bip32_string_debug(&self) -> String {
-        self.to_hd_path().to_bip32_string_debug()
+    fn to_cap43_string_debug(&self) -> String {
+        self.to_hd_path().to_cap43_string_debug()
     }
 }
 
-impl FromBIP32Str for IdentityPath {
-    fn from_bip32_string(s: impl AsRef<str>) -> Result<Self> {
-        HDPath::from_bip32_string(s).and_then(Self::try_from)
+impl FromCAP43String for IdentityPath {
+    fn from_cap43_string(s: impl AsRef<str>) -> Result<Self> {
+        HDPath::from_cap43_string(s).and_then(Self::try_from)
     }
 }
 impl FromStr for IdentityPath {
     type Err = CommonError;
 
     fn from_str(s: &str) -> Result<Self> {
-        Self::from_bip32_string(s)
+        Self::from_cap43_string(s)
     }
 }
 

--- a/crates/crypto/hd/src/derivation/derivation_path.rs
+++ b/crates/crypto/hd/src/derivation/derivation_path.rs
@@ -45,7 +45,7 @@ macro_rules! path_union {
             impl FromStr for $union_name {
                 type Err = CommonError;
                 fn from_str(s: &str) -> Result<Self> {
-                    Self::from_bip32_string(s)
+                    Self::from_cap43_string(s)
                 }
             }
 
@@ -59,8 +59,8 @@ macro_rules! path_union {
                     }
                 }
 
-                pub fn to_canonical_bip32_string(&self) -> String {
-                    self.to_hd_path().to_canonical_bip32_string()
+                pub fn to_bip32_string(&self) -> String {
+                    self.to_hd_path().to_bip32_string()
                 }
             }
             impl From<$union_name> for HDPath {
@@ -69,21 +69,21 @@ macro_rules! path_union {
                 }
             }
 
-            impl ToBIP32Str for $union_name {
-                fn to_bip32_string(&self) -> String {
-                    self.to_hd_path().to_bip32_string()
+            impl ToCAP43String for $union_name {
+                fn to_cap43_string(&self) -> String {
+                    self.to_hd_path().to_cap43_string()
                 }
-                fn to_bip32_string_debug(&self) -> String {
-                    self.to_hd_path().to_bip32_string_debug()
+                fn to_cap43_string_debug(&self) -> String {
+                    self.to_hd_path().to_cap43_string_debug()
                 }
             }
 
-            impl FromBIP32Str for $union_name {
-                fn from_bip32_string(s: impl AsRef<str>) -> Result<Self> {
+            impl FromCAP43String for $union_name {
+                fn from_cap43_string(s: impl AsRef<str>) -> Result<Self> {
                     let s = s.as_ref();
                     Result::<Self>::Err(CommonError::InvalidBIP32Path { bad_value: s.to_owned() })
                     $(
-                        .or_else(|_| $variant_type::from_bip32_string(s).map(Self::[< $variant_name:snake >]))
+                        .or_else(|_| $variant_type::from_cap43_string(s).map(Self::[< $variant_name:snake >]))
                     )+
 
                 }
@@ -255,7 +255,7 @@ mod tests {
         let sut = SUT::Account {
             value: AccountPath::sample(),
         };
-        assert_eq!(sut.to_bip32_string(), format!("{}", sut));
+        assert_eq!(sut.to_cap43_string(), format!("{}", sut));
     }
 
     #[test]
@@ -263,7 +263,7 @@ mod tests {
         let sut = SUT::Account {
             value: AccountPath::sample(),
         };
-        assert_eq!(sut.to_bip32_string_debug(), format!("{:?}", sut));
+        assert_eq!(sut.to_cap43_string_debug(), format!("{:?}", sut));
     }
 
     #[test]
@@ -271,7 +271,7 @@ mod tests {
         let sut = SUT::Identity {
             value: IdentityPath::sample(),
         };
-        assert_eq!(sut.to_bip32_string(), format!("{}", sut));
+        assert_eq!(sut.to_cap43_string(), format!("{}", sut));
     }
 
     #[test]
@@ -279,14 +279,14 @@ mod tests {
         let sut = SUT::Identity {
             value: IdentityPath::sample(),
         };
-        assert_eq!(sut.to_bip32_string_debug(), format!("{:?}", sut));
+        assert_eq!(sut.to_cap43_string_debug(), format!("{:?}", sut));
     }
 
     #[test]
     fn string_roundtrip_account_from_account() {
         let value = AccountPath::sample();
-        let s = value.to_bip32_string();
-        let path2 = SUT::from_bip32_string(&s).unwrap();
+        let s = value.to_cap43_string();
+        let path2 = SUT::from_cap43_string(&s).unwrap();
         assert_eq!(SUT::Account { value }, path2);
     }
 
@@ -295,16 +295,16 @@ mod tests {
         let sut = SUT::Account {
             value: AccountPath::sample(),
         };
-        let s = sut.to_bip32_string();
-        let value = AccountPath::from_bip32_string(&s).unwrap();
+        let s = sut.to_cap43_string();
+        let value = AccountPath::from_cap43_string(&s).unwrap();
         assert_eq!(SUT::Account { value }, sut)
     }
 
     #[test]
     fn string_roundtrip_identity_from_identity() {
         let value = IdentityPath::sample();
-        let s = value.to_bip32_string();
-        let path2 = SUT::from_bip32_string(&s).unwrap();
+        let s = value.to_cap43_string();
+        let path2 = SUT::from_cap43_string(&s).unwrap();
         assert_eq!(SUT::Identity { value }, path2);
     }
 
@@ -313,16 +313,16 @@ mod tests {
         let sut = SUT::Identity {
             value: IdentityPath::sample(),
         };
-        let s = sut.to_bip32_string();
-        let value = IdentityPath::from_bip32_string(&s).unwrap();
+        let s = sut.to_cap43_string();
+        let value = IdentityPath::from_cap43_string(&s).unwrap();
         assert_eq!(SUT::Identity { value }, sut)
     }
 
     #[test]
     fn string_roundtrip_bip44_from_bip44() {
         let value = BIP44LikePath::sample();
-        let s = value.to_bip32_string();
-        let path2 = SUT::from_bip32_string(&s).unwrap();
+        let s = value.to_cap43_string();
+        let path2 = SUT::from_cap43_string(&s).unwrap();
         assert_eq!(SUT::Bip44Like { value }, path2);
     }
 
@@ -331,8 +331,8 @@ mod tests {
         let sut = SUT::Bip44Like {
             value: BIP44LikePath::sample(),
         };
-        let s = sut.to_bip32_string();
-        let value = BIP44LikePath::from_bip32_string(&s).unwrap();
+        let s = sut.to_cap43_string();
+        let value = BIP44LikePath::from_cap43_string(&s).unwrap();
         assert_eq!(SUT::Bip44Like { value }, sut)
     }
 
@@ -351,21 +351,21 @@ mod tests {
         };
 
         assert_eq!(
-            sut.to_bip32_string(),
+            sut.to_cap43_string(),
             "m/44H/1022H/1H/525H/1460H/1073741823H"
         );
         assert_eq!(
-            sut.to_canonical_bip32_string(),
+            sut.to_bip32_string(),
             "m/44H/1022H/1H/525H/1460H/1073741823H"
         );
     }
 
     #[test]
-    fn from_canonical_bip32_str() {
+    fn from_bip32_str() {
         let canonical = "m/44H/1022H/1H/525H/1460H/1073741824H";
         let sut = SUT::from_str(canonical).unwrap();
-        assert_eq!(sut.to_canonical_bip32_string(), canonical);
-        assert_eq!(sut.to_bip32_string(), "m/44H/1022H/1H/525H/1460H/0S");
+        assert_eq!(sut.to_bip32_string(), canonical);
+        assert_eq!(sut.to_cap43_string(), "m/44H/1022H/1H/525H/1460H/0S");
     }
 
     #[test]
@@ -380,13 +380,13 @@ mod tests {
             ),
         };
 
-        assert_eq!(sut.to_bip32_string(), "m/44H/1022H/1H/525H/1460H/0S");
+        assert_eq!(sut.to_cap43_string(), "m/44H/1022H/1H/525H/1460H/0S");
         assert_eq!(
-            sut.to_canonical_bip32_string(),
+            sut.to_bip32_string(),
             "m/44H/1022H/1H/525H/1460H/1073741824H"
         );
         assert_eq!(
-            sut.to_canonical_bip32_string(),
+            sut.to_bip32_string(),
             format!("m/44H/1022H/1H/525H/1460H/{}H", 2u32.pow(30))
         );
     }
@@ -403,9 +403,9 @@ mod tests {
             ),
         };
 
-        assert_eq!(sut.to_bip32_string(), "m/44H/1022H/1H/525H/1460H/2S");
+        assert_eq!(sut.to_cap43_string(), "m/44H/1022H/1H/525H/1460H/2S");
         assert_eq!(
-            sut.to_canonical_bip32_string(),
+            sut.to_bip32_string(),
             "m/44H/1022H/1H/525H/1460H/1073741826H"
         )
     }
@@ -422,7 +422,7 @@ mod tests {
             ),
         };
 
-        assert_eq!(sut.to_bip32_string(), sut.to_canonical_bip32_string());
+        assert_eq!(sut.to_cap43_string(), sut.to_bip32_string());
     }
 
     #[test]

--- a/crates/crypto/hd/src/derivation/derivation_path.rs
+++ b/crates/crypto/hd/src/derivation/derivation_path.rs
@@ -81,8 +81,7 @@ macro_rules! path_union {
             impl FromBIP32Str for $union_name {
                 fn from_bip32_string(s: impl AsRef<str>) -> Result<Self> {
                     let s = s.as_ref();
-                    // Result::<Self>::Err(CommonError::InvalidBIP32Path { bad_value: s.to_owned() })
-                    Result::<Self>::Err(CommonError::InvalidDisplayNameEmpty)
+                    Result::<Self>::Err(CommonError::InvalidBIP32Path { bad_value: s.to_owned() })
                     $(
                         .or_else(|_| $variant_type::from_bip32_string(s).map(Self::[< $variant_name:snake >]))
                     )+

--- a/crates/crypto/hd/src/derivation/derivation_path.rs
+++ b/crates/crypto/hd/src/derivation/derivation_path.rs
@@ -81,9 +81,10 @@ macro_rules! path_union {
             impl FromBIP32Str for $union_name {
                 fn from_bip32_string(s: impl AsRef<str>) -> Result<Self> {
                     let s = s.as_ref();
-                    Result::<Self>::Err(CommonError::InvalidBIP32Path { bad_value: s.to_owned() })
+                    // Result::<Self>::Err(CommonError::InvalidBIP32Path { bad_value: s.to_owned() })
+                    Result::<Self>::Err(CommonError::InvalidDisplayNameEmpty)
                     $(
-                        .or($variant_type::from_bip32_string(s).map(Self::[< $variant_name:snake >]))
+                        .or_else(|_| $variant_type::from_bip32_string(s).map(Self::[< $variant_name:snake >]))
                     )+
 
                 }
@@ -361,6 +362,14 @@ mod tests {
     }
 
     #[test]
+    fn from_canonical_bip32_str() {
+        let canonical = "m/44H/1022H/1H/525H/1460H/1073741824H";
+        let sut = SUT::from_str(canonical).unwrap();
+        assert_eq!(sut.to_canonical_bip32_string(), canonical);
+        assert_eq!(sut.to_bip32_string(), "m/44H/1022H/1H/525H/1460H/0S");
+    }
+
+    #[test]
     fn string_representation_of_canonical_and_non_canonical_for_securified_derivation_path_zero(
     ) {
         let sut = SUT::Account {
@@ -384,7 +393,7 @@ mod tests {
     }
 
     #[test]
-    fn string_representation_of_canonical_and_non_canonical_for_securified_derivation_path_2(
+    fn string_representation_of_canonical_and_shorthand_syntax_for_securified_derivation_path_2(
     ) {
         let sut = SUT::Account {
             value: AccountPath::new(
@@ -403,7 +412,7 @@ mod tests {
     }
 
     #[test]
-    fn string_representation_of_canonical_and_non_canonical_for_unsecurified_derivation_path(
+    fn string_representation_of_canonical_and_shorthand_syntax_for_unsecurified_derivation_path(
     ) {
         let sut = SUT::Account {
             value: AccountPath::new(

--- a/crates/crypto/hd/src/derivation/derivation_path.rs
+++ b/crates/crypto/hd/src/derivation/derivation_path.rs
@@ -251,7 +251,7 @@ mod tests {
     type SUT = DerivationPath;
 
     #[test]
-    fn test_to_bip32_string_is_display_account() {
+    fn test_to_cap43_string_is_display_account() {
         let sut = SUT::Account {
             value: AccountPath::sample(),
         };
@@ -259,7 +259,7 @@ mod tests {
     }
 
     #[test]
-    fn test_to_bip32_string_is_debug_account() {
+    fn test_to_cap43_string_debug_is_debug_account() {
         let sut = SUT::Account {
             value: AccountPath::sample(),
         };
@@ -267,7 +267,7 @@ mod tests {
     }
 
     #[test]
-    fn test_to_bip32_string_is_display_identity() {
+    fn test_to_cap43_string_is_display_identity() {
         let sut = SUT::Identity {
             value: IdentityPath::sample(),
         };
@@ -275,7 +275,7 @@ mod tests {
     }
 
     #[test]
-    fn test_to_bip32_string_is_debug_identity() {
+    fn test_to_cap43_string_debug_is_debug_identity() {
         let sut = SUT::Identity {
             value: IdentityPath::sample(),
         };

--- a/crates/factors/factors/Cargo.toml
+++ b/crates/factors/factors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factors"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/instances-provider/Cargo.toml
+++ b/crates/factors/instances-provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factor-instances-provider"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/keys-collector/Cargo.toml
+++ b/crates/factors/keys-collector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keys-collector"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/next-derivation-index-ephemeral/Cargo.toml
+++ b/crates/factors/next-derivation-index-ephemeral/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "next-derivation-index-ephemeral"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/next-derivation-index-ephemeral/src/agnostic_paths/index_agnostic_path.rs
+++ b/crates/factors/next-derivation-index-ephemeral/src/agnostic_paths/index_agnostic_path.rs
@@ -40,7 +40,7 @@ impl FromStr for IndexAgnosticPath {
         let key_space = KeySpace::from_str(&key_space_component)?;
         let parts = parts[..3].to_vec();
         let s = parts.join(HDPath::SEPARATOR);
-        let hd_path = HDPath::from_bip32_string(s)?;
+        let hd_path = HDPath::from_cap43_string(s)?;
         let components = hd_path.components();
 
         let network_id = NetworkID::try_from(components[0])?;
@@ -73,7 +73,7 @@ impl IndexAgnosticPath {
     }
 
     fn _to_str(&self) -> String {
-        let base = self._to_hd_path().to_bip32_string_with(false, false);
+        let base = self._to_hd_path().to_cap43_string_with(false, false);
         format!("{}/{}{}", base, self.key_space, Self::COMPONENT_SUFFIX)
     }
 }

--- a/crates/factors/supporting-types/Cargo.toml
+++ b/crates/factors/supporting-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factors-supporting-types"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/gateway/client-and-api/Cargo.toml
+++ b/crates/gateway/client-and-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gateway-client-and-api"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/gateway/models/Cargo.toml
+++ b/crates/gateway/models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gateway-models"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 

--- a/crates/profile/logic/logic_SPLIT_ME/Cargo.toml
+++ b/crates/profile/logic/logic_SPLIT_ME/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-logic"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/account-for-display/Cargo.toml
+++ b/crates/profile/models/account-for-display/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "account-for-display"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/account-or-persona/Cargo.toml
+++ b/crates/profile/models/account-or-persona/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-account-or-persona"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/account/Cargo.toml
+++ b/crates/profile/models/account/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-account"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/app-preferences/Cargo.toml
+++ b/crates/profile/models/app-preferences/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-app-preferences"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/base-entity/Cargo.toml
+++ b/crates/profile/models/base-entity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-base-entity"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/gateway/Cargo.toml
+++ b/crates/profile/models/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-gateway"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/persona-data/Cargo.toml
+++ b/crates/profile/models/persona-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-persona-data"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/persona/Cargo.toml
+++ b/crates/profile/models/persona/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-persona"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/profile_SPLIT_ME/Cargo.toml
+++ b/crates/profile/models/profile_SPLIT_ME/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 

--- a/crates/profile/models/security-structures/Cargo.toml
+++ b/crates/profile/models/security-structures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-security-structures"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/supporting-types/Cargo.toml
+++ b/crates/profile/models/supporting-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-supporting-types"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/traits/entity-by-address/Cargo.toml
+++ b/crates/profile/traits/entity-by-address/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entity-by-address"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/sargon/Cargo.toml
+++ b/crates/sargon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 resolver = "2" # features enabled in integration test

--- a/crates/sargon/tests/vectors/main.rs
+++ b/crates/sargon/tests/vectors/main.rs
@@ -142,12 +142,12 @@ mod cap26_tests {
         // Test display
         let derivation_path = DerivationPath::from(account_path.clone());
         pretty_assertions::assert_eq!(
-            derivation_path.to_canonical_bip32_string(),
+            derivation_path.to_bip32_string(),
             path_canonical_notation
         );
         if let Some(path_securified_notation) = path_securified_notation {
             pretty_assertions::assert_eq!(
-                derivation_path.to_bip32_string(),
+                derivation_path.to_cap43_string(),
                 path_securified_notation
             );
             pretty_assertions::assert_eq!(

--- a/crates/system/clients/clients/Cargo.toml
+++ b/crates/system/clients/clients/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clients"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 

--- a/crates/system/clients/http/Cargo.toml
+++ b/crates/system/clients/http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http-client"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/drivers/Cargo.toml
+++ b/crates/system/drivers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drivers"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 

--- a/crates/system/interactors/Cargo.toml
+++ b/crates/system/interactors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interactors"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/accounts/Cargo.toml
+++ b/crates/system/os/accounts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-accounts"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/derive-public-keys/Cargo.toml
+++ b/crates/system/os/derive-public-keys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-derive-public-keys"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/factors/Cargo.toml
+++ b/crates/system/os/factors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-factors"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/os/Cargo.toml
+++ b/crates/system/os/os/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/security-center/Cargo.toml
+++ b/crates/system/os/security-center/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-security-center"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/signing/Cargo.toml
+++ b/crates/system/os/signing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-signing"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/transaction/Cargo.toml
+++ b/crates/system/os/transaction/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-transaction"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/profile-state-holder/Cargo.toml
+++ b/crates/system/profile-state-holder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-state-holder"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/sub-systems/Cargo.toml
+++ b/crates/system/sub-systems/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sub-systems"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/transaction/foundation/Cargo.toml
+++ b/crates/transaction/foundation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transaction-foundation"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/transaction/manifests/Cargo.toml
+++ b/crates/transaction/manifests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "manifests"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 

--- a/crates/transaction/models/Cargo.toml
+++ b/crates/transaction/models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transaction-models"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 

--- a/crates/uniffi/conversion-macros/Cargo.toml
+++ b/crates/uniffi/conversion-macros/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "sargon-uniffi-conversion-macros"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 
 [dependencies]

--- a/crates/uniffi/uniffi_SPLIT_ME/Cargo.toml
+++ b/crates/uniffi/uniffi_SPLIT_ME/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-uniffi"
-version = "1.1.118"
+version = "1.1.119"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/uniffi/uniffi_SPLIT_ME/src/hierarchical_deterministic/bip32/hd_path_component.rs
+++ b/crates/uniffi/uniffi_SPLIT_ME/src/hierarchical_deterministic/bip32/hd_path_component.rs
@@ -4,7 +4,7 @@ use sargon::{
     IsKeySpaceAware,
 };
 
-use sargon::{FromGlobalKeySpace, IsMappableToGlobalKeySpace, ToBIP32Str};
+use sargon::{FromGlobalKeySpace, IsMappableToGlobalKeySpace, ToCAP43String};
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, uniffi::Enum)]
 pub enum HDPathComponent {
@@ -81,14 +81,14 @@ pub fn hd_path_component_to_hardened(
 
 #[uniffi::export]
 pub fn hd_path_component_to_bip32_string(component: HDPathComponent) -> String {
-    component.into_internal().to_bip32_string()
+    component.into_internal().to_cap43_string()
 }
 
 #[uniffi::export]
 pub fn hd_path_component_to_bip32_string_debug(
     component: HDPathComponent,
 ) -> String {
-    component.into_internal().to_bip32_string_debug()
+    component.into_internal().to_cap43_string_debug()
 }
 
 #[uniffi::export]

--- a/crates/uniffi/uniffi_SPLIT_ME/src/hierarchical_deterministic/derivation/derivation_path.rs
+++ b/crates/uniffi/uniffi_SPLIT_ME/src/hierarchical_deterministic/derivation/derivation_path.rs
@@ -48,5 +48,5 @@ pub fn derivation_path_to_string(path: &DerivationPath) -> String {
 /// e.g. using Ledger hardware wallet or Arculus.
 #[uniffi::export]
 pub fn derivation_path_to_bip32_string(path: &DerivationPath) -> String {
-    path.into_internal().to_cap43_string()
+    path.into_internal().to_bip32_string()
 }

--- a/crates/uniffi/uniffi_SPLIT_ME/src/hierarchical_deterministic/derivation/derivation_path.rs
+++ b/crates/uniffi/uniffi_SPLIT_ME/src/hierarchical_deterministic/derivation/derivation_path.rs
@@ -36,9 +36,17 @@ pub fn derivation_path_to_string(path: &DerivationPath) -> String {
     path.into_internal().to_string()
 }
 
+/// String representation of the path using BIP32 notation.
+/// In sargon, paths in the securified space are printed with the `S` notation after the index,
+/// for readability purposes.
+///
+/// The notation `{i}S` means `{i + 2^30}H`, and since `H` means `+ 2^31` we can
+/// verbosely express `{i}S` as `{i + 2^30 + 2^31} (without the H)
+///
+/// Such paths need to be on BIP32 notation meaning that
+/// an index of `"{i}S"` => `"{i + 2^30}H"` when communication with other external APIs,
+/// e.g. using Ledger hardware wallet or Arculus.
 #[uniffi::export]
-pub fn derivation_path_to_canonical_bip32_string(
-    path: &DerivationPath,
-) -> String {
-    path.into_internal().to_canonical_bip32_string()
+pub fn derivation_path_to_bip32_string(path: &DerivationPath) -> String {
+    path.into_internal().to_cap43_string()
 }

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/DerivationPath.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/DerivationPath.kt
@@ -10,7 +10,7 @@ import com.radixdlt.sargon.HdPathComponent
 import com.radixdlt.sargon.IdentityPath
 import com.radixdlt.sargon.NetworkId
 import com.radixdlt.sargon.Slip10Curve
-import com.radixdlt.sargon.derivationPathToCanonicalBip32String
+import com.radixdlt.sargon.derivationPathToBip32String
 import com.radixdlt.sargon.derivationPathToHdPath
 import com.radixdlt.sargon.derivationPathToString
 import com.radixdlt.sargon.newDerivationPathFromString
@@ -37,8 +37,8 @@ fun DerivationPath.Companion.initForEntity(
 val DerivationPath.displayString
     get() = derivationPathToString(path = this)
 
-val DerivationPath.bip32CanonicalString: String
-    get() = derivationPathToCanonicalBip32String(path = this)
+val DerivationPath.bip32String: String
+    get() = derivationPathToBip32String(path = this)
 
 val DerivationPath.path: HdPath
     get() = derivationPathToHdPath(path = this)

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/DerivationPathTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/DerivationPathTest.kt
@@ -1,7 +1,7 @@
 package com.radixdlt.sargon
 
 import com.radixdlt.sargon.extensions.asGeneral
-import com.radixdlt.sargon.extensions.bip32CanonicalString
+import com.radixdlt.sargon.extensions.bip32String
 import com.radixdlt.sargon.extensions.curve
 import com.radixdlt.sargon.extensions.displayString
 import com.radixdlt.sargon.extensions.init
@@ -72,7 +72,7 @@ class DerivationPathTest: SampleTestable<DerivationPath> {
         )
         assertEquals(
             "m/44H/1022H/1H/525H/1460H/1073741824H",
-            accountPathInSecurifiedSpace.bip32CanonicalString
+            accountPathInSecurifiedSpace.bip32String
         )
 
         val accountPathInUnsecurifiedSpace = AccountPath.init(
@@ -87,7 +87,7 @@ class DerivationPathTest: SampleTestable<DerivationPath> {
         )
         assertEquals(
             "m/44H/1022H/1H/525H/1460H/0H",
-            accountPathInUnsecurifiedSpace.bip32CanonicalString
+            accountPathInUnsecurifiedSpace.bip32String
         )
     }
 


### PR DESCRIPTION
# Changes
* Change some internal terminology which called BIP32 string containing `"H"`/`"S"` "canonical" and those with `"'"`/`"^"` as non-canonical => (verbose / shorthand)-syntax instead => freeing up to properly use terminology "canonical" as we want to do in this PR ([and previous one](https://github.com/radixdlt/sargon/pull/348))
* Change `FromStr` of `Securified30` to be "lenient" and allowing canonical BIP32 strings