### PR TITLE
[ABW-4051] API to perform Spot Check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "account-for-display"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "addresses",
  "derive_more",
@@ -49,10 +49,10 @@ dependencies = [
 
 [[package]]
 name = "addresses"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "assert-json",
- "bytes 1.1.133",
+ "bytes 1.1.134",
  "cap26-models",
  "core-utils",
  "derive_more",
@@ -246,7 +246,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "assert-json"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "assert-json-diff",
  "error",
@@ -546,7 +546,7 @@ dependencies = [
 
 [[package]]
 name = "build-info"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "assert-json",
  "cargo_toml",
@@ -573,7 +573,7 @@ checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
 
 [[package]]
 name = "bytes"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "assert-json",
  "delegate",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "cap26-models"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "assert-json",
  "derive_more",
@@ -748,7 +748,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "clients"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -808,7 +808,7 @@ checksum = "0d8a42181e0652c2997ae4d217f25b63c5337a52fd2279736e97b832fa0a3cff"
 
 [[package]]
 name = "core-collections"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "has-sample-values",
  "indexmap 2.7.0",
@@ -835,7 +835,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-misc"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "assert-json",
  "core-utils",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "core-utils"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "error",
  "iso8601-timestamp",
@@ -1084,7 +1084,7 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "drivers"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -1108,10 +1108,10 @@ dependencies = [
 
 [[package]]
 name = "ecc"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "assert-json",
- "bytes 1.1.133",
+ "bytes 1.1.134",
  "derive_more",
  "enum-as-inner",
  "error",
@@ -1210,11 +1210,11 @@ dependencies = [
 
 [[package]]
 name = "encryption"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "aes-gcm",
  "assert-json",
- "bytes 1.1.133",
+ "bytes 1.1.134",
  "derive_more",
  "error",
  "has-sample-values",
@@ -1231,7 +1231,7 @@ dependencies = [
 
 [[package]]
 name = "entity-by-address"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "addresses",
  "error",
@@ -1243,7 +1243,7 @@ dependencies = [
 
 [[package]]
 name = "entity-foundation"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "assert-json",
  "derive_more",
@@ -1318,7 +1318,7 @@ dependencies = [
 
 [[package]]
 name = "error"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "derive_more",
  "log",
@@ -1377,7 +1377,7 @@ dependencies = [
 
 [[package]]
 name = "factor-instances-provider"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -1403,9 +1403,9 @@ dependencies = [
 
 [[package]]
 name = "factors"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
- "bytes 1.1.133",
+ "bytes 1.1.134",
  "cap26-models",
  "core-collections",
  "core-misc",
@@ -1440,7 +1440,7 @@ dependencies = [
 
 [[package]]
 name = "factors-supporting-types"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "async-trait",
  "error",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-client-and-api"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -1613,7 +1613,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-models"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "addresses",
  "assert-json",
@@ -1718,7 +1718,7 @@ dependencies = [
 
 [[package]]
 name = "has-sample-values"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "error",
  "indexmap 2.7.0",
@@ -1729,9 +1729,9 @@ dependencies = [
 
 [[package]]
 name = "hash"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
- "bytes 1.1.133",
+ "bytes 1.1.134",
  "derive_more",
  "prelude",
  "radix-common",
@@ -1795,11 +1795,11 @@ dependencies = [
 
 [[package]]
 name = "hierarchical-deterministic"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "assert-json",
  "bip39",
- "bytes 1.1.133",
+ "bytes 1.1.134",
  "cap26-models",
  "derive_more",
  "ecc",
@@ -1842,13 +1842,13 @@ dependencies = [
 
 [[package]]
 name = "home-cards"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "actix-rt",
  "addresses",
  "async-trait",
  "base64",
- "bytes 1.1.133",
+ "bytes 1.1.134",
  "core-utils",
  "derive_more",
  "drivers",
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "host-info"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "assert-json",
  "derive_more",
@@ -1915,10 +1915,10 @@ dependencies = [
 
 [[package]]
 name = "http-client"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "actix-rt",
- "bytes 1.1.133",
+ "bytes 1.1.134",
  "core-utils",
  "drivers",
  "error",
@@ -2143,7 +2143,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "identified-vec-of"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "assert-json",
  "derive_more",
@@ -2216,7 +2216,7 @@ dependencies = [
 
 [[package]]
 name = "interactors"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -2336,7 +2336,7 @@ dependencies = [
 
 [[package]]
 name = "key-derivation-traits"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "addresses",
  "async-trait",
@@ -2354,7 +2354,7 @@ dependencies = [
 
 [[package]]
 name = "keys-collector"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -2443,7 +2443,7 @@ dependencies = [
 
 [[package]]
 name = "manifests"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "account-for-display",
  "addresses",
@@ -2485,7 +2485,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "metadata"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "derive_more",
  "has-sample-values",
@@ -2585,7 +2585,7 @@ dependencies = [
 
 [[package]]
 name = "network"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "assert-json",
  "enum-iterator",
@@ -2601,7 +2601,7 @@ dependencies = [
 
 [[package]]
 name = "next-derivation-index-ephemeral"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "addresses",
  "assert-json",
@@ -2677,9 +2677,9 @@ dependencies = [
 
 [[package]]
 name = "numeric"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
- "bytes 1.1.133",
+ "bytes 1.1.134",
  "delegate",
  "derive_more",
  "enum-iterator",
@@ -2899,7 +2899,7 @@ dependencies = [
 
 [[package]]
 name = "prelude"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "radix-engine",
  "radix-engine-toolkit",
@@ -2936,7 +2936,7 @@ dependencies = [
 
 [[package]]
 name = "profile"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "account-for-display",
  "addresses",
@@ -2980,7 +2980,7 @@ dependencies = [
 
 [[package]]
 name = "profile-account"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "account-for-display",
  "addresses",
@@ -3000,7 +3000,7 @@ dependencies = [
 
 [[package]]
 name = "profile-account-or-persona"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "cap26-models",
  "derive_more",
@@ -3017,7 +3017,7 @@ dependencies = [
 
 [[package]]
 name = "profile-app-preferences"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "addresses",
  "core-misc",
@@ -3040,7 +3040,7 @@ dependencies = [
 
 [[package]]
 name = "profile-base-entity"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "addresses",
  "derive_more",
@@ -3063,7 +3063,7 @@ dependencies = [
 
 [[package]]
 name = "profile-gateway"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "addresses",
  "assert-json",
@@ -3087,7 +3087,7 @@ dependencies = [
 
 [[package]]
 name = "profile-logic"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "addresses",
  "derive_more",
@@ -3109,7 +3109,7 @@ dependencies = [
 
 [[package]]
 name = "profile-persona"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "addresses",
  "cap26-models",
@@ -3130,7 +3130,7 @@ dependencies = [
 
 [[package]]
 name = "profile-persona-data"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "addresses",
  "assert-json",
@@ -3149,7 +3149,7 @@ dependencies = [
 
 [[package]]
 name = "profile-security-structures"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "addresses",
  "cap26-models",
@@ -3177,7 +3177,7 @@ dependencies = [
 
 [[package]]
 name = "profile-state-holder"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "derive_more",
  "error",
@@ -3192,7 +3192,7 @@ dependencies = [
 
 [[package]]
 name = "profile-supporting-types"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "addresses",
  "derive_more",
@@ -3281,14 +3281,14 @@ dependencies = [
 
 [[package]]
 name = "radix-connect"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "actix-rt",
  "addresses",
  "assert-json",
  "async-trait",
  "base64",
- "bytes 1.1.133",
+ "bytes 1.1.134",
  "core-misc",
  "core-utils",
  "derive_more",
@@ -3317,10 +3317,10 @@ dependencies = [
 
 [[package]]
 name = "radix-connect-models"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "addresses",
- "bytes 1.1.133",
+ "bytes 1.1.134",
  "core-misc",
  "derive_more",
  "error",
@@ -3762,7 +3762,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -3827,7 +3827,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -3854,7 +3854,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-accounts"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -3877,7 +3877,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-derive-public-keys"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -3896,7 +3896,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-factors"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -3924,7 +3924,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-security-center"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "actix-rt",
  "derive_more",
@@ -3940,7 +3940,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-signing"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -3966,7 +3966,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-transaction"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "actix-rt",
  "async-std",
@@ -3995,7 +3995,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-uniffi"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -4052,7 +4052,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-uniffi-conversion-macros"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4225,7 +4225,7 @@ dependencies = [
 
 [[package]]
 name = "security-center"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "addresses",
  "assert-json",
@@ -4393,7 +4393,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "short-string"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "arraystring",
  "assert-json",
@@ -4428,13 +4428,13 @@ dependencies = [
 
 [[package]]
 name = "signatures-collector"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "actix-rt",
  "addresses",
  "assert-json",
  "async-trait",
- "bytes 1.1.133",
+ "bytes 1.1.134",
  "cap26-models",
  "core-collections",
  "core-misc",
@@ -4466,10 +4466,10 @@ dependencies = [
 
 [[package]]
 name = "signing-traits"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "async-trait",
- "bytes 1.1.133",
+ "bytes 1.1.134",
  "core-collections",
  "derive_more",
  "ecc",
@@ -4634,7 +4634,7 @@ dependencies = [
 
 [[package]]
 name = "sub-systems"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "derive_more",
  "drivers",
@@ -4793,7 +4793,7 @@ dependencies = [
 
 [[package]]
 name = "time-utils"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "iso8601-timestamp",
  "prelude",
@@ -4943,10 +4943,10 @@ dependencies = [
 
 [[package]]
 name = "transaction-foundation"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "assert-json",
- "bytes 1.1.133",
+ "bytes 1.1.134",
  "derive_more",
  "has-sample-values",
  "paste",
@@ -4958,10 +4958,10 @@ dependencies = [
 
 [[package]]
 name = "transaction-models"
-version = "1.1.133"
+version = "1.1.134"
 dependencies = [
  "addresses",
- "bytes 1.1.133",
+ "bytes 1.1.134",
  "cargo_toml",
  "core-collections",
  "core-misc",

--- a/apple/Sources/Sargon/Extensions/Methods/Crypto/Derivation/MnemonicWithPassphrase+Wrap+Functions.swift
+++ b/apple/Sources/Sargon/Extensions/Methods/Crypto/Derivation/MnemonicWithPassphrase+Wrap+Functions.swift
@@ -2,6 +2,10 @@ import Foundation
 import SargonUniFFI
 
 extension MnemonicWithPassphrase {
+	public init(mnemonic: Mnemonic) {
+		self.init(mnemonic: mnemonic, passphrase: "")
+	}
+
 	public init(jsonData: some DataProtocol) throws {
 		self = try newMnemonicWithPassphraseFromJsonBytes(
 			jsonBytes: Data(jsonData)

--- a/apple/Sources/Sargon/Extensions/Methods/Profile/Factor/FactorSource+Wrap+Functions.swift
+++ b/apple/Sources/Sargon/Extensions/Methods/Profile/Factor/FactorSource+Wrap+Functions.swift
@@ -17,4 +17,8 @@ extension FactorSource {
 	public var name: String {
 		factorSourceName(factorSource: self)
 	}
+
+	public func spotCheck(input: SpotCheckInput) -> Bool {
+		factorSourcePerformSpotCheck(factorSource: self, input: input)
+	}
 }

--- a/apple/Sources/Sargon/Extensions/Methods/Profile/Factor/FactorSourceID+Wrap+Functions.swift
+++ b/apple/Sources/Sargon/Extensions/Methods/Profile/Factor/FactorSourceID+Wrap+Functions.swift
@@ -5,4 +5,11 @@ extension FactorSourceID {
 	public func toString() -> String {
 		factorSourceIdToString(factorSourceId: self)
 	}
+
+	public var kind: FactorSourceKind {
+		switch self {
+		case let .hash(value):
+			value.kind
+		}
+	}
 }

--- a/apple/Sources/Sargon/Extensions/Methods/Profile/Factor/FactorSourceID+Wrap+Functions.swift
+++ b/apple/Sources/Sargon/Extensions/Methods/Profile/Factor/FactorSourceID+Wrap+Functions.swift
@@ -12,4 +12,8 @@ extension FactorSourceID {
 			value.kind
 		}
 	}
+
+	public func spotCheck(input: SpotCheckInput) -> Bool {
+		factorSourceIdPerformSpotCheck(factorSourceId: self, input: input)
+	}
 }

--- a/apple/Sources/Sargon/Extensions/Methods/Profile/Factor/FactorSourceIDFromHash+Wrap+Functions.swift
+++ b/apple/Sources/Sargon/Extensions/Methods/Profile/Factor/FactorSourceIDFromHash+Wrap+Functions.swift
@@ -20,4 +20,8 @@ extension FactorSourceIDFromHash {
 	public func toString() -> String {
 		factorSourceIdFromHashToString(factorSourceId: self)
 	}
+
+	public func spotCheck(input: SpotCheckInput) -> Bool {
+		factorSourceIdFromHashPerformSpotCheck(factorSourceIdFromHash: self, input: input)
+	}
 }

--- a/apple/Sources/Sargon/SargonOS/ThrowingHostInteractor+Static+Shared.swift
+++ b/apple/Sources/Sargon/SargonOS/ThrowingHostInteractor+Static+Shared.swift
@@ -22,7 +22,7 @@ public class ThrowingHostInteractor: HostInteractor {
 		.rejected
 	}
 
-	public func spotCheck(factorSource: FactorSource) async throws -> SpotCheckResponse {
+	public func spotCheck(factorSource: FactorSource, allowSkip: Bool) async throws -> SpotCheckResponse {
 		throw CommonError.HostInteractionAborted
 	}
 }

--- a/apple/Sources/Sargon/SargonOS/ThrowingHostInteractor+Static+Shared.swift
+++ b/apple/Sources/Sargon/SargonOS/ThrowingHostInteractor+Static+Shared.swift
@@ -21,4 +21,8 @@ public class ThrowingHostInteractor: HostInteractor {
 	public func requestAuthorization(purpose: SargonUniFFI.AuthorizationPurpose) async -> SargonUniFFI.AuthorizationResponse {
 		.rejected
 	}
+
+	public func spotCheck(factorSourceId: FactorSourceIdFromHash) async throws -> SpotCheckResponse {
+		throw CommonError.HostInteractionAborted
+	}
 }

--- a/apple/Sources/Sargon/SargonOS/ThrowingHostInteractor+Static+Shared.swift
+++ b/apple/Sources/Sargon/SargonOS/ThrowingHostInteractor+Static+Shared.swift
@@ -22,7 +22,7 @@ public class ThrowingHostInteractor: HostInteractor {
 		.rejected
 	}
 
-	public func spotCheck(factorSourceId: FactorSourceIdFromHash) async throws -> SpotCheckResponse {
+	public func spotCheck(factorSource: FactorSource) async throws -> SpotCheckResponse {
 		throw CommonError.HostInteractionAborted
 	}
 }

--- a/apple/Tests/TestCases/Crypto/BIP39/MnemonicWithPassphraseTests.swift
+++ b/apple/Tests/TestCases/Crypto/BIP39/MnemonicWithPassphraseTests.swift
@@ -55,9 +55,9 @@ final class MnemonicWithPassphraseTests: Test<MnemonicWithPassphrase> {
 	func testJSONRoundtripAllSamples() throws {
 		try eachSampleCodableRoundtripTest()
 	}
-	
+
 	func testInitWithoutPaspshrase() {
-		let sut = SUT.init(mnemonic: .sample)
+		let sut = SUT(mnemonic: .sample)
 		XCTAssertEqual(sut.passphrase, "")
 	}
 }

--- a/apple/Tests/TestCases/Crypto/BIP39/MnemonicWithPassphraseTests.swift
+++ b/apple/Tests/TestCases/Crypto/BIP39/MnemonicWithPassphraseTests.swift
@@ -55,4 +55,9 @@ final class MnemonicWithPassphraseTests: Test<MnemonicWithPassphrase> {
 	func testJSONRoundtripAllSamples() throws {
 		try eachSampleCodableRoundtripTest()
 	}
+	
+	func testInitWithoutPaspshrase() {
+		let sut = SUT.init(mnemonic: .sample)
+		XCTAssertEqual(sut.passphrase, "")
+	}
 }

--- a/apple/Tests/TestCases/Profile/Factor/FactorSourceIDFromHashTests.swift
+++ b/apple/Tests/TestCases/Profile/Factor/FactorSourceIDFromHashTests.swift
@@ -26,6 +26,5 @@ final class FactorSourceIDFromHashTests: SpecificFactorSourceIDTest<FactorSource
 	func test_spot_check() {
 		let input = SpotCheckInput.software(mnemonicWithPassphrase: .sample)
 		XCTAssertTrue(SUT.sample.spotCheck(input: input))
-		XCTAssertFalse(SUT.sampleOther.spotCheck(input: input))
 	}
 }

--- a/apple/Tests/TestCases/Profile/Factor/FactorSourceIDFromHashTests.swift
+++ b/apple/Tests/TestCases/Profile/Factor/FactorSourceIDFromHashTests.swift
@@ -22,4 +22,10 @@ final class FactorSourceIDFromHashTests: SpecificFactorSourceIDTest<FactorSource
 //			XCTAssertThrowsError(try sut.asGeneral.extract(as: FactorSourceIDFromAddress.self))
 //		}
 //	}
+
+	func test_spot_check() {
+		let input = SpotCheckInput.software(mnemonicWithPassphrase: .sample)
+		XCTAssertTrue(SUT.sample.spotCheck(input: input))
+		XCTAssertFalse(SUT.sampleOther.spotCheck(input: input))
+	}
 }

--- a/apple/Tests/TestCases/Profile/Factor/FactorSourceIDTests.swift
+++ b/apple/Tests/TestCases/Profile/Factor/FactorSourceIDTests.swift
@@ -14,6 +14,5 @@ final class FactorSourceIDTests: FactorSourceIDTest<FactorSourceID> {
 	func test_spot_check() {
 		let input = SpotCheckInput.software(mnemonicWithPassphrase: .sample)
 		XCTAssertTrue(SUT.sample.spotCheck(input: input))
-		XCTAssertFalse(SUT.sampleOther.spotCheck(input: input))
 	}
 }

--- a/apple/Tests/TestCases/Profile/Factor/FactorSourceIDTests.swift
+++ b/apple/Tests/TestCases/Profile/Factor/FactorSourceIDTests.swift
@@ -10,4 +10,10 @@ final class FactorSourceIDTests: FactorSourceIDTest<FactorSourceID> {
 			XCTAssertEqual(sut.asGeneral, sut)
 		}
 	}
+
+	func test_spot_check() {
+		let input = SpotCheckInput.software(mnemonicWithPassphrase: .sample)
+		XCTAssertTrue(SUT.sample.spotCheck(input: input))
+		XCTAssertFalse(SUT.sampleOther.spotCheck(input: input))
+	}
 }

--- a/apple/Tests/TestCases/Profile/Factor/FactorSourceTests.swift
+++ b/apple/Tests/TestCases/Profile/Factor/FactorSourceTests.swift
@@ -29,4 +29,10 @@ final class FactorSourceTests: FactorSourceTest<FactorSource> {
 	func test_name() {
 		XCTAssertEqual(SUT.sample.name, "My Phone")
 	}
+
+	func test_spot_check() {
+		let input = SpotCheckInput.software(mnemonicWithPassphrase: .sample)
+		XCTAssertTrue(SUT.sample.spotCheck(input: input))
+		XCTAssertFalse(SUT.sampleOther.spotCheck(input: input))
+	}
 }

--- a/apple/Tests/TestCases/Profile/Factor/FactorSourceTests.swift
+++ b/apple/Tests/TestCases/Profile/Factor/FactorSourceTests.swift
@@ -33,6 +33,5 @@ final class FactorSourceTests: FactorSourceTest<FactorSource> {
 	func test_spot_check() {
 		let input = SpotCheckInput.software(mnemonicWithPassphrase: .sample)
 		XCTAssertTrue(SUT.sample.spotCheck(input: input))
-		XCTAssertFalse(SUT.sampleOther.spotCheck(input: input))
 	}
 }

--- a/crates/app/home-cards/Cargo.toml
+++ b/crates/app/home-cards/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "home-cards"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/key-derivation-traits/Cargo.toml
+++ b/crates/app/key-derivation-traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "key-derivation-traits"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/radix-connect-models/Cargo.toml
+++ b/crates/app/radix-connect-models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "radix-connect-models"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/radix-connect/Cargo.toml
+++ b/crates/app/radix-connect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "radix-connect"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 

--- a/crates/app/security-center/Cargo.toml
+++ b/crates/app/security-center/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "security-center"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/signing-traits/Cargo.toml
+++ b/crates/app/signing-traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signing-traits"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/build-info/Cargo.toml
+++ b/crates/common/build-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "build-info"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/common/bytes/Cargo.toml
+++ b/crates/common/bytes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bytes"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/entity-foundation/Cargo.toml
+++ b/crates/common/entity-foundation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entity-foundation"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/host-info/Cargo.toml
+++ b/crates/common/host-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "host-info"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/identified-vec-of/Cargo.toml
+++ b/crates/common/identified-vec-of/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "identified-vec-of"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/metadata/Cargo.toml
+++ b/crates/common/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metadata"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/network/Cargo.toml
+++ b/crates/common/network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "network"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/numeric/Cargo.toml
+++ b/crates/common/numeric/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numeric"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/short-string/Cargo.toml
+++ b/crates/common/short-string/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "short-string"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/assert-json/Cargo.toml
+++ b/crates/core/assert-json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assert-json"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/collections/Cargo.toml
+++ b/crates/core/collections/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-collections"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/error/Cargo.toml
+++ b/crates/core/error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "error"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/has-sample-values/Cargo.toml
+++ b/crates/core/has-sample-values/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "has-sample-values"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/misc/Cargo.toml
+++ b/crates/core/misc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-misc"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/prelude/Cargo.toml
+++ b/crates/core/prelude/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prelude"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/time-utils/Cargo.toml
+++ b/crates/core/time-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "time-utils"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/utils/Cargo.toml
+++ b/crates/core/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-utils"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/addresses/Cargo.toml
+++ b/crates/crypto/addresses/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "addresses"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/cap26-models/Cargo.toml
+++ b/crates/crypto/cap26-models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cap26-models"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/ecc/Cargo.toml
+++ b/crates/crypto/ecc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecc"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/encryption/Cargo.toml
+++ b/crates/crypto/encryption/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "encryption"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/hash/Cargo.toml
+++ b/crates/crypto/hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hash"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/hd/Cargo.toml
+++ b/crates/crypto/hd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hierarchical-deterministic"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/factors/Cargo.toml
+++ b/crates/factors/factors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factors"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/factors/src/factor_source_id_spot_check.rs
+++ b/crates/factors/factors/src/factor_source_id_spot_check.rs
@@ -1,0 +1,227 @@
+use crate::prelude::*;
+
+/// An enum with the input to perform a spot check for a given `FactorSourceID`.
+/// This is, to validate that the `FactorSourceID` was created with the same input that has been provided.
+#[derive(Clone, Debug, PartialEq, Eq, std::hash::Hash)]
+pub enum SpotCheckInput {
+    /// The user retrieved the id of a Ledger device.
+    /// Used for the identification of `LedgerHardwareWalletFactorSource`.
+    Ledger { id: Exactly32Bytes },
+
+    /// The user retrieved the `FactorSourceIdFromHash` that identified an Arculus card.
+    /// /// Used for the identification of `ArculusCardFactorSource`.
+    ArculusCard { id: FactorSourceIDFromHash },
+
+    /// The user retrieved a `MnemonicWithPassphrase`.
+    /// Used for the identification of any software `FactorSource`.
+    Software {
+        mnemonic_with_passphrase: MnemonicWithPassphrase,
+    },
+}
+
+pub trait FactorSourceIDSpotCheck {
+    /// Performs a spot check and returns whether the `FactorSourceID` was created with the same input that has been provided.
+    fn perform_spot_check(&self, input: SpotCheckInput) -> bool;
+}
+
+impl FactorSourceIDSpotCheck for FactorSourceID {
+    fn perform_spot_check(&self, input: SpotCheckInput) -> bool {
+        let Some(id_from_hash) = self.as_hash().cloned() else {
+            panic!("Address FactorSourceID not supported for spot check")
+        };
+        let kind = id_from_hash.kind;
+        match input {
+            SpotCheckInput::Ledger { id } => {
+                if kind != FactorSourceKind::LedgerHQHardwareWallet {
+                    return false;
+                }
+                let built_id = FactorSourceIDFromHash::new(kind, id);
+                built_id == id_from_hash
+            }
+            SpotCheckInput::ArculusCard { id } => {
+                if kind != FactorSourceKind::ArculusCard {
+                    return false;
+                }
+                id == id_from_hash
+            }
+            SpotCheckInput::Software {
+                mnemonic_with_passphrase,
+            } => {
+                if !kind.is_software() {
+                    return false;
+                }
+                let built_id =
+                    FactorSourceIDFromHash::from_mnemonic_with_passphrase(
+                        kind,
+                        &mnemonic_with_passphrase,
+                    );
+                built_id == id_from_hash
+            }
+        }
+    }
+}
+
+impl FactorSourceIDSpotCheck for FactorSource {
+    fn perform_spot_check(&self, input: SpotCheckInput) -> bool {
+        self.id().perform_spot_check(input)
+    }
+}
+
+impl FactorSourceIDSpotCheck for FactorSourceIDFromHash {
+    fn perform_spot_check(&self, input: SpotCheckInput) -> bool {
+        FactorSourceID::from(*self).perform_spot_check(input)
+    }
+}
+
+impl FactorSourceKind {
+    fn is_software(&self) -> bool {
+        match self {
+            FactorSourceKind::Device
+            | FactorSourceKind::OffDeviceMnemonic
+            | FactorSourceKind::Password
+            | FactorSourceKind::SecurityQuestions => true,
+            FactorSourceKind::LedgerHQHardwareWallet
+            | FactorSourceKind::ArculusCard
+            | FactorSourceKind::TrustedContact => false,
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(non_snake_case)]
+mod tests {
+    use super::*;
+
+    #[allow(clippy::upper_case_acronyms)]
+    type SUT = FactorSourceID;
+
+    #[test]
+    fn spot_check__device__mvp_matches() {
+        let sut = SUT::sample_device();
+        let input = SpotCheckInput::Software {
+            mnemonic_with_passphrase: MnemonicWithPassphrase::sample_device(), // same mvp
+        };
+        let result = sut.perform_spot_check(input);
+        assert!(result);
+    }
+
+    #[test]
+    fn spot_check__device__mvp_does_not_match() {
+        let sut = SUT::sample_device();
+        let input = SpotCheckInput::Software {
+            mnemonic_with_passphrase:
+                MnemonicWithPassphrase::sample_device_other(), // different mvp
+        };
+        let result = sut.perform_spot_check(input);
+        assert!(!result);
+    }
+
+    #[test]
+    fn spot_check__device__wrong_input() {
+        let sut = SUT::sample_device();
+        let input = SpotCheckInput::Ledger {
+            id: Exactly32Bytes::sample(),
+        };
+        let result = sut.perform_spot_check(input);
+        assert!(!result);
+    }
+
+    #[test]
+    fn spot_check__ledger__id_matches() {
+        let bytes = Exactly32Bytes::sample();
+        let id = FactorSourceIDFromHash::new(
+            FactorSourceKind::LedgerHQHardwareWallet,
+            bytes,
+        );
+        let sut = SUT::from(id);
+        let input = SpotCheckInput::Ledger { id: bytes };
+        let result = sut.perform_spot_check(input);
+        assert!(result);
+    }
+
+    #[test]
+    fn spot_check__ledger__id_does_not_match() {
+        let bytes = Exactly32Bytes::sample();
+        let id = FactorSourceIDFromHash::new(
+            FactorSourceKind::LedgerHQHardwareWallet,
+            Exactly32Bytes::sample_other(),
+        );
+        let sut = SUT::from(id);
+        let input = SpotCheckInput::Ledger { id: bytes };
+        let result = sut.perform_spot_check(input);
+        assert!(!result);
+    }
+
+    #[test]
+    fn spot_check__ledger__wrong_input() {
+        let sut = SUT::sample_ledger();
+        let input = SpotCheckInput::ArculusCard {
+            id: FactorSourceIDFromHash::sample(),
+        };
+        let result = sut.perform_spot_check(input);
+        assert!(!result);
+    }
+
+    #[test]
+    fn spot_check__arculus__id_matches() {
+        let id = FactorSourceIDFromHash::sample_arculus();
+        let sut = SUT::from(id);
+        let input = SpotCheckInput::ArculusCard { id };
+        let result = sut.perform_spot_check(input);
+        assert!(result);
+    }
+
+    #[test]
+    fn spot_check__arculus__id_does_not_match() {
+        let id = FactorSourceIDFromHash::sample_arculus();
+        let sut = SUT::from(FactorSourceIDFromHash::sample_arculus_other());
+        let input = SpotCheckInput::ArculusCard { id };
+        let result = sut.perform_spot_check(input);
+        assert!(!result);
+    }
+
+    #[test]
+    fn spot_check__arculus__wrong_input() {
+        let input = SpotCheckInput::Software {
+            mnemonic_with_passphrase: MnemonicWithPassphrase::sample(),
+        };
+        let result = SUT::sample_arculus().perform_spot_check(input.clone());
+        assert!(!result);
+
+        let result = SUT::sample_ledger().perform_spot_check(input.clone());
+        assert!(!result);
+    }
+
+    #[test]
+    fn kind_is_software() {
+        assert!(FactorSourceKind::Device.is_software());
+        assert!(FactorSourceKind::OffDeviceMnemonic.is_software());
+        assert!(FactorSourceKind::Password.is_software());
+        assert!(FactorSourceKind::SecurityQuestions.is_software());
+        assert!(!FactorSourceKind::LedgerHQHardwareWallet.is_software());
+        assert!(!FactorSourceKind::ArculusCard.is_software());
+        assert!(!FactorSourceKind::TrustedContact.is_software());
+    }
+
+    #[test]
+    fn spot_check_traits() {
+        let factor_source = FactorSource::sample_device();
+        let id = factor_source.id();
+        let id_from_hash = id.as_hash().cloned().unwrap();
+        let input = SpotCheckInput::Software {
+            mnemonic_with_passphrase: MnemonicWithPassphrase::sample_device(),
+        };
+        assert_eq!(
+            id.perform_spot_check(input.clone()),
+            factor_source.perform_spot_check(input.clone())
+        );
+        assert_eq!(
+            id_from_hash.perform_spot_check(input.clone()),
+            factor_source.perform_spot_check(input.clone())
+        );
+        assert_eq!(
+            id.perform_spot_check(input.clone()),
+            id_from_hash.perform_spot_check(input.clone())
+        );
+    }
+}

--- a/crates/factors/factors/src/factor_source_id_spot_check.rs
+++ b/crates/factors/factors/src/factor_source_id_spot_check.rs
@@ -47,7 +47,7 @@ impl FactorSourceIDSpotCheck for FactorSourceID {
             SpotCheckInput::Software {
                 mnemonic_with_passphrase,
             } => {
-                if !kind.is_software() {
+                if !kind.expects_software_spot_check_input() {
                     return false;
                 }
                 let built_id =
@@ -74,7 +74,8 @@ impl FactorSourceIDSpotCheck for FactorSourceIDFromHash {
 }
 
 impl FactorSourceKind {
-    fn is_software(&self) -> bool {
+    /// Returns whether the kind expects a `Software` input for spot check.
+    fn expects_software_spot_check_input(&self) -> bool {
         match self {
             FactorSourceKind::Device
             | FactorSourceKind::OffDeviceMnemonic
@@ -193,14 +194,20 @@ mod tests {
     }
 
     #[test]
-    fn kind_is_software() {
-        assert!(FactorSourceKind::Device.is_software());
-        assert!(FactorSourceKind::OffDeviceMnemonic.is_software());
-        assert!(FactorSourceKind::Password.is_software());
-        assert!(FactorSourceKind::SecurityQuestions.is_software());
-        assert!(!FactorSourceKind::LedgerHQHardwareWallet.is_software());
-        assert!(!FactorSourceKind::ArculusCard.is_software());
-        assert!(!FactorSourceKind::TrustedContact.is_software());
+    fn kind_expects_software_spot_check_input() {
+        assert!(FactorSourceKind::Device.expects_software_spot_check_input());
+        assert!(FactorSourceKind::OffDeviceMnemonic
+            .expects_software_spot_check_input());
+        assert!(FactorSourceKind::Password.expects_software_spot_check_input());
+        assert!(FactorSourceKind::SecurityQuestions
+            .expects_software_spot_check_input());
+        assert!(!FactorSourceKind::LedgerHQHardwareWallet
+            .expects_software_spot_check_input());
+        assert!(
+            !FactorSourceKind::ArculusCard.expects_software_spot_check_input()
+        );
+        assert!(!FactorSourceKind::TrustedContact
+            .expects_software_spot_check_input());
     }
 
     #[test]

--- a/crates/factors/factors/src/factor_sources/ledger_hardware_wallet_factor_source/ledger_hardware_wallet_factor_source.rs
+++ b/crates/factors/factors/src/factor_sources/ledger_hardware_wallet_factor_source/ledger_hardware_wallet_factor_source.rs
@@ -26,6 +26,10 @@ pub struct LedgerHardwareWalletFactorSource {
     pub hint: LedgerHardwareWalletHint,
 }
 
+/// # Safety
+/// Rust memory safe, but marked "unsafe" since this ctor is only used for tests (and shouldn't be
+/// used by production code). A real Ledger device won't be initialized with a `MnemonicWithPassphrase`,
+/// but with `Exactly32Bytes` detailing the device's ID.
 unsafe fn new_ledger_with_mwp(
     mwp: MnemonicWithPassphrase,
     hint: LedgerHardwareWalletHint,

--- a/crates/factors/factors/src/factor_sources/ledger_hardware_wallet_factor_source/ledger_hardware_wallet_factor_source.rs
+++ b/crates/factors/factors/src/factor_sources/ledger_hardware_wallet_factor_source/ledger_hardware_wallet_factor_source.rs
@@ -26,7 +26,7 @@ pub struct LedgerHardwareWalletFactorSource {
     pub hint: LedgerHardwareWalletHint,
 }
 
-fn new_ledger_with_mwp(
+unsafe fn new_ledger_with_mwp(
     mwp: MnemonicWithPassphrase,
     hint: LedgerHardwareWalletHint,
     common: FactorSourceCommon,
@@ -51,19 +51,23 @@ impl LedgerHardwareWalletFactorSource {
 
 impl HasSampleValues for LedgerHardwareWalletFactorSource {
     fn sample() -> Self {
-        new_ledger_with_mwp(
-            MnemonicWithPassphrase::sample_ledger(),
-            LedgerHardwareWalletHint::sample(),
-            FactorSourceCommon::new_bdfs(false),
-        )
+        unsafe {
+            new_ledger_with_mwp(
+                MnemonicWithPassphrase::sample_ledger(),
+                LedgerHardwareWalletHint::sample(),
+                FactorSourceCommon::new_bdfs(false),
+            )
+        }
     }
 
     fn sample_other() -> Self {
-        new_ledger_with_mwp(
-            MnemonicWithPassphrase::sample_ledger_other(),
-            LedgerHardwareWalletHint::sample_other(),
-            FactorSourceCommon::new_olympia(),
-        )
+        unsafe {
+            new_ledger_with_mwp(
+                MnemonicWithPassphrase::sample_ledger_other(),
+                LedgerHardwareWalletHint::sample_other(),
+                FactorSourceCommon::new_olympia(),
+            )
+        }
     }
 }
 

--- a/crates/factors/factors/src/lib.rs
+++ b/crates/factors/factors/src/lib.rs
@@ -10,6 +10,7 @@ mod factor_source_flag;
 mod factor_source_id;
 mod factor_source_id_from_address;
 mod factor_source_id_from_hash;
+mod factor_source_id_spot_check;
 mod factor_source_kind;
 mod factor_sources;
 mod factor_sources_of_kind;
@@ -43,6 +44,7 @@ pub mod prelude {
     pub use crate::factor_source_id::*;
     pub use crate::factor_source_id_from_address::*;
     pub use crate::factor_source_id_from_hash::*;
+    pub use crate::factor_source_id_spot_check::*;
     pub use crate::factor_source_kind::*;
     pub use crate::factor_sources::*;
     pub use crate::factor_sources_of_kind::*;

--- a/crates/factors/instances-provider/Cargo.toml
+++ b/crates/factors/instances-provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factor-instances-provider"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/keys-collector/Cargo.toml
+++ b/crates/factors/keys-collector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keys-collector"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/next-derivation-index-ephemeral/Cargo.toml
+++ b/crates/factors/next-derivation-index-ephemeral/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "next-derivation-index-ephemeral"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/signatures-collector/Cargo.toml
+++ b/crates/factors/signatures-collector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signatures-collector"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 

--- a/crates/factors/supporting-types/Cargo.toml
+++ b/crates/factors/supporting-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factors-supporting-types"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/gateway/client-and-api/Cargo.toml
+++ b/crates/gateway/client-and-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gateway-client-and-api"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/gateway/models/Cargo.toml
+++ b/crates/gateway/models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gateway-models"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 

--- a/crates/profile/logic/logic_SPLIT_ME/Cargo.toml
+++ b/crates/profile/logic/logic_SPLIT_ME/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-logic"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/account-for-display/Cargo.toml
+++ b/crates/profile/models/account-for-display/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "account-for-display"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/account-or-persona/Cargo.toml
+++ b/crates/profile/models/account-or-persona/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-account-or-persona"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/account/Cargo.toml
+++ b/crates/profile/models/account/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-account"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/app-preferences/Cargo.toml
+++ b/crates/profile/models/app-preferences/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-app-preferences"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/base-entity/Cargo.toml
+++ b/crates/profile/models/base-entity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-base-entity"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/gateway/Cargo.toml
+++ b/crates/profile/models/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-gateway"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/persona-data/Cargo.toml
+++ b/crates/profile/models/persona-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-persona-data"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/persona/Cargo.toml
+++ b/crates/profile/models/persona/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-persona"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/profile_SPLIT_ME/Cargo.toml
+++ b/crates/profile/models/profile_SPLIT_ME/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 

--- a/crates/profile/models/security-structures/Cargo.toml
+++ b/crates/profile/models/security-structures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-security-structures"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/supporting-types/Cargo.toml
+++ b/crates/profile/models/supporting-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-supporting-types"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/traits/entity-by-address/Cargo.toml
+++ b/crates/profile/traits/entity-by-address/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entity-by-address"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/sargon/Cargo.toml
+++ b/crates/sargon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 resolver = "2" # features enabled in integration test

--- a/crates/system/clients/clients/Cargo.toml
+++ b/crates/system/clients/clients/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clients"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 

--- a/crates/system/clients/http/Cargo.toml
+++ b/crates/system/clients/http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http-client"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/drivers/Cargo.toml
+++ b/crates/system/drivers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drivers"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 

--- a/crates/system/interactors/Cargo.toml
+++ b/crates/system/interactors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interactors"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/interactors/src/interactors.rs
+++ b/crates/system/interactors/src/interactors.rs
@@ -8,16 +8,21 @@ pub struct Interactors {
 
     /// Interactor that asks the user to authorize
     pub authorization_interactor: Arc<dyn AuthorizationInteractor>,
+
+    /// Interactor that asks the user perform a spot check
+    pub spot_check_interactor: Arc<dyn SpotCheckInteractor>,
 }
 
 impl Interactors {
     pub fn new(
         use_factor_sources_interactor: Arc<dyn UseFactorSourcesInteractor>,
         authorization_interactor: Arc<dyn AuthorizationInteractor>,
+        spot_check_interactor: Arc<dyn SpotCheckInteractor>,
     ) -> Self {
         Self {
             use_factor_sources_interactor,
             authorization_interactor,
+            spot_check_interactor,
         }
     }
 }

--- a/crates/system/interactors/src/lib.rs
+++ b/crates/system/interactors/src/lib.rs
@@ -1,11 +1,13 @@
 mod authorization_interactor;
 mod interactors;
+mod spot_check_interactor;
 mod testing;
 mod use_factor_sources_interactor;
 
 pub mod prelude {
     pub use crate::authorization_interactor::*;
     pub use crate::interactors::*;
+    pub use crate::spot_check_interactor::*;
     pub use crate::testing::*;
     pub use crate::use_factor_sources_interactor::*;
 

--- a/crates/system/interactors/src/spot_check_interactor.rs
+++ b/crates/system/interactors/src/spot_check_interactor.rs
@@ -4,25 +4,24 @@ use crate::prelude::*;
 /// on a factor source.
 #[async_trait::async_trait]
 pub trait SpotCheckInteractor: Send + Sync {
+    /// Perform a spot check on the given `FactorSource`.
+    /// If `allow_skip`, host should allow users to skip the spot check.
     async fn spot_check(
         &self,
         factor_source: FactorSource,
+        allow_skip: bool,
     ) -> Result<SpotCheckResponse>;
 }
 
+/// An enum indicating the result of a spot check.
+///
+/// Note that there isn't a failure case since user never fails a spot check: it either succeeds,
+/// skips it or aborts the interaction.
 #[derive(Clone, Debug, PartialEq, Eq, std::hash::Hash)]
 pub enum SpotCheckResponse {
-    /// The user retrieved the id of a Ledger device.
-    /// Used for the identification of `LedgerHardwareWalletFactorSource`.
-    Ledger { id: Exactly32Bytes },
+    /// The factor source was successfully validated.
+    Valid,
 
-    /// The user retrieved the `FactorSourceIdFromHash` that identified an Arculus card.
-    /// /// Used for the identification of `ArculusCardFactorSource`.
-    ArculusCard { id: FactorSourceIDFromHash },
-
-    /// The user retrieved a `MnemonicWithPassphrase`.
-    /// Used for the identification of any software `FactorSource`.
-    Software {
-        mnemonic_with_passphrase: MnemonicWithPassphrase,
-    },
+    /// The user skipped the spot check.
+    Skipped,
 }

--- a/crates/system/interactors/src/spot_check_interactor.rs
+++ b/crates/system/interactors/src/spot_check_interactor.rs
@@ -15,8 +15,10 @@ pub trait SpotCheckInteractor: Send + Sync {
 
 /// An enum indicating the result of a spot check.
 ///
-/// Note that there isn't a failure case since user never fails a spot check: it either succeeds,
-/// skips it or aborts the interaction.
+/// Note that there isn't a failure case since user never fails a spot check. It either:
+/// - succeeds (`Valid` returned by host),
+/// - skips (`Skipped` returned by host),
+/// - aborts (`CommonError::HostInteractionAborted` thrown by host)
 #[derive(Clone, Debug, PartialEq, Eq, std::hash::Hash)]
 pub enum SpotCheckResponse {
     /// The factor source was successfully validated.

--- a/crates/system/interactors/src/spot_check_interactor.rs
+++ b/crates/system/interactors/src/spot_check_interactor.rs
@@ -6,7 +6,7 @@ use crate::prelude::*;
 pub trait SpotCheckInteractor: Send + Sync {
     async fn spot_check(
         &self,
-        factor_source_id: FactorSourceIDFromHash,
+        factor_source: FactorSource,
     ) -> Result<SpotCheckResponse>;
 }
 

--- a/crates/system/interactors/src/spot_check_interactor.rs
+++ b/crates/system/interactors/src/spot_check_interactor.rs
@@ -16,6 +16,10 @@ pub enum SpotCheckResponse {
     /// Used for the identification of `LedgerHardwareWalletFactorSource`.
     Ledger { id: Exactly32Bytes },
 
+    /// The user retrieved the `FactorSourceIdFromHash` that identified an Arculus card.
+    /// /// Used for the identification of `ArculusCardFactorSource`.
+    ArculusCard { id: FactorSourceIDFromHash },
+
     /// The user retrieved a `MnemonicWithPassphrase`.
     /// Used for the identification of any other `FactorSource`.
     MnemonicWithPassphrase { value: MnemonicWithPassphrase },

--- a/crates/system/interactors/src/spot_check_interactor.rs
+++ b/crates/system/interactors/src/spot_check_interactor.rs
@@ -1,0 +1,22 @@
+use crate::prelude::*;
+
+/// An interactor responsible for communicating with the user on host, to perform a spot check
+/// on a factor source.
+#[async_trait::async_trait]
+pub trait SpotCheckInteractor: Send + Sync {
+    async fn spot_check(
+        &self,
+        factor_source_id: FactorSourceIDFromHash,
+    ) -> Result<SpotCheckResponse>;
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, std::hash::Hash)]
+pub enum SpotCheckResponse {
+    /// The user retrieved the id of a Ledger device.
+    /// Used for the identification of `LedgerHardwareWalletFactorSource`.
+    Ledger { id: Exactly32Bytes },
+
+    /// The user retrieved a `MnemonicWithPassphrase`.
+    /// Used for the identification of any other `FactorSource`.
+    MnemonicWithPassphrase { value: MnemonicWithPassphrase },
+}

--- a/crates/system/interactors/src/spot_check_interactor.rs
+++ b/crates/system/interactors/src/spot_check_interactor.rs
@@ -21,6 +21,8 @@ pub enum SpotCheckResponse {
     ArculusCard { id: FactorSourceIDFromHash },
 
     /// The user retrieved a `MnemonicWithPassphrase`.
-    /// Used for the identification of any other `FactorSource`.
-    MnemonicWithPassphrase { value: MnemonicWithPassphrase },
+    /// Used for the identification of any software `FactorSource`.
+    Software {
+        mnemonic_with_passphrase: MnemonicWithPassphrase,
+    },
 }

--- a/crates/system/interactors/src/testing/mod.rs
+++ b/crates/system/interactors/src/testing/mod.rs
@@ -1,5 +1,7 @@
 mod test_authorization_interactor;
+mod test_spot_check_interactor;
 mod test_use_factor_sources_interactors;
 
 pub use test_authorization_interactor::*;
+pub use test_spot_check_interactor::*;
 pub use test_use_factor_sources_interactors::*;

--- a/crates/system/interactors/src/testing/test_spot_check_interactor.rs
+++ b/crates/system/interactors/src/testing/test_spot_check_interactor.rs
@@ -9,18 +9,12 @@ impl SpotCheckInteractor for TestSpotCheckInteractor {
     async fn spot_check(
         &self,
         _factor_source: FactorSource,
+        _allow_skip: bool,
     ) -> Result<SpotCheckResponse> {
         match self.user.clone() {
             SpotCheckUser::Failure(common_error) => Err(common_error),
-            SpotCheckUser::Ledger(id) => Ok(SpotCheckResponse::Ledger { id }),
-            SpotCheckUser::ArculusCard(id) => {
-                Ok(SpotCheckResponse::ArculusCard { id })
-            }
-            SpotCheckUser::Software(mnemonic_with_passphrase) => {
-                Ok(SpotCheckResponse::Software {
-                    mnemonic_with_passphrase,
-                })
-            }
+            SpotCheckUser::Valid => Ok(SpotCheckResponse::Valid),
+            SpotCheckUser::Skipped => Ok(SpotCheckResponse::Skipped),
         }
     }
 }
@@ -28,34 +22,24 @@ impl SpotCheckInteractor for TestSpotCheckInteractor {
 #[derive(Clone)]
 pub enum SpotCheckUser {
     Failure(CommonError),
-    Ledger(Exactly32Bytes),
-    ArculusCard(FactorSourceIDFromHash),
-    Software(MnemonicWithPassphrase),
+    Valid,
+    Skipped,
 }
 
 impl TestSpotCheckInteractor {
     pub fn new(user: SpotCheckUser) -> Self {
         Self { user }
     }
-    pub fn new_failing() -> Self {
-        Self::new(SpotCheckUser::Failure(CommonError::Unknown))
-    }
 
-    pub fn new_failing_error(common_error: CommonError) -> Self {
+    pub fn new_failing(common_error: CommonError) -> Self {
         Self::new(SpotCheckUser::Failure(common_error))
     }
 
-    pub fn new_ledger(id: Exactly32Bytes) -> Self {
-        Self::new(SpotCheckUser::Ledger(id))
+    pub fn new_valid() -> Self {
+        Self::new(SpotCheckUser::Valid)
     }
 
-    pub fn new_arculus_card(id: FactorSourceIDFromHash) -> Self {
-        Self::new(SpotCheckUser::ArculusCard(id))
-    }
-
-    pub fn new_software(
-        mnemonic_with_passphrase: MnemonicWithPassphrase,
-    ) -> Self {
-        Self::new(SpotCheckUser::Software(mnemonic_with_passphrase))
+    pub fn new_skipped() -> Self {
+        Self::new(SpotCheckUser::Skipped)
     }
 }

--- a/crates/system/interactors/src/testing/test_spot_check_interactor.rs
+++ b/crates/system/interactors/src/testing/test_spot_check_interactor.rs
@@ -8,7 +8,7 @@ pub struct TestSpotCheckInteractor {
 impl SpotCheckInteractor for TestSpotCheckInteractor {
     async fn spot_check(
         &self,
-        _factor_source_id: FactorSourceIDFromHash,
+        _factor_source: FactorSource,
     ) -> Result<SpotCheckResponse> {
         match self.user.clone() {
             SpotCheckUser::Failure(common_error) => Err(common_error),

--- a/crates/system/interactors/src/testing/test_spot_check_interactor.rs
+++ b/crates/system/interactors/src/testing/test_spot_check_interactor.rs
@@ -1,0 +1,19 @@
+use crate::prelude::*;
+
+pub struct TestSpotCheckInteractor {}
+
+#[async_trait::async_trait]
+impl SpotCheckInteractor for TestSpotCheckInteractor {
+    async fn spot_check(
+        &self,
+        factor_source_id: FactorSourceIDFromHash,
+    ) -> Result<SpotCheckResponse> {
+        Err(CommonError::Unknown)
+    }
+}
+
+impl TestSpotCheckInteractor {
+    pub fn new_failing() -> Self {
+        Self {}
+    }
+}

--- a/crates/system/interactors/src/testing/test_spot_check_interactor.rs
+++ b/crates/system/interactors/src/testing/test_spot_check_interactor.rs
@@ -12,8 +12,8 @@ impl SpotCheckInteractor for TestSpotCheckInteractor {
         _allow_skip: bool,
     ) -> Result<SpotCheckResponse> {
         match self.user.clone() {
-            SpotCheckUser::Failure(common_error) => Err(common_error),
-            SpotCheckUser::Valid => Ok(SpotCheckResponse::Valid),
+            SpotCheckUser::Failed(common_error) => Err(common_error),
+            SpotCheckUser::Succeeded => Ok(SpotCheckResponse::Valid),
             SpotCheckUser::Skipped => Ok(SpotCheckResponse::Skipped),
         }
     }
@@ -21,8 +21,8 @@ impl SpotCheckInteractor for TestSpotCheckInteractor {
 
 #[derive(Clone)]
 pub enum SpotCheckUser {
-    Failure(CommonError),
-    Valid,
+    Failed(CommonError),
+    Succeeded,
     Skipped,
 }
 
@@ -31,12 +31,12 @@ impl TestSpotCheckInteractor {
         Self { user }
     }
 
-    pub fn new_failing(common_error: CommonError) -> Self {
-        Self::new(SpotCheckUser::Failure(common_error))
+    pub fn new_failed(common_error: CommonError) -> Self {
+        Self::new(SpotCheckUser::Failed(common_error))
     }
 
-    pub fn new_valid() -> Self {
-        Self::new(SpotCheckUser::Valid)
+    pub fn new_succeeded() -> Self {
+        Self::new(SpotCheckUser::Succeeded)
     }
 
     pub fn new_skipped() -> Self {

--- a/crates/system/interactors/src/testing/test_spot_check_interactor.rs
+++ b/crates/system/interactors/src/testing/test_spot_check_interactor.rs
@@ -16,8 +16,10 @@ impl SpotCheckInteractor for TestSpotCheckInteractor {
             SpotCheckUser::ArculusCard(id) => {
                 Ok(SpotCheckResponse::ArculusCard { id })
             }
-            SpotCheckUser::MnemonicWithPassphrase(value) => {
-                Ok(SpotCheckResponse::MnemonicWithPassphrase { value })
+            SpotCheckUser::Software(mnemonic_with_passphrase) => {
+                Ok(SpotCheckResponse::Software {
+                    mnemonic_with_passphrase,
+                })
             }
         }
     }
@@ -28,7 +30,7 @@ pub enum SpotCheckUser {
     Failure(CommonError),
     Ledger(Exactly32Bytes),
     ArculusCard(FactorSourceIDFromHash),
-    MnemonicWithPassphrase(MnemonicWithPassphrase),
+    Software(MnemonicWithPassphrase),
 }
 
 impl TestSpotCheckInteractor {
@@ -51,11 +53,9 @@ impl TestSpotCheckInteractor {
         Self::new(SpotCheckUser::ArculusCard(id))
     }
 
-    pub fn new_mnemonic_with_passphrase(
+    pub fn new_software(
         mnemonic_with_passphrase: MnemonicWithPassphrase,
     ) -> Self {
-        Self::new(SpotCheckUser::MnemonicWithPassphrase(
-            mnemonic_with_passphrase,
-        ))
+        Self::new(SpotCheckUser::Software(mnemonic_with_passphrase))
     }
 }

--- a/crates/system/interactors/src/testing/test_spot_check_interactor.rs
+++ b/crates/system/interactors/src/testing/test_spot_check_interactor.rs
@@ -1,19 +1,61 @@
 use crate::prelude::*;
 
-pub struct TestSpotCheckInteractor {}
+pub struct TestSpotCheckInteractor {
+    user: SpotCheckUser,
+}
 
 #[async_trait::async_trait]
 impl SpotCheckInteractor for TestSpotCheckInteractor {
     async fn spot_check(
         &self,
-        factor_source_id: FactorSourceIDFromHash,
+        _factor_source_id: FactorSourceIDFromHash,
     ) -> Result<SpotCheckResponse> {
-        Err(CommonError::Unknown)
+        match self.user.clone() {
+            SpotCheckUser::Failure(common_error) => Err(common_error),
+            SpotCheckUser::Ledger(id) => Ok(SpotCheckResponse::Ledger { id }),
+            SpotCheckUser::ArculusCard(id) => {
+                Ok(SpotCheckResponse::ArculusCard { id })
+            }
+            SpotCheckUser::MnemonicWithPassphrase(value) => {
+                Ok(SpotCheckResponse::MnemonicWithPassphrase { value })
+            }
+        }
     }
 }
 
+#[derive(Clone)]
+pub enum SpotCheckUser {
+    Failure(CommonError),
+    Ledger(Exactly32Bytes),
+    ArculusCard(FactorSourceIDFromHash),
+    MnemonicWithPassphrase(MnemonicWithPassphrase),
+}
+
 impl TestSpotCheckInteractor {
+    pub fn new(user: SpotCheckUser) -> Self {
+        Self { user }
+    }
     pub fn new_failing() -> Self {
-        Self {}
+        Self::new(SpotCheckUser::Failure(CommonError::Unknown))
+    }
+
+    pub fn new_failing_error(common_error: CommonError) -> Self {
+        Self::new(SpotCheckUser::Failure(common_error))
+    }
+
+    pub fn new_ledger(id: Exactly32Bytes) -> Self {
+        Self::new(SpotCheckUser::Ledger(id))
+    }
+
+    pub fn new_arculus_card(id: FactorSourceIDFromHash) -> Self {
+        Self::new(SpotCheckUser::ArculusCard(id))
+    }
+
+    pub fn new_mnemonic_with_passphrase(
+        mnemonic_with_passphrase: MnemonicWithPassphrase,
+    ) -> Self {
+        Self::new(SpotCheckUser::MnemonicWithPassphrase(
+            mnemonic_with_passphrase,
+        ))
     }
 }

--- a/crates/system/os/accounts/Cargo.toml
+++ b/crates/system/os/accounts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-accounts"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/derive-public-keys/Cargo.toml
+++ b/crates/system/os/derive-public-keys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-derive-public-keys"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/factors/Cargo.toml
+++ b/crates/system/os/factors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-factors"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/os/Cargo.toml
+++ b/crates/system/os/os/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/os/src/sargon_os.rs
+++ b/crates/system/os/os/src/sargon_os.rs
@@ -320,6 +320,10 @@ impl SargonOS {
         self.interactors.authorization_interactor.clone()
     }
 
+    pub fn spot_check_interactor(&self) -> Arc<dyn SpotCheckInteractor> {
+        self.interactors.spot_check_interactor.clone()
+    }
+
     pub fn host_id(&self) -> HostId {
         self.host_id
     }

--- a/crates/system/os/os/src/sargon_os_factors.rs
+++ b/crates/system/os/os/src/sargon_os_factors.rs
@@ -1082,7 +1082,7 @@ mod tests {
         let interactors =
             Interactors::new_from_clients_and_spot_check_interactor(
                 &clients,
-                Arc::new(TestSpotCheckInteractor::new_valid()),
+                Arc::new(TestSpotCheckInteractor::new_succeeded()),
             );
         let os = timeout(
             SARGON_OS_TEST_MAX_ASYNC_DURATION,
@@ -1133,7 +1133,7 @@ mod tests {
         let interactors =
             Interactors::new_from_clients_and_spot_check_interactor(
                 &clients,
-                Arc::new(TestSpotCheckInteractor::new_failing(error.clone())),
+                Arc::new(TestSpotCheckInteractor::new_failed(error.clone())),
             );
         let os = timeout(
             SARGON_OS_TEST_MAX_ASYNC_DURATION,

--- a/crates/system/os/os/src/sargon_os_factors.rs
+++ b/crates/system/os/os/src/sargon_os_factors.rs
@@ -530,9 +530,9 @@ impl SargonOS {
         };
         let response = self
             .spot_check_interactor()
-            .spot_check(id_from_hash)
+            .spot_check(factor_source)
             .await?;
-        let kind = factor_source_id.get_factor_source_kind();
+        let kind = id_from_hash.kind;
         match response {
             SpotCheckResponse::Ledger { id } => {
                 assert_eq!(
@@ -554,10 +554,12 @@ impl SargonOS {
                 Ok(id == id_from_hash)
             }
             SpotCheckResponse::MnemonicWithPassphrase { value } => {
-                let accepted_kinds = [FactorSourceKind::Device,
+                let accepted_kinds = [
+                    FactorSourceKind::Device,
                     FactorSourceKind::OffDeviceMnemonic,
                     FactorSourceKind::Password,
-                    FactorSourceKind::SecurityQuestions];
+                    FactorSourceKind::SecurityQuestions,
+                ];
                 assert!(
                     accepted_kinds.contains(&kind),
                     "Unexpected MnemonicWithPassphrase Response for {:?}",

--- a/crates/system/os/os/src/sargon_os_factors.rs
+++ b/crates/system/os/os/src/sargon_os_factors.rs
@@ -553,7 +553,9 @@ impl SargonOS {
                 );
                 Ok(id == id_from_hash)
             }
-            SpotCheckResponse::MnemonicWithPassphrase { value } => {
+            SpotCheckResponse::Software {
+                mnemonic_with_passphrase,
+            } => {
                 let accepted_kinds = [
                     FactorSourceKind::Device,
                     FactorSourceKind::OffDeviceMnemonic,
@@ -562,12 +564,13 @@ impl SargonOS {
                 ];
                 assert!(
                     accepted_kinds.contains(&kind),
-                    "Unexpected MnemonicWithPassphrase Response for {:?}",
+                    "Unexpected Software Response for {:?}",
                     kind
                 );
                 let built_id =
                     FactorSourceIDFromHash::from_mnemonic_with_passphrase(
-                        kind, &value,
+                        kind,
+                        &mnemonic_with_passphrase,
                     );
                 Ok(built_id == id_from_hash)
             }
@@ -1124,9 +1127,7 @@ mod tests {
         let interactors =
             Interactors::new_from_clients_and_spot_check_interactor(
                 &clients,
-                Arc::new(
-                    TestSpotCheckInteractor::new_mnemonic_with_passphrase(mwp),
-                ),
+                Arc::new(TestSpotCheckInteractor::new_software(mwp)),
             );
         let os = timeout(
             SARGON_OS_TEST_MAX_ASYNC_DURATION,
@@ -1153,9 +1154,7 @@ mod tests {
         let interactors =
             Interactors::new_from_clients_and_spot_check_interactor(
                 &clients,
-                Arc::new(
-                    TestSpotCheckInteractor::new_mnemonic_with_passphrase(mwp),
-                ),
+                Arc::new(TestSpotCheckInteractor::new_software(mwp)),
             );
         let os = timeout(
             SARGON_OS_TEST_MAX_ASYNC_DURATION,
@@ -1273,19 +1272,17 @@ mod tests {
 
     #[actix_rt::test]
     #[should_panic(
-        expected = "Unexpected MnemonicWithPassphrase Response for LedgerHQHardwareWallet"
+        expected = "Unexpected Software Response for LedgerHQHardwareWallet"
     )]
-    async fn spot_check__ledger__mvp_response() {
+    async fn spot_check__ledger__software_response() {
         let clients = Clients::new(Bios::new(Drivers::test()));
         let factor_source = LedgerHardwareWalletFactorSource::sample();
         let interactors =
             Interactors::new_from_clients_and_spot_check_interactor(
                 &clients,
-                Arc::new(
-                    TestSpotCheckInteractor::new_mnemonic_with_passphrase(
-                        MnemonicWithPassphrase::sample(),
-                    ),
-                ),
+                Arc::new(TestSpotCheckInteractor::new_software(
+                    MnemonicWithPassphrase::sample(),
+                )),
             );
         let os = timeout(
             SARGON_OS_TEST_MAX_ASYNC_DURATION,
@@ -1358,20 +1355,16 @@ mod tests {
     }
 
     #[actix_rt::test]
-    #[should_panic(
-        expected = "Unexpected MnemonicWithPassphrase Response for ArculusCard"
-    )]
-    async fn spot_check__arculus__mvp_response() {
+    #[should_panic(expected = "Unexpected Software Response for ArculusCard")]
+    async fn spot_check__arculus__software_response() {
         let clients = Clients::new(Bios::new(Drivers::test()));
         let factor_source = ArculusCardFactorSource::sample();
         let interactors =
             Interactors::new_from_clients_and_spot_check_interactor(
                 &clients,
-                Arc::new(
-                    TestSpotCheckInteractor::new_mnemonic_with_passphrase(
-                        MnemonicWithPassphrase::sample(),
-                    ),
-                ),
+                Arc::new(TestSpotCheckInteractor::new_software(
+                    MnemonicWithPassphrase::sample(),
+                )),
             );
         let os = timeout(
             SARGON_OS_TEST_MAX_ASYNC_DURATION,

--- a/crates/system/os/os/src/testing_interactors.rs
+++ b/crates/system/os/os/src/testing_interactors.rs
@@ -54,6 +54,7 @@ impl InteractorsCtors for Interactors {
         Self::new(
             Arc::new(use_factor_sources_interactors),
             Arc::new(TestAuthorizationInteractor::stubborn_authorizing()),
+            Arc::new(TestSpotCheckInteractor::new_failing()),
         )
     }
 
@@ -78,6 +79,7 @@ impl InteractorsCtors for Interactors {
         Self::new(
             Arc::new(use_factor_sources_interactors),
             authorization_interactor,
+            Arc::new(TestSpotCheckInteractor::new_failing()),
         )
     }
 }

--- a/crates/system/os/os/src/testing_interactors.rs
+++ b/crates/system/os/os/src/testing_interactors.rs
@@ -10,6 +10,11 @@ pub trait InteractorsCtors {
         authorization_interactor: Arc<dyn AuthorizationInteractor>,
     ) -> Interactors;
 
+    fn new_from_clients_and_spot_check_interactor(
+        clients: &Clients,
+        spot_check_interactor: Arc<dyn SpotCheckInteractor>,
+    ) -> Interactors;
+
     fn new_from_clients(clients: &Clients) -> Interactors {
         Self::new_with_derivation_interactor(Arc::new(
             TestDerivationInteractor::new(
@@ -80,6 +85,34 @@ impl InteractorsCtors for Interactors {
             Arc::new(use_factor_sources_interactors),
             authorization_interactor,
             Arc::new(TestSpotCheckInteractor::new_failing()),
+        )
+    }
+
+    fn new_from_clients_and_spot_check_interactor(
+        clients: &Clients,
+        spot_check_interactor: Arc<dyn SpotCheckInteractor>,
+    ) -> Interactors {
+        let use_factor_sources_interactors =
+            TestUseFactorSourcesInteractors::new(
+                Arc::new(TestSignInteractor::<TransactionIntent>::new(
+                    SimulatedUser::prudent_no_fail(),
+                )),
+                Arc::new(TestSignInteractor::<Subintent>::new(
+                    SimulatedUser::prudent_no_fail(),
+                )),
+                Arc::new(TestDerivationInteractor::new(
+                    false,
+                    Arc::new(clients.secure_storage.clone()),
+                )),
+                Arc::new(TestSignInteractor::<AuthIntent>::new(
+                    SimulatedUser::prudent_no_fail(),
+                )),
+            );
+
+        Self::new(
+            Arc::new(use_factor_sources_interactors),
+            Arc::new(TestAuthorizationInteractor::stubborn_authorizing()),
+            spot_check_interactor,
         )
     }
 }

--- a/crates/system/os/os/src/testing_interactors.rs
+++ b/crates/system/os/os/src/testing_interactors.rs
@@ -59,7 +59,7 @@ impl InteractorsCtors for Interactors {
         Self::new(
             Arc::new(use_factor_sources_interactors),
             Arc::new(TestAuthorizationInteractor::stubborn_authorizing()),
-            Arc::new(TestSpotCheckInteractor::new_valid()),
+            Arc::new(TestSpotCheckInteractor::new_succeeded()),
         )
     }
 
@@ -84,7 +84,7 @@ impl InteractorsCtors for Interactors {
         Self::new(
             Arc::new(use_factor_sources_interactors),
             authorization_interactor,
-            Arc::new(TestSpotCheckInteractor::new_valid()),
+            Arc::new(TestSpotCheckInteractor::new_succeeded()),
         )
     }
 

--- a/crates/system/os/os/src/testing_interactors.rs
+++ b/crates/system/os/os/src/testing_interactors.rs
@@ -59,7 +59,7 @@ impl InteractorsCtors for Interactors {
         Self::new(
             Arc::new(use_factor_sources_interactors),
             Arc::new(TestAuthorizationInteractor::stubborn_authorizing()),
-            Arc::new(TestSpotCheckInteractor::new_failing()),
+            Arc::new(TestSpotCheckInteractor::new_valid()),
         )
     }
 
@@ -84,7 +84,7 @@ impl InteractorsCtors for Interactors {
         Self::new(
             Arc::new(use_factor_sources_interactors),
             authorization_interactor,
-            Arc::new(TestSpotCheckInteractor::new_failing()),
+            Arc::new(TestSpotCheckInteractor::new_valid()),
         )
     }
 

--- a/crates/system/os/security-center/Cargo.toml
+++ b/crates/system/os/security-center/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-security-center"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/signing/Cargo.toml
+++ b/crates/system/os/signing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-signing"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/signing/src/sargon_os_signing.rs
+++ b/crates/system/os/signing/src/sargon_os_signing.rs
@@ -464,7 +464,7 @@ mod test {
         let interactors = Interactors::new(
             use_factor_sources_interactors,
             Arc::new(TestAuthorizationInteractor::stubborn_authorizing()),
-            Arc::new(TestSpotCheckInteractor::new_failing()),
+            Arc::new(TestSpotCheckInteractor::new_valid()),
         );
         SUT::boot_with_clients_and_interactor(clients, interactors).await
     }

--- a/crates/system/os/signing/src/sargon_os_signing.rs
+++ b/crates/system/os/signing/src/sargon_os_signing.rs
@@ -464,7 +464,7 @@ mod test {
         let interactors = Interactors::new(
             use_factor_sources_interactors,
             Arc::new(TestAuthorizationInteractor::stubborn_authorizing()),
-            Arc::new(TestSpotCheckInteractor::new_valid()),
+            Arc::new(TestSpotCheckInteractor::new_succeeded()),
         );
         SUT::boot_with_clients_and_interactor(clients, interactors).await
     }

--- a/crates/system/os/signing/src/sargon_os_signing.rs
+++ b/crates/system/os/signing/src/sargon_os_signing.rs
@@ -464,6 +464,7 @@ mod test {
         let interactors = Interactors::new(
             use_factor_sources_interactors,
             Arc::new(TestAuthorizationInteractor::stubborn_authorizing()),
+            Arc::new(TestSpotCheckInteractor::new_failing()),
         );
         SUT::boot_with_clients_and_interactor(clients, interactors).await
     }

--- a/crates/system/os/transaction/Cargo.toml
+++ b/crates/system/os/transaction/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-transaction"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/profile-state-holder/Cargo.toml
+++ b/crates/system/profile-state-holder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-state-holder"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/sub-systems/Cargo.toml
+++ b/crates/system/sub-systems/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sub-systems"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/transaction/foundation/Cargo.toml
+++ b/crates/transaction/foundation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transaction-foundation"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/transaction/manifests/Cargo.toml
+++ b/crates/transaction/manifests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "manifests"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 

--- a/crates/transaction/models/Cargo.toml
+++ b/crates/transaction/models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transaction-models"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 

--- a/crates/uniffi/conversion-macros/Cargo.toml
+++ b/crates/uniffi/conversion-macros/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "sargon-uniffi-conversion-macros"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 
 [dependencies]

--- a/crates/uniffi/uniffi_SPLIT_ME/Cargo.toml
+++ b/crates/uniffi/uniffi_SPLIT_ME/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-uniffi"
-version = "1.1.133"
+version = "1.1.134"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/uniffi/uniffi_SPLIT_ME/src/profile/v100/factors/factor_source_id_spot_check.rs
+++ b/crates/uniffi/uniffi_SPLIT_ME/src/profile/v100/factors/factor_source_id_spot_check.rs
@@ -1,0 +1,53 @@
+use crate::prelude::*;
+use factors::FactorSourceIDSpotCheck;
+use sargon::FactorSourceID as InternalFactorSourceID;
+use sargon::SpotCheckInput as InternalSpotCheckInput;
+
+/// An enum with the input to perform a spot check for a given `FactorSourceID`.
+/// This is, to validate that the `FactorSourceID` was created with the same input that has been provided.
+#[derive(Clone, PartialEq, Eq, InternalConversion, uniffi::Enum)]
+pub enum SpotCheckInput {
+    /// The user retrieved the id of a Ledger device.
+    /// Used for the identification of `LedgerHardwareWalletFactorSource`.
+    Ledger { id: Exactly32Bytes },
+
+    /// The user retrieved the `FactorSourceIdFromHash` that identified an Arculus card.
+    /// /// Used for the identification of `ArculusCardFactorSource`.
+    ArculusCard { id: FactorSourceIDFromHash },
+
+    /// The user retrieved a `MnemonicWithPassphrase`.
+    /// Used for the identification of any software `FactorSource`.
+    Software {
+        mnemonic_with_passphrase: MnemonicWithPassphrase,
+    },
+}
+
+#[uniffi::export]
+pub fn factor_source_id_perform_spot_check(
+    factor_source_id: FactorSourceID,
+    input: SpotCheckInput,
+) -> bool {
+    factor_source_id
+        .into_internal()
+        .perform_spot_check(input.into_internal())
+}
+
+#[uniffi::export]
+pub fn factor_source_perform_spot_check(
+    factor_source: FactorSource,
+    input: SpotCheckInput,
+) -> bool {
+    factor_source
+        .into_internal()
+        .perform_spot_check(input.into_internal())
+}
+
+#[uniffi::export]
+pub fn factor_source_id_from_hash_perform_spot_check(
+    factor_source_id_from_hash: FactorSourceIDFromHash,
+    input: SpotCheckInput,
+) -> bool {
+    factor_source_id_from_hash
+        .into_internal()
+        .perform_spot_check(input.into_internal())
+}

--- a/crates/uniffi/uniffi_SPLIT_ME/src/profile/v100/factors/mod.rs
+++ b/crates/uniffi/uniffi_SPLIT_ME/src/profile/v100/factors/mod.rs
@@ -6,6 +6,7 @@ mod factor_source_flag;
 mod factor_source_id;
 mod factor_source_id_from_address;
 mod factor_source_id_from_hash;
+mod factor_source_id_spot_check;
 mod factor_source_kind;
 mod factor_sources;
 mod hierarchical_deterministic_factor_instance;

--- a/crates/uniffi/uniffi_SPLIT_ME/src/system/interactors/host_interactor.rs
+++ b/crates/uniffi/uniffi_SPLIT_ME/src/system/interactors/host_interactor.rs
@@ -4,7 +4,7 @@ use sargon::AuthIntentHash as InternalAuthIntentHash;
 use sargon::AuthorizationInteractor as InternalAuthorizationInteractor;
 use sargon::AuthorizationPurpose as InternalAuthorizationPurpose;
 use sargon::AuthorizationResponse as InternalAuthorizationResponse;
-use sargon::FactorSourceIDFromHash as InternalFactorSourceIDFromHash;
+use sargon::FactorSource as InternalFactorSource;
 use sargon::KeyDerivationInteractor as InternalKeyDerivationInteractor;
 use sargon::KeyDerivationRequest as InternalKeyDerivationRequest;
 use sargon::KeyDerivationResponse as InternalKeyDerivationResponse;
@@ -60,7 +60,7 @@ pub trait HostInteractor: Send + Sync + std::fmt::Debug {
 
     async fn spot_check(
         &self,
-        factor_source_id: FactorSourceIDFromHash,
+        factor_source: FactorSource,
     ) -> Result<SpotCheckResponse>;
 }
 
@@ -103,10 +103,10 @@ impl SpotCheckInteractorAdapter {
 impl InternalSpotCheckInteractor for SpotCheckInteractorAdapter {
     async fn spot_check(
         &self,
-        factor_source_id: InternalFactorSourceIDFromHash,
+        factor_source: InternalFactorSource,
     ) -> InternalResult<InternalSpotCheckResponse> {
         self.wrapped
-            .spot_check(factor_source_id.into())
+            .spot_check(factor_source.into())
             .await
             .into_internal_result()
     }

--- a/crates/uniffi/uniffi_SPLIT_ME/src/system/interactors/host_interactor.rs
+++ b/crates/uniffi/uniffi_SPLIT_ME/src/system/interactors/host_interactor.rs
@@ -4,11 +4,14 @@ use sargon::AuthIntentHash as InternalAuthIntentHash;
 use sargon::AuthorizationInteractor as InternalAuthorizationInteractor;
 use sargon::AuthorizationPurpose as InternalAuthorizationPurpose;
 use sargon::AuthorizationResponse as InternalAuthorizationResponse;
+use sargon::FactorSourceIDFromHash as InternalFactorSourceIDFromHash;
 use sargon::KeyDerivationInteractor as InternalKeyDerivationInteractor;
 use sargon::KeyDerivationRequest as InternalKeyDerivationRequest;
 use sargon::KeyDerivationResponse as InternalKeyDerivationResponse;
 use sargon::Result as InternalResult;
 use sargon::SignInteractor as InternalSignInteractor;
+use sargon::SpotCheckInteractor as InternalSpotCheckInteractor;
+use sargon::SpotCheckResponse as InternalSpotCheckResponse;
 use sargon::Subintent as InternalSubintent;
 use sargon::SubintentHash as InternalSubintentHash;
 use sargon::TransactionIntent as InternalTransactionIntent;
@@ -54,6 +57,11 @@ pub trait HostInteractor: Send + Sync + std::fmt::Debug {
         &self,
         purpose: AuthorizationPurpose,
     ) -> AuthorizationResponse;
+
+    async fn spot_check(
+        &self,
+        factor_source_id: FactorSourceIDFromHash,
+    ) -> Result<SpotCheckResponse>;
 }
 
 #[derive(Debug)]
@@ -77,6 +85,30 @@ impl InternalAuthorizationInteractor for AuthorizationInteractorAdapter {
             .request_authorization(purpose.into())
             .await
             .into_internal()
+    }
+}
+
+#[derive(Debug)]
+pub struct SpotCheckInteractorAdapter {
+    pub wrapped: Arc<dyn HostInteractor>,
+}
+
+impl SpotCheckInteractorAdapter {
+    pub fn new(wrapped: Arc<dyn HostInteractor>) -> Self {
+        Self { wrapped }
+    }
+}
+
+#[async_trait::async_trait]
+impl InternalSpotCheckInteractor for SpotCheckInteractorAdapter {
+    async fn spot_check(
+        &self,
+        factor_source_id: InternalFactorSourceIDFromHash,
+    ) -> InternalResult<InternalSpotCheckResponse> {
+        self.wrapped
+            .spot_check(factor_source_id.into())
+            .await
+            .into_internal_result()
     }
 }
 

--- a/crates/uniffi/uniffi_SPLIT_ME/src/system/interactors/host_interactor.rs
+++ b/crates/uniffi/uniffi_SPLIT_ME/src/system/interactors/host_interactor.rs
@@ -61,6 +61,7 @@ pub trait HostInteractor: Send + Sync + std::fmt::Debug {
     async fn spot_check(
         &self,
         factor_source: FactorSource,
+        allow_skip: bool,
     ) -> Result<SpotCheckResponse>;
 }
 
@@ -104,9 +105,10 @@ impl InternalSpotCheckInteractor for SpotCheckInteractorAdapter {
     async fn spot_check(
         &self,
         factor_source: InternalFactorSource,
+        allow_skip: bool,
     ) -> InternalResult<InternalSpotCheckResponse> {
         self.wrapped
-            .spot_check(factor_source.into())
+            .spot_check(factor_source.into(), allow_skip)
             .await
             .into_internal_result()
     }

--- a/crates/uniffi/uniffi_SPLIT_ME/src/system/sargon_os/sargon_os.rs
+++ b/crates/uniffi/uniffi_SPLIT_ME/src/system/sargon_os/sargon_os.rs
@@ -26,7 +26,10 @@ impl SargonOS {
                 Arc::new(UseFactorSourcesInteractorAdapter::new(
                     interactor.clone(),
                 )),
-                Arc::new(AuthorizationInteractorAdapter::new(interactor)),
+                Arc::new(AuthorizationInteractorAdapter::new(
+                    interactor.clone(),
+                )),
+                Arc::new(SpotCheckInteractorAdapter::new(interactor)),
             ),
         )
         .await;

--- a/crates/uniffi/uniffi_SPLIT_ME/src/system/sargon_os/sargon_os_factors.rs
+++ b/crates/uniffi/uniffi_SPLIT_ME/src/system/sargon_os/sargon_os_factors.rs
@@ -216,4 +216,15 @@ impl SargonOS {
             .await
             .into_result()
     }
+
+    /// Performs a spot check on the factor source, and returns whether the spot check was successful.
+    pub async fn perform_spot_check(
+        &self,
+        factor_source: FactorSource,
+    ) -> Result<bool> {
+        self.wrapped
+            .perform_spot_check(factor_source.into_internal())
+            .await
+            .into_result()
+    }
 }

--- a/crates/uniffi/uniffi_SPLIT_ME/src/system/sargon_os/sargon_os_factors.rs
+++ b/crates/uniffi/uniffi_SPLIT_ME/src/system/sargon_os/sargon_os_factors.rs
@@ -217,13 +217,13 @@ impl SargonOS {
             .into_result()
     }
 
-    /// Performs a spot check on the factor source, and returns whether the spot check was successful.
-    pub async fn perform_spot_check(
+    /// Triggers the spot check for the given factor source, and returns whether the spot check was successful.
+    pub async fn trigger_spot_check(
         &self,
         factor_source: FactorSource,
     ) -> Result<bool> {
         self.wrapped
-            .perform_spot_check(factor_source.into_internal())
+            .trigger_spot_check(factor_source.into_internal(), false)
             .await
             .into_result()
     }

--- a/crates/uniffi/uniffi_SPLIT_ME/src/types/mod.rs
+++ b/crates/uniffi/uniffi_SPLIT_ME/src/types/mod.rs
@@ -1,9 +1,11 @@
 mod authorization;
 mod ffi_url;
 mod owned_factor_instance;
+mod spot_check;
 mod vector_image_type;
 
 pub use authorization::*;
 pub use ffi_url::*;
 pub use owned_factor_instance::*;
+pub use spot_check::*;
 pub use vector_image_type::*;

--- a/crates/uniffi/uniffi_SPLIT_ME/src/types/spot_check.rs
+++ b/crates/uniffi/uniffi_SPLIT_ME/src/types/spot_check.rs
@@ -1,20 +1,15 @@
 use crate::prelude::*;
 use sargon::SpotCheckResponse as InternalSpotCheckResponse;
 
-/// The purpose of the authorization request
+/// An enum indicating the result of a spot check.
+///
+/// Note that there isn't a failure case since user never fails a spot check: it either succeeds,
+/// skips it or aborts the interaction.
 #[derive(Clone, PartialEq, Eq, InternalConversion, uniffi::Enum)]
 pub enum SpotCheckResponse {
-    /// The user retrieved the id of a Ledger device.
-    /// Used for the identification of `LedgerHardwareWalletFactorSource`.
-    Ledger { id: Exactly32Bytes },
+    /// The factor source was successfully validated.
+    Valid,
 
-    /// The user retrieved the `FactorSourceIdFromHash` that identified an Arculus card.
-    /// /// Used for the identification of `ArculusCardFactorSource`.
-    ArculusCard { id: FactorSourceIDFromHash },
-
-    /// The user retrieved a `MnemonicWithPassphrase`.
-    /// Used for the identification of any software `FactorSource`.
-    Software {
-        mnemonic_with_passphrase: MnemonicWithPassphrase,
-    },
+    /// The user skipped the spot check.
+    Skipped,
 }

--- a/crates/uniffi/uniffi_SPLIT_ME/src/types/spot_check.rs
+++ b/crates/uniffi/uniffi_SPLIT_ME/src/types/spot_check.rs
@@ -1,0 +1,14 @@
+use crate::prelude::*;
+use sargon::SpotCheckResponse as InternalSpotCheckResponse;
+
+/// The purpose of the authorization request
+#[derive(Clone, PartialEq, Eq, InternalConversion, uniffi::Enum)]
+pub enum SpotCheckResponse {
+    /// The user retrieved the id of a Ledger device.
+    /// Used for the identification of `LedgerHardwareWalletFactorSource`.
+    Ledger { id: Exactly32Bytes },
+
+    /// The user retrieved a `MnemonicWithPassphrase`.
+    /// Used for the identification of any other `FactorSource`.
+    MnemonicWithPassphrase { value: MnemonicWithPassphrase },
+}

--- a/crates/uniffi/uniffi_SPLIT_ME/src/types/spot_check.rs
+++ b/crates/uniffi/uniffi_SPLIT_ME/src/types/spot_check.rs
@@ -3,8 +3,10 @@ use sargon::SpotCheckResponse as InternalSpotCheckResponse;
 
 /// An enum indicating the result of a spot check.
 ///
-/// Note that there isn't a failure case since user never fails a spot check: it either succeeds,
-/// skips it or aborts the interaction.
+/// Note that there isn't a failure case since user never fails a spot check. It either:
+/// - succeeds (`Valid` returned by host),
+/// - skips (`Skipped` returned by host),
+/// - aborts (`CommonError::HostInteractionAborted` thrown by host)
 #[derive(Clone, PartialEq, Eq, InternalConversion, uniffi::Enum)]
 pub enum SpotCheckResponse {
     /// The factor source was successfully validated.

--- a/crates/uniffi/uniffi_SPLIT_ME/src/types/spot_check.rs
+++ b/crates/uniffi/uniffi_SPLIT_ME/src/types/spot_check.rs
@@ -8,6 +8,10 @@ pub enum SpotCheckResponse {
     /// Used for the identification of `LedgerHardwareWalletFactorSource`.
     Ledger { id: Exactly32Bytes },
 
+    /// The user retrieved the `FactorSourceIdFromHash` that identified an Arculus card.
+    /// /// Used for the identification of `ArculusCardFactorSource`.
+    ArculusCard { id: FactorSourceIDFromHash },
+
     /// The user retrieved a `MnemonicWithPassphrase`.
     /// Used for the identification of any other `FactorSource`.
     MnemonicWithPassphrase { value: MnemonicWithPassphrase },

--- a/crates/uniffi/uniffi_SPLIT_ME/src/types/spot_check.rs
+++ b/crates/uniffi/uniffi_SPLIT_ME/src/types/spot_check.rs
@@ -13,6 +13,8 @@ pub enum SpotCheckResponse {
     ArculusCard { id: FactorSourceIDFromHash },
 
     /// The user retrieved a `MnemonicWithPassphrase`.
-    /// Used for the identification of any other `FactorSource`.
-    MnemonicWithPassphrase { value: MnemonicWithPassphrase },
+    /// Used for the identification of any software `FactorSource`.
+    Software {
+        mnemonic_with_passphrase: MnemonicWithPassphrase,
+    },
 }

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/FactorSource.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/FactorSource.kt
@@ -10,10 +10,12 @@ import com.radixdlt.sargon.LedgerHardwareWalletFactorSource
 import com.radixdlt.sargon.MnemonicWithPassphrase
 import com.radixdlt.sargon.OffDeviceMnemonicFactorSource
 import com.radixdlt.sargon.PasswordFactorSource
+import com.radixdlt.sargon.SpotCheckInput
 import com.radixdlt.sargon.deviceFactorSourceIsMainBdfs
 import com.radixdlt.sargon.factorSourceSupportsBabylon
 import com.radixdlt.sargon.factorSourceSupportsOlympia
 import com.radixdlt.sargon.factorSourceName
+import com.radixdlt.sargon.factorSourcePerformSpotCheck
 import com.radixdlt.sargon.newDeviceFactorSourceBabylon
 import com.radixdlt.sargon.newDeviceFactorSourceOlympia
 
@@ -65,6 +67,10 @@ fun FactorSource.Device.Companion.babylon(
     mnemonicWithPassphrase = mnemonicWithPassphrase,
     hostInfo = hostInfo
 ).asGeneral()
+
+fun FactorSource.spotCheck(
+    input: SpotCheckInput
+) = factorSourcePerformSpotCheck(this, input)
 
 val FactorSource.Device.isMain: Boolean
     get() = deviceFactorSourceIsMainBdfs(deviceFactorSource = value)

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/FactorSourceId.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/FactorSourceId.kt
@@ -1,13 +1,17 @@
 package com.radixdlt.sargon.extensions
 
+import com.radixdlt.sargon.FactorSource
 import com.radixdlt.sargon.FactorSourceId
 import com.radixdlt.sargon.FactorSourceIdFromAddress
 import com.radixdlt.sargon.FactorSourceIdFromHash
 import com.radixdlt.sargon.FactorSourceKind
 import com.radixdlt.sargon.MnemonicWithPassphrase
+import com.radixdlt.sargon.SpotCheckInput
 import com.radixdlt.sargon.factorSourceIDFromAddressToJsonBytes
 import com.radixdlt.sargon.factorSourceIDFromHashToJsonBytes
 import com.radixdlt.sargon.factorSourceIDToJsonBytes
+import com.radixdlt.sargon.factorSourceIdPerformSpotCheck
+import com.radixdlt.sargon.factorSourcePerformSpotCheck
 import com.radixdlt.sargon.newFactorSourceIDFromAddressFromJsonBytes
 import com.radixdlt.sargon.newFactorSourceIDFromHashFromJsonBytes
 import com.radixdlt.sargon.newFactorSourceIDFromJsonBytes
@@ -56,3 +60,7 @@ fun FactorSourceId.Companion.fromJson(
 
 fun FactorSourceId.toJson(): String =
     factorSourceIDToJsonBytes(factorSourceID = this).string
+
+fun FactorSourceId.spotCheck(
+    input: SpotCheckInput
+) = factorSourceIdPerformSpotCheck(this, input)

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/FactorSourceIdFromHash.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/FactorSourceIdFromHash.kt
@@ -1,0 +1,9 @@
+package com.radixdlt.sargon.extensions
+
+import com.radixdlt.sargon.FactorSourceIdFromHash
+import com.radixdlt.sargon.SpotCheckInput
+import com.radixdlt.sargon.factorSourceIdFromHashPerformSpotCheck
+
+fun FactorSourceIdFromHash.spotCheck(
+    input: SpotCheckInput
+) = factorSourceIdFromHashPerformSpotCheck(this, input)

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/os/interactor/FakeHostInteractor.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/os/interactor/FakeHostInteractor.kt
@@ -3,6 +3,7 @@ package com.radixdlt.sargon.os.interactor
 import com.radixdlt.sargon.AuthorizationPurpose
 import com.radixdlt.sargon.AuthorizationResponse
 import com.radixdlt.sargon.CommonException
+import com.radixdlt.sargon.FactorSource
 import com.radixdlt.sargon.HostInteractor
 import com.radixdlt.sargon.KeyDerivationRequest
 import com.radixdlt.sargon.KeyDerivationResponse
@@ -12,6 +13,7 @@ import com.radixdlt.sargon.SignRequestOfTransactionIntent
 import com.radixdlt.sargon.SignResponseOfAuthIntentHash
 import com.radixdlt.sargon.SignResponseOfSubintentHash
 import com.radixdlt.sargon.SignResponseOfTransactionIntentHash
+import com.radixdlt.sargon.SpotCheckResponse
 
 class FakeHostInteractor: HostInteractor {
     override suspend fun signTransactions(
@@ -34,6 +36,10 @@ class FakeHostInteractor: HostInteractor {
 
     override suspend fun requestAuthorization(purpose: AuthorizationPurpose): AuthorizationResponse {
         return AuthorizationResponse.REJECTED
+    }
+
+    override suspend fun spotCheck(factorSource: FactorSource): SpotCheckResponse {
+        throw CommonException.HostInteractionAborted()
     }
 
 }

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/os/interactor/FakeHostInteractor.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/os/interactor/FakeHostInteractor.kt
@@ -38,7 +38,10 @@ class FakeHostInteractor: HostInteractor {
         return AuthorizationResponse.REJECTED
     }
 
-    override suspend fun spotCheck(factorSource: FactorSource): SpotCheckResponse {
+    override suspend fun spotCheck(
+        factorSource: FactorSource,
+        allowSkip: Boolean
+    ): SpotCheckResponse {
         throw CommonException.HostInteractionAborted()
     }
 


### PR DESCRIPTION
## Changelog
- Adds a new `fn perform_spot_check(&self, input: SpotCheckInput) -> bool` implemented by `FactorSourceIDFromHash`, `FactorSource` & `FactorSourceID`. This determines whether the associated id was created with the same `input` than provided.
- Adds a new function on `SargonOS` to trigger a Factor Source spot check. This will use a new host interactor that will be responsible for presenting the corresponding UI for user to perform the check. To do so, it will use the function described on previous point.