### PR TITLE
Main Security Shield updates

### DIFF
--- a/apple/Sources/Sargon/Extensions/Methods/Profile/MFA/SecurityStructureMetadata+Wrap+Functions.swift
+++ b/apple/Sources/Sargon/Extensions/Methods/Profile/MFA/SecurityStructureMetadata+Wrap+Functions.swift
@@ -5,4 +5,8 @@ extension SecurityStructureMetadata {
 	public init(name: DisplayName) {
 		self = newSecurityStructureMetadataNamed(name: name)
 	}
+
+	public var isMain: Bool {
+		securityStructureIsMain(securityStructureMetadata: self)
+	}
 }

--- a/apple/Tests/TestCases/Profile/MFA/SecurityStructureMetadataTests.swift
+++ b/apple/Tests/TestCases/Profile/MFA/SecurityStructureMetadataTests.swift
@@ -9,4 +9,9 @@ final class SecurityStructureMetadataTests: Test<SecurityStructureMetadata> {
 		let sut = SUT(name: "foo")
 		XCTAssertEqual(sut.displayName, "foo")
 	}
+
+	func test_is_main() {
+		var sut = SUT(name: "foo")
+		XCTAssert(sut.isMain)
+	}
 }

--- a/crates/system/os/factors/src/sargon_os_security_structures.rs
+++ b/crates/system/os/factors/src/sargon_os_security_structures.rs
@@ -155,6 +155,17 @@ impl OsSecurityStructuresQuerying for SargonOS {
                 EventProfileModified::SecurityStructureAdded { id },
             ))
             .await;
+
+        if !self
+            .profile()?
+            .app_preferences
+            .security
+            .security_structures_of_factor_source_ids
+            .iter()
+            .any(|s| s.metadata.is_main())
+        {
+            self.set_main_security_structure(id).await?;
+        }
         Ok(())
     }
 
@@ -368,6 +379,35 @@ mod tests {
     }
 
     #[actix_rt::test]
+    async fn add_first_structure_sets_it_as_main() {
+        // ARRANGE
+        let os = SUT::fast_boot().await;
+        os.with_timeout(|x| x.debug_add_all_sample_hd_factor_sources())
+            .await
+            .unwrap();
+
+        // ACT
+        let structure_ids = SecurityStructureOfFactorSourceIDs::sample_other();
+        os.with_timeout(|x| {
+            x.add_security_structure_of_factor_source_ids(&structure_ids)
+        })
+        .await
+        .unwrap();
+
+        // ASSERT
+        let added_structure = os
+            .profile()
+            .unwrap()
+            .app_preferences
+            .security
+            .security_structures_of_factor_source_ids
+            .iter()
+            .find(|s| s.metadata.id == structure_ids.metadata.id)
+            .unwrap();
+        assert!(added_structure.metadata.is_main());
+    }
+
+    #[actix_rt::test]
     async fn when_setting_main_security_structure_with_invalid_id_error_is_thrown(
     ) {
         // ARRANGE
@@ -536,6 +576,13 @@ mod tests {
             .await
             .unwrap();
 
+        let structure_ids_sample = SecurityStructureOfFactorSourceIDs::sample();
+        os.with_timeout(|x| {
+            x.add_security_structure_of_factor_source_ids(&structure_ids_sample)
+        })
+        .await
+        .unwrap();
+
         let structure_ids_sample_other =
             SecurityStructureOfFactorSourceIDs::sample_other();
         os.with_timeout(|x| {
@@ -563,7 +610,10 @@ mod tests {
         assert!(events.iter().any(|e| e.event
             == Event::ProfileModified {
                 change: EventProfileModified::SecurityStructuresUpdated {
-                    ids: vec![structure_ids_sample_other.metadata.id()]
+                    ids: vec![
+                        structure_ids_sample.metadata.id(),
+                        structure_ids_sample_other.metadata.id()
+                    ]
                 }
             }));
     }

--- a/crates/uniffi/uniffi_SPLIT_ME/src/profile/mfa/security_structures/security_structure_metadata.rs
+++ b/crates/uniffi/uniffi_SPLIT_ME/src/profile/mfa/security_structures/security_structure_metadata.rs
@@ -40,3 +40,10 @@ pub fn new_security_structure_metadata_named(
     )
     .into()
 }
+
+#[uniffi::export]
+pub fn security_structure_is_main(
+    security_structure_metadata: &SecurityStructureMetadata,
+) -> bool {
+    security_structure_metadata.into_internal().is_main()
+}

--- a/crates/uniffi/uniffi_SPLIT_ME/src/system/sargon_os/sargon_os_security_structures.rs
+++ b/crates/uniffi/uniffi_SPLIT_ME/src/system/sargon_os/sargon_os_security_structures.rs
@@ -26,6 +26,18 @@ impl SargonOS {
             .into_iter_result()
     }
 
+    /// Returns the `SecurityStructureOfFactorSourceIDs` with the given `shield_id`.
+    pub fn security_structure_of_factor_source_ids_by_security_structure_id(
+        &self,
+        shield_id: SecurityStructureID,
+    ) -> Result<SecurityStructureOfFactorSourceIDs> {
+        self.wrapped
+            .security_structure_of_factor_source_ids_by_security_structure_id(
+                shield_id.into_internal(),
+            )
+            .into_result()
+    }
+
     /// Returns all the `SecurityStructuresOfFactorSourceIDs` which are stored
     /// in profile.
     pub fn security_structure_of_factor_sources_from_security_structure_of_factor_source_ids(

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/SecurityStructureMetadata.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/SecurityStructureMetadata.kt
@@ -1,0 +1,7 @@
+package com.radixdlt.sargon.extensions
+
+import com.radixdlt.sargon.SecurityStructureMetadata
+import com.radixdlt.sargon.extensions.securityStructureIsMain
+
+val SecurityStructureMetadata.isMain
+    get() = securityStructureIsMain(securityStructureMetadata = this)


### PR DESCRIPTION
- When adding a new security shield, set it as `Main` if no main shield exists
- Expose `is_Main` from `SecurityStructureMetadata` to hosts
- Expose `security_structure_of_factor_source_ids_by_security_structure_id` to hosts