### PR TITLE
Create WalletToDappInteractionAuthProof on Sargon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "account-for-display"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "addresses",
  "derive_more",
@@ -49,10 +49,10 @@ dependencies = [
 
 [[package]]
 name = "addresses"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "assert-json",
- "bytes 1.1.121",
+ "bytes 1.1.122",
  "cap26-models",
  "core-utils",
  "derive_more",
@@ -246,7 +246,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "assert-json"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "assert-json-diff",
  "error",
@@ -546,7 +546,7 @@ dependencies = [
 
 [[package]]
 name = "build-info"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "assert-json",
  "cargo_toml",
@@ -573,7 +573,7 @@ checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
 
 [[package]]
 name = "bytes"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "assert-json",
  "delegate",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "cap26-models"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "assert-json",
  "derive_more",
@@ -748,7 +748,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "clients"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -808,7 +808,7 @@ checksum = "0d8a42181e0652c2997ae4d217f25b63c5337a52fd2279736e97b832fa0a3cff"
 
 [[package]]
 name = "core-collections"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "has-sample-values",
  "indexmap 2.7.0",
@@ -835,7 +835,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-misc"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "assert-json",
  "core-utils",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "core-utils"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "error",
  "iso8601-timestamp",
@@ -1084,7 +1084,7 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "drivers"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -1108,10 +1108,10 @@ dependencies = [
 
 [[package]]
 name = "ecc"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "assert-json",
- "bytes 1.1.121",
+ "bytes 1.1.122",
  "derive_more",
  "enum-as-inner",
  "error",
@@ -1210,11 +1210,11 @@ dependencies = [
 
 [[package]]
 name = "encryption"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "aes-gcm",
  "assert-json",
- "bytes 1.1.121",
+ "bytes 1.1.122",
  "derive_more",
  "error",
  "has-sample-values",
@@ -1231,7 +1231,7 @@ dependencies = [
 
 [[package]]
 name = "entity-by-address"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "addresses",
  "error",
@@ -1243,7 +1243,7 @@ dependencies = [
 
 [[package]]
 name = "entity-foundation"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "assert-json",
  "derive_more",
@@ -1318,7 +1318,7 @@ dependencies = [
 
 [[package]]
 name = "error"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "derive_more",
  "log",
@@ -1377,7 +1377,7 @@ dependencies = [
 
 [[package]]
 name = "factor-instances-provider"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -1403,9 +1403,9 @@ dependencies = [
 
 [[package]]
 name = "factors"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
- "bytes 1.1.121",
+ "bytes 1.1.122",
  "cap26-models",
  "core-collections",
  "core-misc",
@@ -1440,7 +1440,7 @@ dependencies = [
 
 [[package]]
 name = "factors-supporting-types"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "async-trait",
  "error",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-client-and-api"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -1613,7 +1613,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-models"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "addresses",
  "assert-json",
@@ -1718,7 +1718,7 @@ dependencies = [
 
 [[package]]
 name = "has-sample-values"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "error",
  "indexmap 2.7.0",
@@ -1729,9 +1729,9 @@ dependencies = [
 
 [[package]]
 name = "hash"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
- "bytes 1.1.121",
+ "bytes 1.1.122",
  "derive_more",
  "prelude",
  "radix-common",
@@ -1795,11 +1795,11 @@ dependencies = [
 
 [[package]]
 name = "hierarchical-deterministic"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "assert-json",
  "bip39",
- "bytes 1.1.121",
+ "bytes 1.1.122",
  "cap26-models",
  "derive_more",
  "ecc",
@@ -1842,13 +1842,13 @@ dependencies = [
 
 [[package]]
 name = "home-cards"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "actix-rt",
  "addresses",
  "async-trait",
  "base64",
- "bytes 1.1.121",
+ "bytes 1.1.122",
  "core-utils",
  "derive_more",
  "drivers",
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "host-info"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "assert-json",
  "derive_more",
@@ -1915,10 +1915,10 @@ dependencies = [
 
 [[package]]
 name = "http-client"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "actix-rt",
- "bytes 1.1.121",
+ "bytes 1.1.122",
  "core-utils",
  "drivers",
  "error",
@@ -2143,7 +2143,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "identified-vec-of"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "assert-json",
  "derive_more",
@@ -2216,7 +2216,7 @@ dependencies = [
 
 [[package]]
 name = "interactors"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -2336,7 +2336,7 @@ dependencies = [
 
 [[package]]
 name = "key-derivation-traits"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "addresses",
  "async-trait",
@@ -2354,7 +2354,7 @@ dependencies = [
 
 [[package]]
 name = "keys-collector"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -2443,7 +2443,7 @@ dependencies = [
 
 [[package]]
 name = "manifests"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "account-for-display",
  "addresses",
@@ -2484,7 +2484,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "metadata"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "derive_more",
  "has-sample-values",
@@ -2584,7 +2584,7 @@ dependencies = [
 
 [[package]]
 name = "network"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "assert-json",
  "enum-iterator",
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "next-derivation-index-ephemeral"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "addresses",
  "assert-json",
@@ -2676,9 +2676,9 @@ dependencies = [
 
 [[package]]
 name = "numeric"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
- "bytes 1.1.121",
+ "bytes 1.1.122",
  "delegate",
  "derive_more",
  "enum-iterator",
@@ -2898,7 +2898,7 @@ dependencies = [
 
 [[package]]
 name = "prelude"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "radix-engine",
  "radix-engine-toolkit",
@@ -2935,7 +2935,7 @@ dependencies = [
 
 [[package]]
 name = "profile"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "account-for-display",
  "addresses",
@@ -2979,7 +2979,7 @@ dependencies = [
 
 [[package]]
 name = "profile-account"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "account-for-display",
  "addresses",
@@ -2999,7 +2999,7 @@ dependencies = [
 
 [[package]]
 name = "profile-account-or-persona"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "cap26-models",
  "derive_more",
@@ -3016,7 +3016,7 @@ dependencies = [
 
 [[package]]
 name = "profile-app-preferences"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "addresses",
  "core-misc",
@@ -3039,7 +3039,7 @@ dependencies = [
 
 [[package]]
 name = "profile-base-entity"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "addresses",
  "derive_more",
@@ -3062,7 +3062,7 @@ dependencies = [
 
 [[package]]
 name = "profile-gateway"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "addresses",
  "assert-json",
@@ -3086,7 +3086,7 @@ dependencies = [
 
 [[package]]
 name = "profile-logic"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "addresses",
  "derive_more",
@@ -3108,7 +3108,7 @@ dependencies = [
 
 [[package]]
 name = "profile-persona"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "addresses",
  "cap26-models",
@@ -3129,7 +3129,7 @@ dependencies = [
 
 [[package]]
 name = "profile-persona-data"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "addresses",
  "assert-json",
@@ -3148,7 +3148,7 @@ dependencies = [
 
 [[package]]
 name = "profile-security-structures"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "addresses",
  "cap26-models",
@@ -3176,7 +3176,7 @@ dependencies = [
 
 [[package]]
 name = "profile-state-holder"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "derive_more",
  "error",
@@ -3191,7 +3191,7 @@ dependencies = [
 
 [[package]]
 name = "profile-supporting-types"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "addresses",
  "derive_more",
@@ -3280,14 +3280,14 @@ dependencies = [
 
 [[package]]
 name = "radix-connect"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "actix-rt",
  "addresses",
  "assert-json",
  "async-trait",
  "base64",
- "bytes 1.1.121",
+ "bytes 1.1.122",
  "core-misc",
  "core-utils",
  "derive_more",
@@ -3315,10 +3315,10 @@ dependencies = [
 
 [[package]]
 name = "radix-connect-models"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "addresses",
- "bytes 1.1.121",
+ "bytes 1.1.122",
  "core-misc",
  "derive_more",
  "error",
@@ -3760,7 +3760,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -3825,7 +3825,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -3852,7 +3852,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-accounts"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -3875,7 +3875,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-derive-public-keys"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -3894,7 +3894,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-factors"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -3922,7 +3922,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-security-center"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "actix-rt",
  "derive_more",
@@ -3938,7 +3938,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-signing"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -3964,7 +3964,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-transaction"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "actix-rt",
  "async-std",
@@ -3993,7 +3993,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-uniffi"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -4050,7 +4050,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-uniffi-conversion-macros"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4223,7 +4223,7 @@ dependencies = [
 
 [[package]]
 name = "security-center"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "addresses",
  "assert-json",
@@ -4391,7 +4391,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "short-string"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "arraystring",
  "assert-json",
@@ -4426,13 +4426,13 @@ dependencies = [
 
 [[package]]
 name = "signatures-collector"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "actix-rt",
  "addresses",
  "assert-json",
  "async-trait",
- "bytes 1.1.121",
+ "bytes 1.1.122",
  "cap26-models",
  "core-collections",
  "core-misc",
@@ -4464,10 +4464,10 @@ dependencies = [
 
 [[package]]
 name = "signing-traits"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "async-trait",
- "bytes 1.1.121",
+ "bytes 1.1.122",
  "core-collections",
  "derive_more",
  "ecc",
@@ -4632,7 +4632,7 @@ dependencies = [
 
 [[package]]
 name = "sub-systems"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "derive_more",
  "drivers",
@@ -4791,7 +4791,7 @@ dependencies = [
 
 [[package]]
 name = "time-utils"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "iso8601-timestamp",
  "prelude",
@@ -4941,10 +4941,10 @@ dependencies = [
 
 [[package]]
 name = "transaction-foundation"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "assert-json",
- "bytes 1.1.121",
+ "bytes 1.1.122",
  "derive_more",
  "has-sample-values",
  "paste",
@@ -4956,10 +4956,10 @@ dependencies = [
 
 [[package]]
 name = "transaction-models"
-version = "1.1.121"
+version = "1.1.122"
 dependencies = [
  "addresses",
- "bytes 1.1.121",
+ "bytes 1.1.122",
  "cargo_toml",
  "core-collections",
  "core-misc",

--- a/apple/Sources/Sargon/Extensions/Methods/RadixConnect/WalletInteraction/WalletToDappInteractionAuthProof+Wrap+Functions.swift
+++ b/apple/Sources/Sargon/Extensions/Methods/RadixConnect/WalletInteraction/WalletToDappInteractionAuthProof+Wrap+Functions.swift
@@ -1,0 +1,8 @@
+import Foundation
+import SargonUniFFI
+
+extension WalletToDappInteractionAuthProof {
+	public init(intentSignatureOfOwner: IntentSignatureOfOwner) {
+		self = newWalletToDappInteractionAuthProofFromIntentSignatureOfOwner(intentSignatureOfOwner: intentSignatureOfOwner)
+	}
+}

--- a/apple/Tests/TestCases/RadixConnect/WalletInteraction/WalletToDappInteractionAuthProofTests.swift
+++ b/apple/Tests/TestCases/RadixConnect/WalletInteraction/WalletToDappInteractionAuthProofTests.swift
@@ -1,0 +1,25 @@
+import CustomDump
+import Foundation
+import Sargon
+import SargonUniFFI
+import XCTest
+
+final class WalletToDappInteractionAuthProofTests: TestCase {
+	typealias SUT = WalletToDappInteractionAuthProof
+
+	func testNewFromIntentSignatures_Ed25519() throws {
+		let intentSignature = IntentSignature.sample // Ed25519
+		let sut = SUT(intentSignatureOfOwner: .init(owner: .sample, intentSignature: intentSignature))
+		XCTAssertEqual(sut.curve, .curve25519)
+		XCTAssertEqual(sut.publicKey, intentSignature.signatureWithPublicKey.publicKey)
+		XCTAssertEqual(sut.signature, intentSignature.signatureWithPublicKey.signature)
+	}
+
+	func testNewFromIntentSignatures_Secp256k1() throws {
+		let intentSignature = IntentSignature.sampleOther // Secp256k1
+		let sut = SUT(intentSignatureOfOwner: .init(owner: .sample, intentSignature: intentSignature))
+		XCTAssertEqual(sut.curve, .secp256k1)
+		XCTAssertEqual(sut.publicKey, intentSignature.signatureWithPublicKey.publicKey)
+		XCTAssertEqual(sut.signature, intentSignature.signatureWithPublicKey.signature)
+	}
+}

--- a/crates/app/home-cards/Cargo.toml
+++ b/crates/app/home-cards/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "home-cards"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/key-derivation-traits/Cargo.toml
+++ b/crates/app/key-derivation-traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "key-derivation-traits"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/radix-connect-models/Cargo.toml
+++ b/crates/app/radix-connect-models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "radix-connect-models"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/radix-connect/Cargo.toml
+++ b/crates/app/radix-connect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "radix-connect"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 

--- a/crates/app/radix-connect/src/wallet_interaction/dapp_wallet_interaction/wallet_to_dapp/success_response/auth/auth_proof.rs
+++ b/crates/app/radix-connect/src/wallet_interaction/dapp_wallet_interaction/wallet_to_dapp/success_response/auth/auth_proof.rs
@@ -28,6 +28,15 @@ impl WalletToDappInteractionAuthProof {
     }
 }
 
+impl From<SignatureWithPublicKey> for WalletToDappInteractionAuthProof {
+    fn from(signature_with_public_key: SignatureWithPublicKey) -> Self {
+        Self::new(
+            signature_with_public_key.public_key(),
+            signature_with_public_key.signature(),
+        )
+    }
+}
+
 impl HasSampleValues for WalletToDappInteractionAuthProof {
     fn sample() -> Self {
         Self::new(PublicKey::sample(), Signature::sample())
@@ -60,5 +69,20 @@ mod tests {
     #[should_panic]
     fn panics_if_curve_discrepancy() {
         let _ = SUT::new(PublicKey::sample(), Signature::sample_other());
+    }
+
+    #[test]
+    fn from_signature_with_public_key() {
+        // Ed25519
+        let signature_with_public_key = SignatureWithPublicKey::sample();
+        let sut = SUT::from(signature_with_public_key);
+        assert_eq!(sut.public_key, signature_with_public_key.public_key());
+        assert_eq!(sut.signature, signature_with_public_key.signature());
+
+        // Secp256k1
+        let signature_with_public_key = SignatureWithPublicKey::sample_other();
+        let sut = SUT::from(signature_with_public_key);
+        assert_eq!(sut.public_key, signature_with_public_key.public_key());
+        assert_eq!(sut.signature, signature_with_public_key.signature());
     }
 }

--- a/crates/app/security-center/Cargo.toml
+++ b/crates/app/security-center/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "security-center"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/signing-traits/Cargo.toml
+++ b/crates/app/signing-traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signing-traits"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/build-info/Cargo.toml
+++ b/crates/common/build-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "build-info"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/common/bytes/Cargo.toml
+++ b/crates/common/bytes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bytes"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/entity-foundation/Cargo.toml
+++ b/crates/common/entity-foundation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entity-foundation"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/host-info/Cargo.toml
+++ b/crates/common/host-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "host-info"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/identified-vec-of/Cargo.toml
+++ b/crates/common/identified-vec-of/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "identified-vec-of"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/metadata/Cargo.toml
+++ b/crates/common/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metadata"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/network/Cargo.toml
+++ b/crates/common/network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "network"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/numeric/Cargo.toml
+++ b/crates/common/numeric/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numeric"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/short-string/Cargo.toml
+++ b/crates/common/short-string/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "short-string"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/assert-json/Cargo.toml
+++ b/crates/core/assert-json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assert-json"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/collections/Cargo.toml
+++ b/crates/core/collections/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-collections"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/error/Cargo.toml
+++ b/crates/core/error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "error"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/has-sample-values/Cargo.toml
+++ b/crates/core/has-sample-values/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "has-sample-values"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/misc/Cargo.toml
+++ b/crates/core/misc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-misc"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/prelude/Cargo.toml
+++ b/crates/core/prelude/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prelude"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/time-utils/Cargo.toml
+++ b/crates/core/time-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "time-utils"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/utils/Cargo.toml
+++ b/crates/core/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-utils"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/addresses/Cargo.toml
+++ b/crates/crypto/addresses/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "addresses"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/cap26-models/Cargo.toml
+++ b/crates/crypto/cap26-models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cap26-models"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/ecc/Cargo.toml
+++ b/crates/crypto/ecc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecc"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/encryption/Cargo.toml
+++ b/crates/crypto/encryption/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "encryption"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/hash/Cargo.toml
+++ b/crates/crypto/hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hash"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/hd/Cargo.toml
+++ b/crates/crypto/hd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hierarchical-deterministic"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/factors/Cargo.toml
+++ b/crates/factors/factors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factors"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/instances-provider/Cargo.toml
+++ b/crates/factors/instances-provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factor-instances-provider"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/keys-collector/Cargo.toml
+++ b/crates/factors/keys-collector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keys-collector"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/next-derivation-index-ephemeral/Cargo.toml
+++ b/crates/factors/next-derivation-index-ephemeral/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "next-derivation-index-ephemeral"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/signatures-collector/Cargo.toml
+++ b/crates/factors/signatures-collector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signatures-collector"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 

--- a/crates/factors/supporting-types/Cargo.toml
+++ b/crates/factors/supporting-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factors-supporting-types"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/gateway/client-and-api/Cargo.toml
+++ b/crates/gateway/client-and-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gateway-client-and-api"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/gateway/models/Cargo.toml
+++ b/crates/gateway/models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gateway-models"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 

--- a/crates/profile/logic/logic_SPLIT_ME/Cargo.toml
+++ b/crates/profile/logic/logic_SPLIT_ME/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-logic"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/account-for-display/Cargo.toml
+++ b/crates/profile/models/account-for-display/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "account-for-display"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/account-or-persona/Cargo.toml
+++ b/crates/profile/models/account-or-persona/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-account-or-persona"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/account/Cargo.toml
+++ b/crates/profile/models/account/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-account"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/app-preferences/Cargo.toml
+++ b/crates/profile/models/app-preferences/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-app-preferences"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/base-entity/Cargo.toml
+++ b/crates/profile/models/base-entity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-base-entity"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/gateway/Cargo.toml
+++ b/crates/profile/models/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-gateway"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/persona-data/Cargo.toml
+++ b/crates/profile/models/persona-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-persona-data"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/persona/Cargo.toml
+++ b/crates/profile/models/persona/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-persona"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/profile_SPLIT_ME/Cargo.toml
+++ b/crates/profile/models/profile_SPLIT_ME/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 

--- a/crates/profile/models/security-structures/Cargo.toml
+++ b/crates/profile/models/security-structures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-security-structures"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/supporting-types/Cargo.toml
+++ b/crates/profile/models/supporting-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-supporting-types"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/traits/entity-by-address/Cargo.toml
+++ b/crates/profile/traits/entity-by-address/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entity-by-address"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/sargon/Cargo.toml
+++ b/crates/sargon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 resolver = "2" # features enabled in integration test

--- a/crates/system/clients/clients/Cargo.toml
+++ b/crates/system/clients/clients/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clients"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 

--- a/crates/system/clients/http/Cargo.toml
+++ b/crates/system/clients/http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http-client"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/drivers/Cargo.toml
+++ b/crates/system/drivers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drivers"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 

--- a/crates/system/interactors/Cargo.toml
+++ b/crates/system/interactors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interactors"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/accounts/Cargo.toml
+++ b/crates/system/os/accounts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-accounts"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/derive-public-keys/Cargo.toml
+++ b/crates/system/os/derive-public-keys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-derive-public-keys"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/factors/Cargo.toml
+++ b/crates/system/os/factors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-factors"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/os/Cargo.toml
+++ b/crates/system/os/os/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/security-center/Cargo.toml
+++ b/crates/system/os/security-center/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-security-center"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/signing/Cargo.toml
+++ b/crates/system/os/signing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-signing"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/transaction/Cargo.toml
+++ b/crates/system/os/transaction/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-transaction"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/profile-state-holder/Cargo.toml
+++ b/crates/system/profile-state-holder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-state-holder"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/sub-systems/Cargo.toml
+++ b/crates/system/sub-systems/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sub-systems"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/transaction/foundation/Cargo.toml
+++ b/crates/transaction/foundation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transaction-foundation"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/transaction/manifests/Cargo.toml
+++ b/crates/transaction/manifests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "manifests"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 

--- a/crates/transaction/models/Cargo.toml
+++ b/crates/transaction/models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transaction-models"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 

--- a/crates/uniffi/conversion-macros/Cargo.toml
+++ b/crates/uniffi/conversion-macros/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "sargon-uniffi-conversion-macros"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 
 [dependencies]

--- a/crates/uniffi/uniffi_SPLIT_ME/Cargo.toml
+++ b/crates/uniffi/uniffi_SPLIT_ME/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-uniffi"
-version = "1.1.121"
+version = "1.1.122"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/uniffi/uniffi_SPLIT_ME/src/radix_connect/wallet_interaction/dapp_wallet_interaction/wallet_to_dapp/success_response/auth/auth_proof.rs
+++ b/crates/uniffi/uniffi_SPLIT_ME/src/radix_connect/wallet_interaction/dapp_wallet_interaction/wallet_to_dapp/success_response/auth/auth_proof.rs
@@ -7,3 +7,16 @@ pub struct WalletToDappInteractionAuthProof {
     pub curve: SLIP10Curve,
     pub signature: Signature,
 }
+
+#[uniffi::export]
+pub fn new_wallet_to_dapp_interaction_auth_proof_from_intent_signature_of_owner(
+    intent_signature_of_owner: IntentSignatureOfOwner,
+) -> WalletToDappInteractionAuthProof {
+    InternalWalletToDappInteractionAuthProof::from(
+        intent_signature_of_owner
+            .intent_signature
+            .value
+            .into_internal(),
+    )
+    .into()
+}

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/WalletToDappInteractionAuthProof.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/WalletToDappInteractionAuthProof.kt
@@ -1,0 +1,8 @@
+package com.radixdlt.sargon.extensions
+
+import com.radixdlt.sargon.WalletToDappInteractionAuthProof
+import com.radixdlt.sargon.newWalletToDappInteractionAuthProofFromIntentSignatureOfOwner
+import com.radixdlt.sargon.IntentSignatureOfOwner
+
+fun WalletToDappInteractionAuthProof.Companion.init(intentSignatureOfOwner: IntentSignatureOfOwner) =
+    newWalletToDappInteractionAuthProofFromIntentSignatureOfOwner(intentSignatureOfOwner = intentSignatureOfOwner)

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/WalletToDappInteractionAuthProof.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/WalletToDappInteractionAuthProof.kt
@@ -1,0 +1,33 @@
+package com.radixdlt.sargon
+
+import com.radixdlt.sargon.extensions.init
+import com.radixdlt.sargon.extensions.publicKey
+import com.radixdlt.sargon.extensions.signature
+import com.radixdlt.sargon.extensions.signatureWithPublicKey
+import com.radixdlt.sargon.samples.sample
+import com.radixdlt.sargon.samples.sampleStokenet
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class WalletToDappInteractionAuthProofTest {
+
+    @Test
+    fun testNewFromIntentSignatures_Ed25519() {
+        val intentSignature = IntentSignature.sample.invoke() // Ed25519
+        val intentSignatureOfOwner = IntentSignatureOfOwner(owner = AddressOfAccountOrPersona.sampleStokenet.invoke(), intentSignature = intentSignature )
+        val sut = WalletToDappInteractionAuthProof.init(intentSignatureOfOwner = intentSignatureOfOwner)
+        assertEquals(sut.curve, Slip10Curve.CURVE25519)
+        assertEquals(sut.publicKey, intentSignature.signatureWithPublicKey.publicKey)
+        assertEquals(sut.signature, intentSignature.signatureWithPublicKey.signature)
+    }
+
+    @Test
+    fun testNewFromIntentSignatures_Secp256k1() {
+        val intentSignature = IntentSignature.sample.other() // Secp256k1
+        val intentSignatureOfOwner = IntentSignatureOfOwner(owner = AddressOfAccountOrPersona.sampleStokenet.invoke(), intentSignature = intentSignature )
+        val sut = WalletToDappInteractionAuthProof.init(intentSignatureOfOwner = intentSignatureOfOwner)
+        assertEquals(sut.curve, Slip10Curve.SECP256K1)
+        assertEquals(sut.publicKey, intentSignature.signatureWithPublicKey.publicKey)
+        assertEquals(sut.signature, intentSignature.signatureWithPublicKey.signature)
+    }
+}


### PR DESCRIPTION
## Changelog
Move to Sargon the creation of `WalletToDappInteractionAuthProof` (used when signing auth) so that it isn't Hosts responsibility to decide which `curve` to use.