### PR TITLE
Authorization Interactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "account-for-display"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "addresses",
  "derive_more",
@@ -49,10 +49,10 @@ dependencies = [
 
 [[package]]
 name = "addresses"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "assert-json",
- "bytes 1.1.119",
+ "bytes 1.1.120",
  "cap26-models",
  "core-utils",
  "derive_more",
@@ -246,7 +246,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "assert-json"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "assert-json-diff",
  "error",
@@ -546,7 +546,7 @@ dependencies = [
 
 [[package]]
 name = "build-info"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "assert-json",
  "cargo_toml",
@@ -573,7 +573,7 @@ checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
 
 [[package]]
 name = "bytes"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "assert-json",
  "delegate",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "cap26-models"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "assert-json",
  "derive_more",
@@ -748,7 +748,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "clients"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -808,7 +808,7 @@ checksum = "0d8a42181e0652c2997ae4d217f25b63c5337a52fd2279736e97b832fa0a3cff"
 
 [[package]]
 name = "core-collections"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "has-sample-values",
  "indexmap 2.7.0",
@@ -835,7 +835,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-misc"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "assert-json",
  "core-utils",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "core-utils"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "error",
  "iso8601-timestamp",
@@ -1084,7 +1084,7 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "drivers"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -1108,10 +1108,10 @@ dependencies = [
 
 [[package]]
 name = "ecc"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "assert-json",
- "bytes 1.1.119",
+ "bytes 1.1.120",
  "derive_more",
  "enum-as-inner",
  "error",
@@ -1210,11 +1210,11 @@ dependencies = [
 
 [[package]]
 name = "encryption"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "aes-gcm",
  "assert-json",
- "bytes 1.1.119",
+ "bytes 1.1.120",
  "derive_more",
  "error",
  "has-sample-values",
@@ -1231,7 +1231,7 @@ dependencies = [
 
 [[package]]
 name = "entity-by-address"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "addresses",
  "error",
@@ -1243,7 +1243,7 @@ dependencies = [
 
 [[package]]
 name = "entity-foundation"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "assert-json",
  "derive_more",
@@ -1318,7 +1318,7 @@ dependencies = [
 
 [[package]]
 name = "error"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "derive_more",
  "log",
@@ -1377,7 +1377,7 @@ dependencies = [
 
 [[package]]
 name = "factor-instances-provider"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -1403,9 +1403,9 @@ dependencies = [
 
 [[package]]
 name = "factors"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
- "bytes 1.1.119",
+ "bytes 1.1.120",
  "cap26-models",
  "core-collections",
  "core-misc",
@@ -1440,7 +1440,7 @@ dependencies = [
 
 [[package]]
 name = "factors-supporting-types"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "async-trait",
  "error",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-client-and-api"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -1613,7 +1613,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-models"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "addresses",
  "assert-json",
@@ -1718,7 +1718,7 @@ dependencies = [
 
 [[package]]
 name = "has-sample-values"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "error",
  "indexmap 2.7.0",
@@ -1729,9 +1729,9 @@ dependencies = [
 
 [[package]]
 name = "hash"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
- "bytes 1.1.119",
+ "bytes 1.1.120",
  "derive_more",
  "prelude",
  "radix-common",
@@ -1795,11 +1795,11 @@ dependencies = [
 
 [[package]]
 name = "hierarchical-deterministic"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "assert-json",
  "bip39",
- "bytes 1.1.119",
+ "bytes 1.1.120",
  "cap26-models",
  "derive_more",
  "ecc",
@@ -1842,13 +1842,13 @@ dependencies = [
 
 [[package]]
 name = "home-cards"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "actix-rt",
  "addresses",
  "async-trait",
  "base64",
- "bytes 1.1.119",
+ "bytes 1.1.120",
  "core-utils",
  "derive_more",
  "drivers",
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "host-info"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "assert-json",
  "derive_more",
@@ -1915,10 +1915,10 @@ dependencies = [
 
 [[package]]
 name = "http-client"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "actix-rt",
- "bytes 1.1.119",
+ "bytes 1.1.120",
  "core-utils",
  "drivers",
  "error",
@@ -2143,7 +2143,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "identified-vec-of"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "assert-json",
  "derive_more",
@@ -2216,7 +2216,7 @@ dependencies = [
 
 [[package]]
 name = "interactors"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -2336,7 +2336,7 @@ dependencies = [
 
 [[package]]
 name = "key-derivation-traits"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "addresses",
  "async-trait",
@@ -2354,7 +2354,7 @@ dependencies = [
 
 [[package]]
 name = "keys-collector"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -2443,7 +2443,7 @@ dependencies = [
 
 [[package]]
 name = "manifests"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "account-for-display",
  "addresses",
@@ -2484,7 +2484,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "metadata"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "derive_more",
  "has-sample-values",
@@ -2584,7 +2584,7 @@ dependencies = [
 
 [[package]]
 name = "network"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "assert-json",
  "enum-iterator",
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "next-derivation-index-ephemeral"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "addresses",
  "assert-json",
@@ -2676,9 +2676,9 @@ dependencies = [
 
 [[package]]
 name = "numeric"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
- "bytes 1.1.119",
+ "bytes 1.1.120",
  "delegate",
  "derive_more",
  "enum-iterator",
@@ -2898,7 +2898,7 @@ dependencies = [
 
 [[package]]
 name = "prelude"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "radix-engine",
  "radix-engine-toolkit",
@@ -2935,7 +2935,7 @@ dependencies = [
 
 [[package]]
 name = "profile"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "account-for-display",
  "addresses",
@@ -2979,7 +2979,7 @@ dependencies = [
 
 [[package]]
 name = "profile-account"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "account-for-display",
  "addresses",
@@ -2999,7 +2999,7 @@ dependencies = [
 
 [[package]]
 name = "profile-account-or-persona"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "cap26-models",
  "derive_more",
@@ -3016,7 +3016,7 @@ dependencies = [
 
 [[package]]
 name = "profile-app-preferences"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "addresses",
  "core-misc",
@@ -3039,7 +3039,7 @@ dependencies = [
 
 [[package]]
 name = "profile-base-entity"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "addresses",
  "derive_more",
@@ -3062,7 +3062,7 @@ dependencies = [
 
 [[package]]
 name = "profile-gateway"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "addresses",
  "assert-json",
@@ -3086,7 +3086,7 @@ dependencies = [
 
 [[package]]
 name = "profile-logic"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "addresses",
  "derive_more",
@@ -3108,7 +3108,7 @@ dependencies = [
 
 [[package]]
 name = "profile-persona"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "addresses",
  "cap26-models",
@@ -3129,7 +3129,7 @@ dependencies = [
 
 [[package]]
 name = "profile-persona-data"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "addresses",
  "assert-json",
@@ -3148,7 +3148,7 @@ dependencies = [
 
 [[package]]
 name = "profile-security-structures"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "addresses",
  "cap26-models",
@@ -3176,7 +3176,7 @@ dependencies = [
 
 [[package]]
 name = "profile-state-holder"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "derive_more",
  "error",
@@ -3191,7 +3191,7 @@ dependencies = [
 
 [[package]]
 name = "profile-supporting-types"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "addresses",
  "derive_more",
@@ -3280,14 +3280,14 @@ dependencies = [
 
 [[package]]
 name = "radix-connect"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "actix-rt",
  "addresses",
  "assert-json",
  "async-trait",
  "base64",
- "bytes 1.1.119",
+ "bytes 1.1.120",
  "core-misc",
  "core-utils",
  "derive_more",
@@ -3315,10 +3315,10 @@ dependencies = [
 
 [[package]]
 name = "radix-connect-models"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "addresses",
- "bytes 1.1.119",
+ "bytes 1.1.120",
  "core-misc",
  "derive_more",
  "error",
@@ -3760,7 +3760,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -3825,7 +3825,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -3852,7 +3852,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-accounts"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -3875,7 +3875,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-derive-public-keys"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -3894,7 +3894,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-factors"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -3922,7 +3922,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-security-center"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "actix-rt",
  "derive_more",
@@ -3938,7 +3938,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-signing"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -3964,7 +3964,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-transaction"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "actix-rt",
  "async-std",
@@ -3993,7 +3993,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-uniffi"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -4050,7 +4050,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-uniffi-conversion-macros"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4223,7 +4223,7 @@ dependencies = [
 
 [[package]]
 name = "security-center"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "addresses",
  "assert-json",
@@ -4391,7 +4391,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "short-string"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "arraystring",
  "assert-json",
@@ -4426,13 +4426,13 @@ dependencies = [
 
 [[package]]
 name = "signing"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "actix-rt",
  "addresses",
  "assert-json",
  "async-trait",
- "bytes 1.1.119",
+ "bytes 1.1.120",
  "cap26-models",
  "core-collections",
  "core-misc",
@@ -4464,10 +4464,10 @@ dependencies = [
 
 [[package]]
 name = "signing-traits"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "async-trait",
- "bytes 1.1.119",
+ "bytes 1.1.120",
  "core-collections",
  "derive_more",
  "ecc",
@@ -4632,7 +4632,7 @@ dependencies = [
 
 [[package]]
 name = "sub-systems"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "derive_more",
  "drivers",
@@ -4791,7 +4791,7 @@ dependencies = [
 
 [[package]]
 name = "time-utils"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "iso8601-timestamp",
  "prelude",
@@ -4941,10 +4941,10 @@ dependencies = [
 
 [[package]]
 name = "transaction-foundation"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "assert-json",
- "bytes 1.1.119",
+ "bytes 1.1.120",
  "derive_more",
  "has-sample-values",
  "paste",
@@ -4956,10 +4956,10 @@ dependencies = [
 
 [[package]]
 name = "transaction-models"
-version = "1.1.119"
+version = "1.1.120"
 dependencies = [
  "addresses",
- "bytes 1.1.119",
+ "bytes 1.1.120",
  "cargo_toml",
  "core-collections",
  "core-misc",

--- a/apple/Sources/Sargon/SargonOS/ThrowingHostInteractor+Static+Shared.swift
+++ b/apple/Sources/Sargon/SargonOS/ThrowingHostInteractor+Static+Shared.swift
@@ -3,18 +3,22 @@ public class ThrowingHostInteractor: HostInteractor {
 	public nonisolated(unsafe) static var shared: HostInteractor = ThrowingHostInteractor()
 
 	public func signAuth(request: SargonUniFFI.SignRequestOfAuthIntent) async throws -> SargonUniFFI.SignResponseOfAuthIntentHash {
-		throw CommonError.SigningRejected
+		throw CommonError.HostInteractionAborted
 	}
 
 	public func signTransactions(request: SargonUniFFI.SignRequestOfTransactionIntent) async throws -> SargonUniFFI.SignResponseOfTransactionIntentHash {
-		throw CommonError.SigningRejected
+		throw CommonError.HostInteractionAborted
 	}
 
 	public func signSubintents(request: SargonUniFFI.SignRequestOfSubintent) async throws -> SargonUniFFI.SignResponseOfSubintentHash {
-		throw CommonError.SigningRejected
+		throw CommonError.HostInteractionAborted
 	}
 
 	public func deriveKeys(request: SargonUniFFI.KeyDerivationRequest) async throws -> SargonUniFFI.KeyDerivationResponse {
-		throw CommonError.SigningRejected
+		throw CommonError.HostInteractionAborted
+	}
+
+	public func requestAuthorization(purpose: SargonUniFFI.AuthorizationPurpose) async -> SargonUniFFI.AuthorizationResponse {
+		.rejected
 	}
 }

--- a/apple/Tests/TestCases/System/ThrowingHostInteractorTests.swift
+++ b/apple/Tests/TestCases/System/ThrowingHostInteractorTests.swift
@@ -12,7 +12,7 @@ final class ThrowingHostInteractorTests: TestCase {
 				request: SargonUniFFI.KeyDerivationRequest(derivationPurpose: .creatingNewAccount, perFactorSource: [])
 			)
 		} catch {
-			XCTAssertEqual(error as? CommonError, CommonError.SigningRejected)
+			XCTAssertEqual(error as? CommonError, CommonError.HostInteractionAborted)
 		}
 	}
 
@@ -22,7 +22,7 @@ final class ThrowingHostInteractorTests: TestCase {
 				request: SargonUniFFI.SignRequestOfAuthIntent(factorSourceKind: .device, perFactorSource: [])
 			)
 		} catch {
-			XCTAssertEqual(error as? CommonError, CommonError.SigningRejected)
+			XCTAssertEqual(error as? CommonError, CommonError.HostInteractionAborted)
 		}
 	}
 
@@ -32,7 +32,7 @@ final class ThrowingHostInteractorTests: TestCase {
 				request: SargonUniFFI.SignRequestOfTransactionIntent(factorSourceKind: .device, perFactorSource: [])
 			)
 		} catch {
-			XCTAssertEqual(error as? CommonError, CommonError.SigningRejected)
+			XCTAssertEqual(error as? CommonError, CommonError.HostInteractionAborted)
 		}
 	}
 
@@ -42,7 +42,12 @@ final class ThrowingHostInteractorTests: TestCase {
 				request: SargonUniFFI.SignRequestOfSubintent(factorSourceKind: .device, perFactorSource: [])
 			)
 		} catch {
-			XCTAssertEqual(error as? CommonError, CommonError.SigningRejected)
+			XCTAssertEqual(error as? CommonError, CommonError.HostInteractionAborted)
 		}
+	}
+
+	func testAuthoriseGetsRejected() async {
+		let outcome = await SUT.shared.requestAuthorization(purpose: .creatingAccount)
+		XCTAssertEqual(outcome, .rejected)
 	}
 }

--- a/crates/app/home-cards/Cargo.toml
+++ b/crates/app/home-cards/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "home-cards"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/key-derivation-traits/Cargo.toml
+++ b/crates/app/key-derivation-traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "key-derivation-traits"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/radix-connect-models/Cargo.toml
+++ b/crates/app/radix-connect-models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "radix-connect-models"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/radix-connect/Cargo.toml
+++ b/crates/app/radix-connect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "radix-connect"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 

--- a/crates/app/security-center/Cargo.toml
+++ b/crates/app/security-center/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "security-center"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/signing-traits/Cargo.toml
+++ b/crates/app/signing-traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signing-traits"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/signing-traits/src/testing/interactors/test_sign_interactor.rs
+++ b/crates/app/signing-traits/src/testing/interactors/test_sign_interactor.rs
@@ -85,7 +85,9 @@ impl<S: Signable> SignInteractor<S> for TestSignInteractor<S> {
                 Ok(SignResponse::user_skipped_factors(ids))
             }
 
-            SigningUserInput::Reject => Err(CommonError::SigningRejected),
+            SigningUserInput::Reject => {
+                Err(CommonError::HostInteractionAborted)
+            }
         }
     }
 }

--- a/crates/app/signing/Cargo.toml
+++ b/crates/app/signing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signing"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 

--- a/crates/common/build-info/Cargo.toml
+++ b/crates/common/build-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "build-info"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/common/bytes/Cargo.toml
+++ b/crates/common/bytes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bytes"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/entity-foundation/Cargo.toml
+++ b/crates/common/entity-foundation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entity-foundation"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/host-info/Cargo.toml
+++ b/crates/common/host-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "host-info"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/identified-vec-of/Cargo.toml
+++ b/crates/common/identified-vec-of/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "identified-vec-of"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/metadata/Cargo.toml
+++ b/crates/common/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metadata"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/network/Cargo.toml
+++ b/crates/common/network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "network"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/numeric/Cargo.toml
+++ b/crates/common/numeric/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numeric"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/short-string/Cargo.toml
+++ b/crates/common/short-string/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "short-string"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/assert-json/Cargo.toml
+++ b/crates/core/assert-json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assert-json"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/collections/Cargo.toml
+++ b/crates/core/collections/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-collections"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/error/Cargo.toml
+++ b/crates/core/error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "error"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/error/src/common_error.rs
+++ b/crates/core/error/src/common_error.rs
@@ -804,8 +804,8 @@ pub enum CommonError {
     #[error("Could not validate signature for the given rola challenge.")]
     InvalidSignatureForRolaChallenge = 10231,
 
-    #[error("Signing was rejected by the user")]
-    SigningRejected = 10232,
+    #[error("User aborted the interaction with sargon on host.")]
+    HostInteractionAborted = 10232,
 
     #[error("Failed to automatically build shield, reason: '{underlying}'")]
     AutomaticShieldBuildingFailure { underlying: String } = 10233,

--- a/crates/core/has-sample-values/Cargo.toml
+++ b/crates/core/has-sample-values/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "has-sample-values"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/misc/Cargo.toml
+++ b/crates/core/misc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-misc"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/prelude/Cargo.toml
+++ b/crates/core/prelude/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prelude"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/time-utils/Cargo.toml
+++ b/crates/core/time-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "time-utils"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/utils/Cargo.toml
+++ b/crates/core/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-utils"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/addresses/Cargo.toml
+++ b/crates/crypto/addresses/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "addresses"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/cap26-models/Cargo.toml
+++ b/crates/crypto/cap26-models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cap26-models"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/ecc/Cargo.toml
+++ b/crates/crypto/ecc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecc"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/encryption/Cargo.toml
+++ b/crates/crypto/encryption/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "encryption"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/hash/Cargo.toml
+++ b/crates/crypto/hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hash"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/hd/Cargo.toml
+++ b/crates/crypto/hd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hierarchical-deterministic"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/factors/Cargo.toml
+++ b/crates/factors/factors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factors"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/instances-provider/Cargo.toml
+++ b/crates/factors/instances-provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factor-instances-provider"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/keys-collector/Cargo.toml
+++ b/crates/factors/keys-collector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keys-collector"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/next-derivation-index-ephemeral/Cargo.toml
+++ b/crates/factors/next-derivation-index-ephemeral/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "next-derivation-index-ephemeral"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/supporting-types/Cargo.toml
+++ b/crates/factors/supporting-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factors-supporting-types"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/gateway/client-and-api/Cargo.toml
+++ b/crates/gateway/client-and-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gateway-client-and-api"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/gateway/models/Cargo.toml
+++ b/crates/gateway/models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gateway-models"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 

--- a/crates/profile/logic/logic_SPLIT_ME/Cargo.toml
+++ b/crates/profile/logic/logic_SPLIT_ME/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-logic"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/account-for-display/Cargo.toml
+++ b/crates/profile/models/account-for-display/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "account-for-display"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/account-or-persona/Cargo.toml
+++ b/crates/profile/models/account-or-persona/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-account-or-persona"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/account/Cargo.toml
+++ b/crates/profile/models/account/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-account"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/app-preferences/Cargo.toml
+++ b/crates/profile/models/app-preferences/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-app-preferences"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/base-entity/Cargo.toml
+++ b/crates/profile/models/base-entity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-base-entity"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/gateway/Cargo.toml
+++ b/crates/profile/models/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-gateway"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/persona-data/Cargo.toml
+++ b/crates/profile/models/persona-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-persona-data"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/persona/Cargo.toml
+++ b/crates/profile/models/persona/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-persona"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/profile_SPLIT_ME/Cargo.toml
+++ b/crates/profile/models/profile_SPLIT_ME/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 

--- a/crates/profile/models/security-structures/Cargo.toml
+++ b/crates/profile/models/security-structures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-security-structures"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/supporting-types/Cargo.toml
+++ b/crates/profile/models/supporting-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-supporting-types"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/traits/entity-by-address/Cargo.toml
+++ b/crates/profile/traits/entity-by-address/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entity-by-address"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/sargon/Cargo.toml
+++ b/crates/sargon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 resolver = "2" # features enabled in integration test

--- a/crates/system/clients/clients/Cargo.toml
+++ b/crates/system/clients/clients/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clients"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 

--- a/crates/system/clients/http/Cargo.toml
+++ b/crates/system/clients/http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http-client"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/drivers/Cargo.toml
+++ b/crates/system/drivers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drivers"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 

--- a/crates/system/interactors/Cargo.toml
+++ b/crates/system/interactors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interactors"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/interactors/src/authorization_interactor.rs
+++ b/crates/system/interactors/src/authorization_interactor.rs
@@ -1,0 +1,38 @@
+use crate::prelude::*;
+
+/// An interactor responsible for communicating with the user on host, to authorize.
+/// Can be used in tandem with flows defined in sargon os, which require user authorization
+/// before continuing.
+#[async_trait::async_trait]
+pub trait AuthorizationInteractor: Send + Sync {
+    /// The user can only authorize or reject.
+    async fn request_authorization(
+        &self,
+        purpose: AuthorizationPurpose,
+    ) -> AuthorizationResponse;
+}
+
+/// The purpose of the authorization request
+#[derive(Clone, std::hash::Hash, Debug, PartialEq, Eq)]
+pub enum AuthorizationPurpose {
+    /// When a new account is about to be created.
+    CreatingAccount,
+
+    /// When a batch of accounts is about to be created.
+    CreatingAccounts,
+
+    /// When a new persona is about to be created.
+    CreatingPersona,
+
+    /// When a batch of personas is about to be created.
+    CreatingPersonas,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AuthorizationResponse {
+    /// The user authorized the request
+    Authorized,
+
+    /// The user rejected the request
+    Rejected,
+}

--- a/crates/system/interactors/src/authorization_interactor.rs
+++ b/crates/system/interactors/src/authorization_interactor.rs
@@ -13,7 +13,7 @@ pub trait AuthorizationInteractor: Send + Sync {
 }
 
 /// The purpose of the authorization request
-#[derive(Clone, std::hash::Hash, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, std::hash::Hash)]
 pub enum AuthorizationPurpose {
     /// When a new account is about to be created.
     CreatingAccount,
@@ -28,7 +28,7 @@ pub enum AuthorizationPurpose {
     CreatingPersonas,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, std::hash::Hash)]
 pub enum AuthorizationResponse {
     /// The user authorized the request
     Authorized,

--- a/crates/system/interactors/src/interactors.rs
+++ b/crates/system/interactors/src/interactors.rs
@@ -5,14 +5,19 @@ use crate::prelude::*;
 pub struct Interactors {
     /// Interactors related to factor sources.
     pub use_factor_sources_interactor: Arc<dyn UseFactorSourcesInteractor>,
+
+    /// Interactor that asks the user to authorize
+    pub authorization_interactor: Arc<dyn AuthorizationInteractor>,
 }
 
 impl Interactors {
     pub fn new(
         use_factor_sources_interactor: Arc<dyn UseFactorSourcesInteractor>,
+        authorization_interactor: Arc<dyn AuthorizationInteractor>,
     ) -> Self {
         Self {
             use_factor_sources_interactor,
+            authorization_interactor,
         }
     }
 }

--- a/crates/system/interactors/src/lib.rs
+++ b/crates/system/interactors/src/lib.rs
@@ -1,8 +1,10 @@
+mod authorization_interactor;
 mod interactors;
 mod testing;
 mod use_factor_sources_interactor;
 
 pub mod prelude {
+    pub use crate::authorization_interactor::*;
     pub use crate::interactors::*;
     pub use crate::testing::*;
     pub use crate::use_factor_sources_interactor::*;

--- a/crates/system/interactors/src/testing/mod.rs
+++ b/crates/system/interactors/src/testing/mod.rs
@@ -1,3 +1,5 @@
+mod test_authorization_interactor;
 mod test_use_factor_sources_interactors;
 
+pub use test_authorization_interactor::*;
 pub use test_use_factor_sources_interactors::*;

--- a/crates/system/interactors/src/testing/test_authorization_interactor.rs
+++ b/crates/system/interactors/src/testing/test_authorization_interactor.rs
@@ -93,7 +93,7 @@ impl TestAuthorizationInteractor {
                 response_per_purpose
                     .insert(purpose, AuthorizationResponse::Rejected);
             }
-            AuthorisingUser::Docile { .. } => panic!("Not possible"),
+            _ => unreachable!(),
         }
 
         Self::new(user)

--- a/crates/system/interactors/src/testing/test_authorization_interactor.rs
+++ b/crates/system/interactors/src/testing/test_authorization_interactor.rs
@@ -1,0 +1,74 @@
+use crate::prelude::*;
+
+pub struct TestAuthorizationInteractor {
+    response_per_purpose: IndexMap<AuthorizationPurpose, AuthorizationResponse>,
+}
+
+#[async_trait::async_trait]
+impl AuthorizationInteractor for TestAuthorizationInteractor {
+    async fn request_authorization(
+        &self,
+        purpose: AuthorizationPurpose,
+    ) -> AuthorizationResponse {
+        self.response_per_purpose
+            .get(&purpose)
+            .cloned()
+            .unwrap_or(AuthorizationResponse::Authorized)
+    }
+}
+
+impl TestAuthorizationInteractor {
+    pub fn new_authorizing() -> Self {
+        Self {
+            response_per_purpose: IndexMap::from_iter([
+                (
+                    AuthorizationPurpose::CreatingAccount,
+                    AuthorizationResponse::Authorized,
+                ),
+                (
+                    AuthorizationPurpose::CreatingAccounts,
+                    AuthorizationResponse::Authorized,
+                ),
+                (
+                    AuthorizationPurpose::CreatingPersona,
+                    AuthorizationResponse::Authorized,
+                ),
+                (
+                    AuthorizationPurpose::CreatingPersonas,
+                    AuthorizationResponse::Authorized,
+                ),
+            ]),
+        }
+    }
+
+    pub fn new_rejecting() -> Self {
+        Self {
+            response_per_purpose: IndexMap::from_iter([
+                (
+                    AuthorizationPurpose::CreatingAccount,
+                    AuthorizationResponse::Rejected,
+                ),
+                (
+                    AuthorizationPurpose::CreatingAccounts,
+                    AuthorizationResponse::Rejected,
+                ),
+                (
+                    AuthorizationPurpose::CreatingPersona,
+                    AuthorizationResponse::Rejected,
+                ),
+                (
+                    AuthorizationPurpose::CreatingPersonas,
+                    AuthorizationResponse::Rejected,
+                ),
+            ]),
+        }
+    }
+
+    pub fn new_rejecting_only(purpose: AuthorizationPurpose) -> Self {
+        let mut interactor = TestAuthorizationInteractor::new_authorizing();
+        interactor
+            .response_per_purpose
+            .insert(purpose, AuthorizationResponse::Rejected);
+        interactor
+    }
+}

--- a/crates/system/interactors/src/testing/test_authorization_interactor.rs
+++ b/crates/system/interactors/src/testing/test_authorization_interactor.rs
@@ -1,7 +1,34 @@
 use crate::prelude::*;
 
 pub struct TestAuthorizationInteractor {
-    response_per_purpose: IndexMap<AuthorizationPurpose, AuthorizationResponse>,
+    request_count: RwLock<u32>,
+    user: AuthorisingUser,
+}
+
+#[derive(Clone)]
+enum AuthorisingUser {
+    Stubborn {
+        response_per_purpose:
+            IndexMap<AuthorizationPurpose, AuthorizationResponse>,
+    },
+
+    Docile {
+        response_per_purpose_per_time:
+            Vec<IndexMap<AuthorizationPurpose, AuthorizationResponse>>,
+    },
+}
+
+impl AuthorisingUser {
+    pub fn stubborn(response: AuthorizationResponse) -> Self {
+        Self::Stubborn {
+            response_per_purpose: IndexMap::from_iter([
+                (AuthorizationPurpose::CreatingAccount, response.clone()),
+                (AuthorizationPurpose::CreatingAccounts, response.clone()),
+                (AuthorizationPurpose::CreatingPersona, response.clone()),
+                (AuthorizationPurpose::CreatingPersonas, response.clone()),
+            ]),
+        }
+    }
 }
 
 #[async_trait::async_trait]
@@ -10,7 +37,31 @@ impl AuthorizationInteractor for TestAuthorizationInteractor {
         &self,
         purpose: AuthorizationPurpose,
     ) -> AuthorizationResponse {
-        self.response_per_purpose
+        let response_per_purpose = match self.user.clone() {
+            AuthorisingUser::Stubborn {
+                response_per_purpose,
+            } => response_per_purpose,
+            AuthorisingUser::Docile {
+                response_per_purpose_per_time,
+            } => {
+                let count = *self
+                    .request_count
+                    .read()
+                    .expect("Request count should not have been poisoned");
+
+                response_per_purpose_per_time
+                    .get(count as usize)
+                    .unwrap()
+                    .clone()
+            }
+        };
+
+        self.request_count
+            .write()
+            .expect("Request count should not have been poisoned")
+            .add_assign(1u32);
+
+        response_per_purpose
             .get(&purpose)
             .cloned()
             .unwrap_or(AuthorizationResponse::Authorized)
@@ -18,34 +69,49 @@ impl AuthorizationInteractor for TestAuthorizationInteractor {
 }
 
 impl TestAuthorizationInteractor {
-    pub fn new_authorizing() -> Self {
+    fn new(user: AuthorisingUser) -> Self {
         Self {
-            response_per_purpose: IndexMap::from_iter([
-                (
-                    AuthorizationPurpose::CreatingAccount,
-                    AuthorizationResponse::Authorized,
-                ),
-                (
-                    AuthorizationPurpose::CreatingAccounts,
-                    AuthorizationResponse::Authorized,
-                ),
-                (
-                    AuthorizationPurpose::CreatingPersona,
-                    AuthorizationResponse::Authorized,
-                ),
-                (
-                    AuthorizationPurpose::CreatingPersonas,
-                    AuthorizationResponse::Authorized,
-                ),
-            ]),
+            request_count: RwLock::new(0u32),
+            user,
         }
     }
 
-    pub fn new_rejecting_only(purpose: AuthorizationPurpose) -> Self {
-        let mut interactor = TestAuthorizationInteractor::new_authorizing();
-        interactor
-            .response_per_purpose
-            .insert(purpose, AuthorizationResponse::Rejected);
-        interactor
+    pub fn stubborn_authorizing() -> Self {
+        Self::new(AuthorisingUser::stubborn(AuthorizationResponse::Authorized))
+    }
+
+    pub fn stubborn_rejecting_specific_purpose(
+        purpose: AuthorizationPurpose,
+    ) -> Self {
+        let mut user =
+            AuthorisingUser::stubborn(AuthorizationResponse::Authorized);
+
+        match user {
+            AuthorisingUser::Stubborn {
+                ref mut response_per_purpose,
+            } => {
+                response_per_purpose
+                    .insert(purpose, AuthorizationResponse::Rejected);
+            }
+            AuthorisingUser::Docile { .. } => panic!("Not possible"),
+        }
+
+        Self::new(user)
+    }
+
+    pub fn docile_with(
+        interactions: impl IntoIterator<
+            Item = (AuthorizationPurpose, AuthorizationResponse),
+        >,
+    ) -> Self {
+        let user = AuthorisingUser::Docile {
+            response_per_purpose_per_time: Vec::from_iter(
+                interactions.into_iter().map(|(purpose, response)| {
+                    IndexMap::from_iter([(purpose, response)])
+                }),
+            ),
+        };
+
+        Self::new(user)
     }
 }

--- a/crates/system/interactors/src/testing/test_authorization_interactor.rs
+++ b/crates/system/interactors/src/testing/test_authorization_interactor.rs
@@ -41,29 +41,6 @@ impl TestAuthorizationInteractor {
         }
     }
 
-    pub fn new_rejecting() -> Self {
-        Self {
-            response_per_purpose: IndexMap::from_iter([
-                (
-                    AuthorizationPurpose::CreatingAccount,
-                    AuthorizationResponse::Rejected,
-                ),
-                (
-                    AuthorizationPurpose::CreatingAccounts,
-                    AuthorizationResponse::Rejected,
-                ),
-                (
-                    AuthorizationPurpose::CreatingPersona,
-                    AuthorizationResponse::Rejected,
-                ),
-                (
-                    AuthorizationPurpose::CreatingPersonas,
-                    AuthorizationResponse::Rejected,
-                ),
-            ]),
-        }
-    }
-
     pub fn new_rejecting_only(purpose: AuthorizationPurpose) -> Self {
         let mut interactor = TestAuthorizationInteractor::new_authorizing();
         interactor

--- a/crates/system/os/accounts/Cargo.toml
+++ b/crates/system/os/accounts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-accounts"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/derive-public-keys/Cargo.toml
+++ b/crates/system/os/derive-public-keys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-derive-public-keys"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/derive-public-keys/src/sargon_os_derive_public_keys.rs
+++ b/crates/system/os/derive-public-keys/src/sargon_os_derive_public_keys.rs
@@ -111,9 +111,8 @@ mod test {
 
         let factor_source_not_in_profile =
             FactorSourceIDFromHash::sample_password();
-        let source = DerivePublicKeysSource::FactorSource(
-            factor_source_not_in_profile.clone(),
-        );
+        let source =
+            DerivePublicKeysSource::FactorSource(factor_source_not_in_profile);
         let result = sut
             .derive_public_keys(sample_derivation_paths(), source)
             .await

--- a/crates/system/os/factors/Cargo.toml
+++ b/crates/system/os/factors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-factors"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/os/Cargo.toml
+++ b/crates/system/os/os/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/os/src/sargon_os.rs
+++ b/crates/system/os/os/src/sargon_os.rs
@@ -454,7 +454,7 @@ impl SargonOS {
 
         let authorization_interactor =
             authorization_interactor.into().unwrap_or_else(|| {
-                Arc::new(TestAuthorizationInteractor::new_authorizing())
+                Arc::new(TestAuthorizationInteractor::stubborn_authorizing())
             });
 
         let os = Self::boot_with_clients_and_interactor(
@@ -492,7 +492,7 @@ impl SargonOS {
         pre_derive_factor_instance_for_bdfs: bool,
     ) -> Arc<Self> {
         let authorization_interactor: Arc<dyn AuthorizationInteractor> =
-            Arc::new(TestAuthorizationInteractor::new_authorizing());
+            Arc::new(TestAuthorizationInteractor::stubborn_authorizing());
 
         let req = Self::boot_test_with_bdfs_mnemonic_and_interactors(
             bdfs_mnemonic,

--- a/crates/system/os/os/src/sargon_os.rs
+++ b/crates/system/os/os/src/sargon_os.rs
@@ -316,6 +316,10 @@ impl SargonOS {
             as Arc<dyn KeyDerivationInteractor>
     }
 
+    pub fn authorization_interactor(&self) -> Arc<dyn AuthorizationInteractor> {
+        self.interactors.authorization_interactor.clone()
+    }
+
     pub fn host_id(&self) -> HostId {
         self.host_id
     }
@@ -426,9 +430,12 @@ impl SargonOS {
             .unwrap()
     }
 
-    pub async fn boot_test_with_bdfs_mnemonic_and_interactor(
+    pub async fn boot_test_with_bdfs_mnemonic_and_interactors(
         bdfs_mnemonic: impl Into<Option<MnemonicWithPassphrase>>,
         derivation_interactor: impl Into<Option<Arc<dyn KeyDerivationInteractor>>>,
+        authorization_interactor: impl Into<
+            Option<Arc<dyn AuthorizationInteractor>>,
+        >,
         pre_derive_factor_instance_for_bdfs: bool,
     ) -> Result<Arc<Self>> {
         let test_drivers =
@@ -445,10 +452,16 @@ impl SargonOS {
                 ))
             });
 
+        let authorization_interactor =
+            authorization_interactor.into().unwrap_or_else(|| {
+                Arc::new(TestAuthorizationInteractor::new_authorizing())
+            });
+
         let os = Self::boot_with_clients_and_interactor(
             clients,
-            Interactors::new_with_derivation_interactor(
+            Interactors::new_with_derivation_and_authorization_interactor(
                 keys_derivation_interactor,
+                authorization_interactor,
             ),
         )
         .await;
@@ -478,9 +491,13 @@ impl SargonOS {
         derivation_interactor: impl Into<Option<Arc<dyn KeyDerivationInteractor>>>,
         pre_derive_factor_instance_for_bdfs: bool,
     ) -> Arc<Self> {
-        let req = Self::boot_test_with_bdfs_mnemonic_and_interactor(
+        let authorization_interactor: Arc<dyn AuthorizationInteractor> =
+            Arc::new(TestAuthorizationInteractor::new_authorizing());
+
+        let req = Self::boot_test_with_bdfs_mnemonic_and_interactors(
             bdfs_mnemonic,
             derivation_interactor,
+            authorization_interactor,
             pre_derive_factor_instance_for_bdfs,
         );
 
@@ -497,8 +514,10 @@ impl SargonOS {
     }
 
     pub async fn boot_test() -> Result<Arc<Self>> {
-        Self::boot_test_with_bdfs_mnemonic_and_interactor(None, None, true)
-            .await
+        Self::boot_test_with_bdfs_mnemonic_and_interactors(
+            None, None, None, true,
+        )
+        .await
     }
 
     /// Boot the SargonOS with a mocked networking driver.

--- a/crates/system/os/os/src/sargon_os_accounts.rs
+++ b/crates/system/os/os/src/sargon_os_accounts.rs
@@ -1379,7 +1379,7 @@ mod tests {
             Interactors::new_from_clients_and_authorization_interactor(
                 &clients,
                 Arc::new(TestAuthorizationInteractor::stubborn_rejecting_specific_purpose(
-                    AuthorizationPurpose::CreatingAccount,
+                    AuthorizationPurpose::CreatingAccounts,
                 )),
             );
         let os = timeout(
@@ -1396,9 +1396,10 @@ mod tests {
 
         let result = os
             .with_timeout(|x| {
-                x.create_and_save_new_account_with_main_bdfs(
+                x.batch_create_many_accounts_with_main_bdfs_then_save_once(
+                    10u16,
                     NetworkID::Mainnet,
-                    DisplayName::new("Authorising Account").unwrap(),
+                    "Authorising Account".to_string(),
                 )
             })
             .await;

--- a/crates/system/os/os/src/sargon_os_accounts.rs
+++ b/crates/system/os/os/src/sargon_os_accounts.rs
@@ -319,7 +319,7 @@ impl SargonOS {
         match authorization {
             AuthorizationResponse::Rejected => {
                 debug!("User rejected authorization, aborting.");
-                return Err(CommonError::SigningRejected);
+                return Err(CommonError::HostInteractionAborted);
             }
             AuthorizationResponse::Authorized => {
                 debug!("User authorized, saving to profile...");
@@ -405,7 +405,7 @@ impl SargonOS {
         match authorization {
             AuthorizationResponse::Rejected => {
                 debug!("User rejected authorization, aborting.");
-                return Err(CommonError::SigningRejected);
+                return Err(CommonError::HostInteractionAborted);
             }
             AuthorizationResponse::Authorized => {
                 debug!("User authorized, saving to profile...");
@@ -1361,7 +1361,7 @@ mod tests {
             })
             .await;
 
-        assert_eq!(Err(CommonError::SigningRejected), result);
+        assert_eq!(Err(CommonError::HostInteractionAborted), result);
 
         assert_eq!(
             initial_profile.accounts_on_current_network().unwrap().len(),
@@ -1404,7 +1404,7 @@ mod tests {
             })
             .await;
 
-        assert_eq!(Err(CommonError::SigningRejected), result);
+        assert_eq!(Err(CommonError::HostInteractionAborted), result);
 
         assert_eq!(
             initial_profile.accounts_on_current_network().unwrap().len(),

--- a/crates/system/os/os/src/sargon_os_accounts.rs
+++ b/crates/system/os/os/src/sargon_os_accounts.rs
@@ -1379,7 +1379,7 @@ mod tests {
             Interactors::new_from_clients_and_authorization_interactor(
                 &clients,
                 Arc::new(TestAuthorizationInteractor::stubborn_rejecting_specific_purpose(
-                    AuthorizationPurpose::CreatingAccounts,
+                    AuthorizationPurpose::CreatingAccount,
                 )),
             );
         let os = timeout(

--- a/crates/system/os/os/src/sargon_os_accounts.rs
+++ b/crates/system/os/os/src/sargon_os_accounts.rs
@@ -309,7 +309,22 @@ impl SargonOS {
                 name,
             )
             .await?;
-        debug!("Created account, now saving it to profile.");
+        debug!("Created account, requesting authorization...");
+
+        let authorization = self
+            .authorization_interactor()
+            .request_authorization(AuthorizationPurpose::CreatingAccount)
+            .await;
+
+        match authorization {
+            AuthorizationResponse::Rejected => {
+                debug!("User rejected authorization, aborting.");
+                return Err(CommonError::SigningRejected);
+            }
+            AuthorizationResponse::Authorized => {
+                debug!("User authorized, saving to profile...");
+            }
+        }
 
         // Add account to Profile...
         self.add_account(account.clone()).await?;
@@ -380,17 +395,29 @@ impl SargonOS {
                 name_prefix,
             )
             .await?;
-        debug!("Created #{} accounts, now saving them to profile.", count);
+        debug!("Created #{} accounts, requesting authorization...", count);
+
+        let authorization = self
+            .authorization_interactor()
+            .request_authorization(AuthorizationPurpose::CreatingAccounts)
+            .await;
+
+        match authorization {
+            AuthorizationResponse::Rejected => {
+                debug!("User rejected authorization, aborting.");
+                return Err(CommonError::SigningRejected);
+            }
+            AuthorizationResponse::Authorized => {
+                debug!("User authorized, saving to profile...");
+            }
+        }
 
         // First try to save accounts into Profile...
         self.add_accounts(accounts.clone()).await?;
         // ... if successful consume the FactorInstances from the Cache!
         instances_in_cache_consumer.consume().await?;
 
-        info!(
-            "Created account and saved #{} new accounts into profile",
-            count
-        );
+        info!("Created and saved #{} new accounts into profile", count);
         Ok((accounts, derivation_outcome))
     }
 
@@ -1297,6 +1324,91 @@ mod tests {
                 ProfileSaved,
                 AccountAdded
             ]
+        );
+    }
+
+    #[actix_rt::test]
+    async fn test_create_and_save_new_account_aborts_when_user_rejects_authorization(
+    ) {
+        let mut clients = Clients::new(Bios::new(Drivers::test()));
+        clients.factor_instances_cache =
+            FactorInstancesCacheClient::in_memory();
+        let interactors =
+            Interactors::new_from_clients_and_authorization_interactor(
+                &clients,
+                Arc::new(TestAuthorizationInteractor::new_rejecting_only(
+                    AuthorizationPurpose::CreatingAccount,
+                )),
+            );
+        let os = timeout(
+            SARGON_OS_TEST_MAX_ASYNC_DURATION,
+            SUT::boot_with_clients_and_interactor(clients, interactors),
+        )
+        .await
+        .unwrap();
+
+        let initial_profile = Profile::sample();
+        os.with_timeout(|x| x.import_wallet(&initial_profile, true))
+            .await
+            .unwrap();
+
+        let result = os
+            .with_timeout(|x| {
+                x.create_and_save_new_account_with_main_bdfs(
+                    NetworkID::Mainnet,
+                    DisplayName::sample(),
+                )
+            })
+            .await;
+
+        assert_eq!(Err(CommonError::SigningRejected), result);
+
+        assert_eq!(
+            initial_profile.accounts_on_current_network().unwrap().len(),
+            os.accounts_on_current_network().unwrap().len()
+        );
+    }
+
+    #[actix_rt::test]
+    async fn test_batch_create_and_save_new_accounts_aborts_when_user_rejects_authorization(
+    ) {
+        let mut clients = Clients::new(Bios::new(Drivers::test()));
+        clients.factor_instances_cache =
+            FactorInstancesCacheClient::in_memory();
+        let interactors =
+            Interactors::new_from_clients_and_authorization_interactor(
+                &clients,
+                Arc::new(TestAuthorizationInteractor::new_rejecting_only(
+                    AuthorizationPurpose::CreatingAccounts,
+                )),
+            );
+        let os = timeout(
+            SARGON_OS_TEST_MAX_ASYNC_DURATION,
+            SUT::boot_with_clients_and_interactor(clients, interactors),
+        )
+        .await
+        .unwrap();
+
+        let initial_profile = Profile::sample();
+        os.with_timeout(|x| x.import_wallet(&initial_profile, true))
+            .await
+            .unwrap();
+
+        let result = os
+            .with_timeout(|x| {
+                x.batch_create_many_accounts_with_main_bdfs_then_save_once(
+                    10,
+                    NetworkID::Mainnet,
+                    "test".to_owned(),
+                )
+            })
+            .await;
+
+        assert_eq!(Err(CommonError::SigningRejected), result);
+
+        assert_eq!(
+            initial_profile.accounts_on_current_network().unwrap().len(),
+            os.accounts_on_current_network().unwrap().len()
         );
     }
 

--- a/crates/system/os/os/src/sargon_os_personas.rs
+++ b/crates/system/os/os/src/sargon_os_personas.rs
@@ -1301,7 +1301,7 @@ mod tests {
         let interactors =
             Interactors::new_from_clients_and_authorization_interactor(
                 &clients,
-                Arc::new(TestAuthorizationInteractor::new_rejecting_only(
+                Arc::new(TestAuthorizationInteractor::stubborn_rejecting_specific_purpose(
                     AuthorizationPurpose::CreatingPersona,
                 )),
             );
@@ -1344,7 +1344,7 @@ mod tests {
         let interactors =
             Interactors::new_from_clients_and_authorization_interactor(
                 &clients,
-                Arc::new(TestAuthorizationInteractor::new_rejecting_only(
+                Arc::new(TestAuthorizationInteractor::stubborn_rejecting_specific_purpose(
                     AuthorizationPurpose::CreatingPersonas,
                 )),
             );
@@ -1375,6 +1375,100 @@ mod tests {
         assert_eq!(
             initial_profile.personas_on_current_network().unwrap().len(),
             os.personas_on_current_network().unwrap().len()
+        );
+    }
+
+    #[actix_rt::test]
+    async fn test_create_and_save_new_persona_uses_correct_index_after_one_rejection(
+    ) {
+        let mut clients = Clients::new(Bios::new(Drivers::test()));
+        clients.factor_instances_cache =
+            FactorInstancesCacheClient::in_memory();
+        let interactors =
+            Interactors::new_from_clients_and_authorization_interactor(
+                &clients,
+                Arc::new(TestAuthorizationInteractor::docile_with([
+                    (
+                        AuthorizationPurpose::CreatingPersona,
+                        AuthorizationResponse::Authorized,
+                    ),
+                    (
+                        AuthorizationPurpose::CreatingPersona,
+                        AuthorizationResponse::Rejected,
+                    ),
+                    (
+                        AuthorizationPurpose::CreatingPersona,
+                        AuthorizationResponse::Authorized,
+                    ),
+                ])),
+            );
+        let os = timeout(
+            SARGON_OS_TEST_MAX_ASYNC_DURATION,
+            SUT::boot_with_clients_and_interactor(clients, interactors),
+        )
+        .await
+        .unwrap();
+
+        let initial_profile = Profile::sample();
+        os.with_timeout(|x| x.import_wallet(&initial_profile, true))
+            .await
+            .unwrap();
+
+        let accepted_first = os
+            .with_timeout(|x| {
+                x.create_and_save_new_persona_with_main_bdfs(
+                    NetworkID::Mainnet,
+                    DisplayName::new("Accepted 1st").unwrap(),
+                    None,
+                )
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(
+            accepted_first
+                .security_state
+                .as_unsecured()
+                .unwrap()
+                .transaction_signing
+                .derivation_entity_index()
+                .index_in_local_key_space()
+                .0,
+            0u32
+        );
+
+        let result = os
+            .with_timeout(|x| {
+                x.create_and_save_new_persona_with_main_bdfs(
+                    NetworkID::Mainnet,
+                    DisplayName::new("Rejected").unwrap(),
+                    None,
+                )
+            })
+            .await;
+        assert_eq!(Err(CommonError::HostInteractionAborted), result);
+
+        let accepted_second = os
+            .with_timeout(|x| {
+                x.create_and_save_new_persona_with_main_bdfs(
+                    NetworkID::Mainnet,
+                    DisplayName::new("Accepted 2nd").unwrap(),
+                    None,
+                )
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(
+            accepted_second
+                .security_state
+                .as_unsecured()
+                .unwrap()
+                .transaction_signing
+                .derivation_entity_index()
+                .index_in_local_key_space()
+                .0,
+            1u32
         );
     }
 }

--- a/crates/system/os/os/src/sargon_os_personas.rs
+++ b/crates/system/os/os/src/sargon_os_personas.rs
@@ -309,7 +309,7 @@ impl SargonOS {
         match authorization {
             AuthorizationResponse::Rejected => {
                 debug!("User rejected authorization, aborting.");
-                return Err(CommonError::SigningRejected);
+                return Err(CommonError::HostInteractionAborted);
             }
             AuthorizationResponse::Authorized => {
                 debug!("User authorized, saving to profile...");
@@ -395,7 +395,7 @@ impl SargonOS {
         match authorization {
             AuthorizationResponse::Rejected => {
                 debug!("User rejected authorization, aborting.");
-                return Err(CommonError::SigningRejected);
+                return Err(CommonError::HostInteractionAborted);
             }
             AuthorizationResponse::Authorized => {
                 debug!("User authorized, saving to profile...");
@@ -1327,7 +1327,7 @@ mod tests {
             })
             .await;
 
-        assert_eq!(Err(CommonError::SigningRejected), result);
+        assert_eq!(Err(CommonError::HostInteractionAborted), result);
 
         assert_eq!(
             initial_profile.personas_on_current_network().unwrap().len(),
@@ -1370,7 +1370,7 @@ mod tests {
             })
             .await;
 
-        assert_eq!(Err(CommonError::SigningRejected), result);
+        assert_eq!(Err(CommonError::HostInteractionAborted), result);
 
         assert_eq!(
             initial_profile.personas_on_current_network().unwrap().len(),

--- a/crates/system/os/os/src/testing_interactors.rs
+++ b/crates/system/os/os/src/testing_interactors.rs
@@ -53,7 +53,7 @@ impl InteractorsCtors for Interactors {
 
         Self::new(
             Arc::new(use_factor_sources_interactors),
-            Arc::new(TestAuthorizationInteractor::new_authorizing()),
+            Arc::new(TestAuthorizationInteractor::stubborn_authorizing()),
         )
     }
 

--- a/crates/system/os/os/src/testing_interactors.rs
+++ b/crates/system/os/os/src/testing_interactors.rs
@@ -5,6 +5,11 @@ pub trait InteractorsCtors {
         keys_derivation_interactor: Arc<dyn KeyDerivationInteractor>,
     ) -> Interactors;
 
+    fn new_with_derivation_and_authorization_interactor(
+        keys_derivation_interactor: Arc<dyn KeyDerivationInteractor>,
+        authorization_interactor: Arc<dyn AuthorizationInteractor>,
+    ) -> Interactors;
+
     fn new_from_clients(clients: &Clients) -> Interactors {
         Self::new_with_derivation_interactor(Arc::new(
             TestDerivationInteractor::new(
@@ -12,6 +17,19 @@ pub trait InteractorsCtors {
                 Arc::new(clients.secure_storage.clone()),
             ),
         ))
+    }
+
+    fn new_from_clients_and_authorization_interactor(
+        clients: &Clients,
+        authorization_interactor: Arc<dyn AuthorizationInteractor>,
+    ) -> Interactors {
+        Self::new_with_derivation_and_authorization_interactor(
+            Arc::new(TestDerivationInteractor::new(
+                false,
+                Arc::new(clients.secure_storage.clone()),
+            )),
+            authorization_interactor,
+        )
     }
 }
 
@@ -33,6 +51,33 @@ impl InteractorsCtors for Interactors {
                 )),
             );
 
-        Self::new(Arc::new(use_factor_sources_interactors))
+        Self::new(
+            Arc::new(use_factor_sources_interactors),
+            Arc::new(TestAuthorizationInteractor::new_authorizing()),
+        )
+    }
+
+    fn new_with_derivation_and_authorization_interactor(
+        keys_derivation_interactor: Arc<dyn KeyDerivationInteractor>,
+        authorization_interactor: Arc<dyn AuthorizationInteractor>,
+    ) -> Interactors {
+        let use_factor_sources_interactors =
+            TestUseFactorSourcesInteractors::new(
+                Arc::new(TestSignInteractor::<TransactionIntent>::new(
+                    SimulatedUser::prudent_no_fail(),
+                )),
+                Arc::new(TestSignInteractor::<Subintent>::new(
+                    SimulatedUser::prudent_no_fail(),
+                )),
+                keys_derivation_interactor,
+                Arc::new(TestSignInteractor::<AuthIntent>::new(
+                    SimulatedUser::prudent_no_fail(),
+                )),
+            );
+
+        Self::new(
+            Arc::new(use_factor_sources_interactors),
+            authorization_interactor,
+        )
     }
 }

--- a/crates/system/os/security-center/Cargo.toml
+++ b/crates/system/os/security-center/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-security-center"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/signing/Cargo.toml
+++ b/crates/system/os/signing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-signing"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/signing/src/sargon_os_signing.rs
+++ b/crates/system/os/signing/src/sargon_os_signing.rs
@@ -172,7 +172,7 @@ mod test {
 
         let result = sut.sign_auth(auth_intent).await;
 
-        assert_eq!(result, Err(CommonError::SigningRejected))
+        assert_eq!(result, Err(CommonError::HostInteractionAborted))
     }
 
     #[actix_rt::test]
@@ -423,7 +423,7 @@ mod test {
             .sign_subintent(signable.clone(), RoleKind::Primary)
             .await;
 
-        assert_eq!(outcome, Err(CommonError::SigningRejected));
+        assert_eq!(outcome, Err(CommonError::HostInteractionAborted));
     }
 
     async fn boot(

--- a/crates/system/os/signing/src/sargon_os_signing.rs
+++ b/crates/system/os/signing/src/sargon_os_signing.rs
@@ -463,7 +463,7 @@ mod test {
             ));
         let interactors = Interactors::new(
             use_factor_sources_interactors,
-            Arc::new(TestAuthorizationInteractor::new_authorizing()),
+            Arc::new(TestAuthorizationInteractor::stubborn_authorizing()),
         );
         SUT::boot_with_clients_and_interactor(clients, interactors).await
     }

--- a/crates/system/os/signing/src/sargon_os_signing.rs
+++ b/crates/system/os/signing/src/sargon_os_signing.rs
@@ -461,7 +461,10 @@ mod test {
                     get_simulated_user::<AuthIntent>(&maybe_signing_failure),
                 )),
             ));
-        let interactors = Interactors::new(use_factor_sources_interactors);
+        let interactors = Interactors::new(
+            use_factor_sources_interactors,
+            Arc::new(TestAuthorizationInteractor::new_authorizing()),
+        );
         SUT::boot_with_clients_and_interactor(clients, interactors).await
     }
 

--- a/crates/system/os/transaction/Cargo.toml
+++ b/crates/system/os/transaction/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-transaction"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/profile-state-holder/Cargo.toml
+++ b/crates/system/profile-state-holder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-state-holder"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/sub-systems/Cargo.toml
+++ b/crates/system/sub-systems/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sub-systems"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/transaction/foundation/Cargo.toml
+++ b/crates/transaction/foundation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transaction-foundation"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/transaction/manifests/Cargo.toml
+++ b/crates/transaction/manifests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "manifests"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 

--- a/crates/transaction/models/Cargo.toml
+++ b/crates/transaction/models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transaction-models"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 

--- a/crates/uniffi/conversion-macros/Cargo.toml
+++ b/crates/uniffi/conversion-macros/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "sargon-uniffi-conversion-macros"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 
 [dependencies]

--- a/crates/uniffi/uniffi_SPLIT_ME/Cargo.toml
+++ b/crates/uniffi/uniffi_SPLIT_ME/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-uniffi"
-version = "1.1.119"
+version = "1.1.120"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/uniffi/uniffi_SPLIT_ME/src/core/error/common_error.rs
+++ b/crates/uniffi/uniffi_SPLIT_ME/src/core/error/common_error.rs
@@ -23,7 +23,7 @@ pub enum CommonError {
     InvalidISO8601String {
         bad_value: String,
     },
-    SigningRejected,
+    HostInteractionAborted,
     WrongEntityKind {
         expected: String,
         found: String,
@@ -187,7 +187,9 @@ impl CommonError {
                     bad_value: bad_value.clone(),
                 }
             }
-            SigningRejected => InternalCommonError::SigningRejected,
+            HostInteractionAborted => {
+                InternalCommonError::HostInteractionAborted
+            }
             WrongEntityKind { expected, found } => {
                 InternalCommonError::WrongEntityKind {
                     expected: expected.clone(),
@@ -373,7 +375,9 @@ impl From<InternalCommonError> for CommonError {
             InternalCommonError::InvalidISO8601String { bad_value } => {
                 InvalidISO8601String { bad_value }
             }
-            InternalCommonError::SigningRejected => SigningRejected,
+            InternalCommonError::HostInteractionAborted => {
+                HostInteractionAborted
+            }
             InternalCommonError::WrongEntityKind { expected, found } => {
                 WrongEntityKind { expected, found }
             }

--- a/crates/uniffi/uniffi_SPLIT_ME/src/system/sargon_os/sargon_os.rs
+++ b/crates/uniffi/uniffi_SPLIT_ME/src/system/sargon_os/sargon_os.rs
@@ -22,9 +22,12 @@ impl SargonOS {
     ) -> Arc<Self> {
         let internal_sargon_os = InternalSargonOS::boot(
             Arc::new(bios.as_ref().clone().into()),
-            Interactors::new(Arc::new(UseFactorSourcesInteractorAdapter::new(
-                interactor,
-            ))),
+            Interactors::new(
+                Arc::new(UseFactorSourcesInteractorAdapter::new(
+                    interactor.clone(),
+                )),
+                Arc::new(AuthorizationInteractorAdapter::new(interactor)),
+            ),
         )
         .await;
 

--- a/crates/uniffi/uniffi_SPLIT_ME/src/types/authorization.rs
+++ b/crates/uniffi/uniffi_SPLIT_ME/src/types/authorization.rs
@@ -1,0 +1,28 @@
+use crate::prelude::*;
+use sargon::AuthorizationPurpose as InternalAuthorizationPurpose;
+use sargon::AuthorizationResponse as InternalAuthorizationResponse;
+
+/// The purpose of the authorization request
+#[derive(Clone, PartialEq, Eq, InternalConversion, uniffi::Enum)]
+pub enum AuthorizationPurpose {
+    /// When a new account is about to be created.
+    CreatingAccount,
+
+    /// When a batch of accounts is about to be created.
+    CreatingAccounts,
+
+    /// When a new persona is about to be created.
+    CreatingPersona,
+
+    /// When a batch of personas is about to be created.
+    CreatingPersonas,
+}
+
+#[derive(Clone, PartialEq, Eq, InternalConversion, uniffi::Enum)]
+pub enum AuthorizationResponse {
+    /// The user authorized the request
+    Authorized,
+
+    /// The user rejected the request
+    Rejected,
+}

--- a/crates/uniffi/uniffi_SPLIT_ME/src/types/mod.rs
+++ b/crates/uniffi/uniffi_SPLIT_ME/src/types/mod.rs
@@ -1,7 +1,9 @@
+mod authorization;
 mod ffi_url;
 mod owned_factor_instance;
 mod vector_image_type;
 
+pub use authorization::*;
 pub use ffi_url::*;
 pub use owned_factor_instance::*;
 pub use vector_image_type::*;

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/os/interactor/FakeHostInteractor.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/os/interactor/FakeHostInteractor.kt
@@ -1,5 +1,7 @@
 package com.radixdlt.sargon.os.interactor
 
+import com.radixdlt.sargon.AuthorizationPurpose
+import com.radixdlt.sargon.AuthorizationResponse
 import com.radixdlt.sargon.CommonException
 import com.radixdlt.sargon.HostInteractor
 import com.radixdlt.sargon.KeyDerivationRequest
@@ -15,19 +17,23 @@ class FakeHostInteractor: HostInteractor {
     override suspend fun signTransactions(
         request: SignRequestOfTransactionIntent
     ): SignResponseOfTransactionIntentHash {
-        throw CommonException.SigningRejected()
+        throw CommonException.HostInteractionAborted()
     }
 
     override suspend fun signSubintents(request: SignRequestOfSubintent): SignResponseOfSubintentHash {
-        throw CommonException.SigningRejected()
+        throw CommonException.HostInteractionAborted()
     }
 
     override suspend fun deriveKeys(request: KeyDerivationRequest): KeyDerivationResponse {
-        throw CommonException.SigningRejected()
+        throw CommonException.HostInteractionAborted()
     }
 
     override suspend fun signAuth(request: SignRequestOfAuthIntent): SignResponseOfAuthIntentHash {
-        throw CommonException.SigningRejected()
+        throw CommonException.HostInteractionAborted()
+    }
+
+    override suspend fun requestAuthorization(purpose: AuthorizationPurpose): AuthorizationResponse {
+        return AuthorizationResponse.REJECTED
     }
 
 }


### PR DESCRIPTION
A new interactor responsible for asking the user through the host to authorise an operation. Such operation is called `AuthorizationPurpose` and it currently supports variants for creating one or batch accounts, or one or batch personas.If the user rejects authorization, then such operation does not mutate the profile, nor does consume the cache.

The user can either `AuthorizationResponse::Authorized` or `AuthorizationResponse::Rejected`.

Note that, I also changed the name of the error used to be called `SigningRejected` to `HostInteractionAborted`. It can be thrown by hosts when answering to the interactor callbacks, and returned back to the method that initiated the interaction. It is a "common result" that hosts receive and can just reset the UI for the user to try again.