### PR TITLE
Determine classification to use in Sargon

### DIFF
--- a/crates/system/os/transaction/src/tx/sargon_os_transaction_analysis.rs
+++ b/crates/system/os/transaction/src/tx/sargon_os_transaction_analysis.rs
@@ -709,7 +709,7 @@ mod transaction_preview_analysis_tests {
                     [ReservedInstruction::AccountLockFee, ReservedInstruction::AccountUpdateOwnerKeysMetadataField],
                     [],
                     [],
-                    [],
+                    None,
                     FeeLocks::default(),
                     FeeSummary::new(0, 0, 0, 0,),
                     NewEntities::default()
@@ -881,7 +881,7 @@ mod transaction_preview_analysis_tests {
                     [],
                     [],
                     [],
-                    [DetailedManifestClass::General],
+                    Some(DetailedManifestClass::General),
                     FeeLocks::default(),
                     FeeSummary::new(0, 0, 0, 0,),
                     NewEntities::default()

--- a/crates/transaction/models/src/low_level/execution_summary/execution_summary.rs
+++ b/crates/transaction/models/src/low_level/execution_summary/execution_summary.rs
@@ -89,7 +89,7 @@ pub struct ExecutionSummary {
 
     /// The various classifications that this manifest matched against. Note
     /// that an empty set means that the manifest is non-conforming.
-    pub detailed_classification: Vec<DetailedManifestClass>,
+    pub detailed_classification: Option<DetailedManifestClass>,
 
     /// List of newly created Non-Fungibles during this transaction.
     pub newly_created_non_fungibles: Vec<NonFungibleGlobalId>,
@@ -134,7 +134,7 @@ impl ExecutionSummary {
         encountered_addresses: impl IntoIterator<
             Item = ManifestEncounteredComponentAddress,
         >,
-        detailed_classification: impl IntoIterator<Item = DetailedManifestClass>,
+        detailed_classification: Option<DetailedManifestClass>,
         fee_locks: impl Into<FeeLocks>,
         fee_summary: impl Into<FeeSummary>,
         new_entities: impl Into<NewEntities>,
@@ -158,9 +158,7 @@ impl ExecutionSummary {
             encountered_addresses: encountered_addresses
                 .into_iter()
                 .collect_vec(),
-            detailed_classification: detailed_classification
-                .into_iter()
-                .collect_vec(),
+            detailed_classification,
             fee_locks: fee_locks.into(),
             fee_summary: fee_summary.into(),
             new_entities: new_entities.into(),
@@ -171,7 +169,7 @@ impl ExecutionSummary {
 impl ExecutionSummary {
     pub fn classify_delete_accounts_if_present(&mut self) {
         // Only try to classify if RET analysis didn't yield any classification
-        if !self.detailed_classification.is_empty() {
+        if self.detailed_classification.is_some() {
             return;
         }
 
@@ -194,11 +192,10 @@ impl ExecutionSummary {
             .collect();
 
         if !deleted_accounts.is_empty() {
-            self.detailed_classification.push(
-                DetailedManifestClass::DeleteAccounts {
+            self.detailed_classification =
+                Some(DetailedManifestClass::DeleteAccounts {
                     account_addresses: deleted_accounts,
-                },
-            );
+                });
         }
     }
 }
@@ -240,6 +237,12 @@ impl From<(RetDynamicAnalysis, NetworkID)> for ExecutionSummary {
             n,
         ));
 
+        let classification = ret
+            .detailed_manifest_classification
+            .into_iter()
+            .filter_map(|d| DetailedManifestClass::new_from(d, n))
+            .find_or_first(|class| !class.is_general());
+
         let mut summary = Self::new(
             addresses_of_accounts_from_ret(
                 ret.account_dynamic_resource_movements_summary
@@ -272,9 +275,7 @@ impl From<(RetDynamicAnalysis, NetworkID)> for ExecutionSummary {
                 ret.entities_encountered_summary.entities,
                 n,
             ),
-            ret.detailed_manifest_classification
-                .into_iter()
-                .map(|d| DetailedManifestClass::from((d, n))),
+            classification,
             ret.fee_locks_summary,
             ret.fee_consumption_summary,
             new_entities,
@@ -314,7 +315,7 @@ impl ExecutionSummary {
                 ManifestEncounteredComponentAddress::sample_component_stokenet(
                 ),
             ],
-            detailed_classification: vec![DetailedManifestClass::sample()],
+            detailed_classification: Some(DetailedManifestClass::sample()),
             fee_locks: FeeLocks::sample(),
             fee_summary: FeeSummary::sample(),
             new_entities: NewEntities::sample(),
@@ -348,7 +349,7 @@ impl HasSampleValues for ExecutionSummary {
             encountered_addresses: vec![
                 ManifestEncounteredComponentAddress::sample(),
             ],
-            detailed_classification: vec![DetailedManifestClass::sample()],
+            detailed_classification: Some(DetailedManifestClass::sample()),
             fee_locks: FeeLocks::sample(),
             fee_summary: FeeSummary::sample(),
             new_entities: NewEntities::sample(),
@@ -384,7 +385,7 @@ impl HasSampleValues for ExecutionSummary {
             encountered_addresses: vec![
                 ManifestEncounteredComponentAddress::sample_other(),
             ],
-            detailed_classification: vec![DetailedManifestClass::sample_other()],
+            detailed_classification: Some(DetailedManifestClass::sample_other()),
             fee_locks: FeeLocks::sample_other(),
             fee_summary: FeeSummary::sample_other(),
             new_entities: NewEntities::sample_other(),

--- a/crates/transaction/models/src/low_level/transaction_classes/detailed_manifest_class.rs
+++ b/crates/transaction/models/src/low_level/transaction_classes/detailed_manifest_class.rs
@@ -13,11 +13,6 @@ pub enum DetailedManifestClass {
     /// will provide.
     General,
 
-    /// A general subintent manifest that has a number of arbitrary package and
-    /// component invocations. This manifest is guaranteed to be subintent since
-    /// we require that a yield to child is present in the manifest.
-    GeneralSubintent,
-
     /// A manifest of a 1-to-1 transfer to a one-to-many transfer of resources.
     Transfer {
         /// When `true`, then this is a one-to-one transfer and the wallet can
@@ -103,9 +98,6 @@ impl DetailedManifestClass {
     pub fn kind(&self) -> DetailedManifestClassKind {
         match self {
             Self::General => DetailedManifestClassKind::General,
-            Self::GeneralSubintent => {
-                DetailedManifestClassKind::GeneralSubintent
-            }
             Self::Transfer { .. } => DetailedManifestClassKind::Transfer,
             Self::ValidatorClaim { .. } => {
                 DetailedManifestClassKind::ValidatorClaim
@@ -149,44 +141,45 @@ impl DetailedManifestClass {
     }
 }
 
-impl From<(RetDetailedManifestClass, NetworkID)> for DetailedManifestClass {
-    fn from(value: (RetDetailedManifestClass, NetworkID)) -> Self {
-        let n = value.1;
-        match value.0 {
-            RetDetailedManifestClass::General => Self::General,
-            RetDetailedManifestClass::GeneralSubintent => {
-                Self::GeneralSubintent
-            }
+impl DetailedManifestClass {
+    pub fn new_from(
+        ret_class: RetDetailedManifestClass,
+        network_id: NetworkID,
+    ) -> Option<Self> {
+        match ret_class {
+            RetDetailedManifestClass::General => Some(Self::General),
 
             RetDetailedManifestClass::Transfer {
                 is_one_to_one_transfer,
-            } => Self::Transfer {
+            } => Some(Self::Transfer {
                 is_one_to_one_transfer,
-            },
+            }),
 
             RetDetailedManifestClass::PoolContribution(output) => {
-                Self::from((output, n))
+                Some(Self::from((output, network_id)))
             }
 
             RetDetailedManifestClass::PoolRedemption(output) => {
-                Self::from((output, n))
+                Some(Self::from((output, network_id)))
             }
 
             RetDetailedManifestClass::ValidatorStake(output) => {
-                Self::from((output, n))
+                Some(Self::from((output, network_id)))
             }
 
             RetDetailedManifestClass::ValidatorUnstake(output) => {
-                Self::from((output, n))
+                Some(Self::from((output, network_id)))
             }
 
             RetDetailedManifestClass::ValidatorClaimXrd(output) => {
-                Self::from((output, n))
+                Some(Self::from((output, network_id)))
             }
 
             RetDetailedManifestClass::AccountDepositSettingsUpdate(output) => {
-                Self::from((output, n))
+                Some(Self::from((output, network_id)))
             }
+
+            RetDetailedManifestClass::GeneralSubintent => None,
         }
     }
 }

--- a/crates/transaction/models/src/low_level/transaction_classes/detailed_manifest_class_kind.rs
+++ b/crates/transaction/models/src/low_level/transaction_classes/detailed_manifest_class_kind.rs
@@ -8,9 +8,6 @@ pub enum DetailedManifestClassKind {
     #[display("General")]
     General,
 
-    #[display("GeneralSubintent")]
-    GeneralSubintent,
-
     #[display("Transfer")]
     Transfer,
 

--- a/crates/transaction/models/src/low_level/v1/transaction_manifest/execution_summary/transaction_manifest_execution_summary.rs
+++ b/crates/transaction/models/src/low_level/v1/transaction_manifest/execution_summary/transaction_manifest_execution_summary.rs
@@ -148,12 +148,11 @@ mod tests {
                 [],
                 [],
                 [],
-                [
-                    DetailedManifestClass::General,
+                Some(
                     DetailedManifestClass::Transfer {
                         is_one_to_one_transfer: false
-                    },
-                ],
+                    }
+                ),
                 FeeLocks::default(),
                 FeeSummary::new(
                     "0.37765305".parse::<Decimal>().unwrap(),
@@ -194,7 +193,7 @@ mod tests {
                 [],
                 [],               // presented_proofs
                 [],               // encountered_component_addresses
-                [
+                Some(
                     DetailedManifestClass::AccountDepositSettingsUpdate {
                         resource_preferences_updates: HashMap::<
                             AccountAddress,
@@ -214,7 +213,7 @@ mod tests {
                         authorized_depositors_added: HashMap::new(),
                         authorized_depositors_removed: HashMap::new(),
                     }
-                ],
+                ),
                 FeeLocks::default(),
                 FeeSummary::new(
                     "0.07638415".parse::<Decimal>().unwrap(),
@@ -262,7 +261,7 @@ mod tests {
                 [], // reserved_instructions
                 [], // presented_proofs
                 [], // encountered_component_addresses
-                [DetailedManifestClass::General],
+                Some(DetailedManifestClass::General),
                 FeeLocks::default(),
                 FeeSummary::new(
                     "0.1585925".parse::<Decimal>().unwrap(),
@@ -339,9 +338,7 @@ mod tests {
                     [], // reserved_instructions
                     [], // presented_proofs
                     [], // encountered_component_addresses
-                    [
-                        DetailedManifestClass::General
-                    ],
+                    Some(DetailedManifestClass::General),
                     FeeLocks::default(),
                     FeeSummary::new(
                         "0.18451315".parse::<Decimal>().unwrap(),
@@ -408,9 +405,7 @@ mod tests {
                 [], // reserved_instructions
                 [], // presented_proofs
                 ["component_tdx_2_1cpd3cgy9kaxvxlptkkgxkm3qvfyqkrsl03kyz532p7e2gk0ygs4xrd".parse::<ManifestEncounteredComponentAddress>().unwrap()], // encountered_component_addresses
-                [
-                    DetailedManifestClass::General
-                ],
+                Some(DetailedManifestClass::General),
                 FeeLocks::default(),
                 FeeSummary::new(
                     "0.3737913".parse::<Decimal>().unwrap(),
@@ -471,9 +466,7 @@ mod tests {
                     [], // reserved_instructions
                     [ResourceSpecifier::non_fungible("resource_tdx_2_1nfmxggm4plrrmc9ft9qn79g7uehqlhjaszv02dnuk85s0h9xnh3xue".parse::<ResourceAddress>().unwrap(), vec!["<Member_83>".parse().unwrap()])], // presented_proofs
                     ["component_tdx_2_1cr4pa9ex9xhwzfjzclv8vjnfylw93wvhkwcwc0xlahpkel0krxqedw".parse::<ManifestEncounteredComponentAddress>().unwrap()], // encountered_component_addresses
-                    [
-                        DetailedManifestClass::General
-                    ],
+                    Some(DetailedManifestClass::General),
                     FeeLocks::default(),
                     FeeSummary::new(
                         "0.4943021".parse::<Decimal>().unwrap(),
@@ -512,7 +505,7 @@ mod tests {
                 [], // reserved_instructions
                 [], // presented_proofs
                 [], // encountered_component_addresses
-                [DetailedManifestClass::General],
+                Some(DetailedManifestClass::General),
                 FeeLocks::default(),
                 FeeSummary::new("0.15184175".parse::<Decimal>().unwrap(), "0.1607719".parse::<Decimal>().unwrap(), "0.33388137243".parse::<Decimal>().unwrap(), 0,),
                 NewEntities::new([
@@ -571,27 +564,24 @@ mod tests {
                 [],       // reserved_instructions
                 [],       // presented_proofs
                 [],       // encountered_component_addresses
-                [
-                    DetailedManifestClass::General,
-                    DetailedManifestClass::PoolContribution {
-                        pool_addresses: vec![pool_address],
-                        pool_contributions: vec![TrackedPoolContribution::new(
-                            pool_address,
-                            [
-                                (
-                                    star_resource_address,
-                                    "100".parse::<Decimal>().unwrap()
-                                ),
-                                (
-                                    ResourceAddress::sample_stokenet_xrd(),
-                                    "100".parse::<Decimal>().unwrap()
-                                ),
-                            ],
-                            pool_unit_resource_address,
-                            100,
-                        )]
-                    }
-                ],
+                Some(DetailedManifestClass::PoolContribution {
+                    pool_addresses: vec![pool_address],
+                    pool_contributions: vec![TrackedPoolContribution::new(
+                        pool_address,
+                        [
+                            (
+                                star_resource_address,
+                                "100".parse::<Decimal>().unwrap()
+                            ),
+                            (
+                                ResourceAddress::sample_stokenet_xrd(),
+                                "100".parse::<Decimal>().unwrap()
+                            ),
+                        ],
+                        pool_unit_resource_address,
+                        100,
+                    )]
+                }),
                 FeeLocks::default(),
                 FeeSummary::new(
                     "0.27887505".parse::<Decimal>().unwrap(),
@@ -663,36 +653,33 @@ mod tests {
                 [],       // reserved_instructions
                 [],       // presented_proofs
                 [],       // encountered_component_addresses
-                [
-                    DetailedManifestClass::General,
-                    DetailedManifestClass::ValidatorStake {
-                        validator_addresses: vec![
+                Some(DetailedManifestClass::ValidatorStake {
+                    validator_addresses: vec![
+                        validator_0,
+                        validator_1,
+                        validator_2
+                    ],
+                    validator_stakes: vec![
+                        TrackedValidatorStake::new(
                             validator_0,
+                            1000,
+                            validator_0_resource_address_of_stake,
+                            1000,
+                        ),
+                        TrackedValidatorStake::new(
                             validator_1,
-                            validator_2
-                        ],
-                        validator_stakes: vec![
-                            TrackedValidatorStake::new(
-                                validator_0,
-                                1000,
-                                validator_0_resource_address_of_stake,
-                                1000,
-                            ),
-                            TrackedValidatorStake::new(
-                                validator_1,
-                                1000,
-                                validator_1_resource_address_of_stake,
-                                1000,
-                            ),
-                            TrackedValidatorStake::new(
-                                validator_2,
-                                1000,
-                                validator_2_resource_address_of_stake,
-                                1000,
-                            ),
-                        ]
-                    }
-                ],
+                            1000,
+                            validator_1_resource_address_of_stake,
+                            1000,
+                        ),
+                        TrackedValidatorStake::new(
+                            validator_2,
+                            1000,
+                            validator_2_resource_address_of_stake,
+                            1000,
+                        ),
+                    ]
+                }),
                 FeeLocks::default(),
                 FeeSummary::new(
                     "0.3527215".parse::<Decimal>().unwrap(),
@@ -784,8 +771,7 @@ mod tests {
 
         pretty_assertions::assert_eq!(
             sut.detailed_classification,
-            vec![
-                DetailedManifestClass::General,
+            Some(
                 DetailedManifestClass::PoolRedemption {
                     pool_addresses: vec![pool_address],
                     pool_redemptions: vec![
@@ -806,7 +792,7 @@ mod tests {
                         )
                     ]
                 }
-            ]
+            )
         );
 
         pretty_assertions::assert_eq!(sut.fee_locks, FeeLocks::default());
@@ -873,16 +859,13 @@ mod tests {
                 [], // reserved_instructions
                 [], // presented_proofs
                 [], // encountered_component_addresses
-                [
-                    DetailedManifestClass::General,
-                    DetailedManifestClass::ValidatorUnstake {
-                        validator_addresses: vec![validator_address],
-                        claims_non_fungible_data: HashMap::from([(
-                            nf_global_id,
-                            UnstakeData::new("Stake Claim", 37923, 500)
-                        )]),
-                    }
-                ],
+                Some(DetailedManifestClass::ValidatorUnstake {
+                    validator_addresses: vec![validator_address],
+                    claims_non_fungible_data: HashMap::from([(
+                        nf_global_id,
+                        UnstakeData::new("Stake Claim", 37923, 500)
+                    )]),
+                }),
                 FeeLocks::default(),
                 FeeSummary::new(
                     "0.2848875".parse::<Decimal>().unwrap(),
@@ -944,18 +927,15 @@ mod tests {
                 [],       // reserved_instructions
                 [],       // presented_proofs
                 [],       // encountered_component_addresses
-                [
-                    DetailedManifestClass::General,
-                    DetailedManifestClass::ValidatorClaim {
-                        validator_addresses: vec![validator_address],
-                        validator_claims: vec![TrackedValidatorClaim::new(
-                            validator_address,
-                            claim_nft_resource_address,
-                            [nf_id_1, nf_id_2],
-                            150
-                        )]
-                    }
-                ],
+                Some(DetailedManifestClass::ValidatorClaim {
+                    validator_addresses: vec![validator_address],
+                    validator_claims: vec![TrackedValidatorClaim::new(
+                        validator_address,
+                        claim_nft_resource_address,
+                        [nf_id_1, nf_id_2],
+                        150
+                    )]
+                }),
                 FeeLocks::default(),
                 FeeSummary::new(
                     "0.2383276".parse::<Decimal>().unwrap(),
@@ -1016,7 +996,7 @@ mod tests {
                 [], // reserved_instructions
                 [], // presented_proofs
                 ["locker_tdx_2_1dr6v4fwufgacxqwxsm44ysglhdv7yyxgvq6xazcwzvu35937wzsjnx".parse::<ManifestEncounteredComponentAddress>().unwrap()],
-                [DetailedManifestClass::General],
+                Some(DetailedManifestClass::General),
                 FeeLocks::default(),
                 FeeSummary::new("0.2516311".parse::<Decimal>().unwrap(), "0.03200635".parse::<Decimal>().unwrap(), "0.12903213279".parse::<Decimal>().unwrap(), 0,),
                 NewEntities::default()
@@ -1068,9 +1048,9 @@ mod tests {
             [ReservedInstruction::AccountSecurify], // reserved_instructions
             [],        // presented_proofs
             [],
-            [DetailedManifestClass::DeleteAccounts {
+            Some(DetailedManifestClass::DeleteAccounts {
                 account_addresses: vec![acc],
-            }],
+            }),
             FeeLocks::default(),
             FeeSummary::new(
                 "0.21017315".parse::<Decimal>().unwrap(),

--- a/crates/uniffi/uniffi_SPLIT_ME/src/wrapped_radix_engine_toolkit/low_level/execution_summary/execution_summary.rs
+++ b/crates/uniffi/uniffi_SPLIT_ME/src/wrapped_radix_engine_toolkit/low_level/execution_summary/execution_summary.rs
@@ -28,7 +28,7 @@ pub struct ExecutionSummary {
 
     /// The various classifications that this manifest matched against. Note
     /// that an empty set means that the manifest is non-conforming.
-    pub detailed_classification: Vec<DetailedManifestClass>,
+    pub detailed_classification: Option<DetailedManifestClass>,
 
     /// List of newly created Non-Fungibles during this transaction.
     pub newly_created_non_fungibles: Vec<NonFungibleGlobalId>,

--- a/crates/uniffi/uniffi_SPLIT_ME/src/wrapped_radix_engine_toolkit/low_level/transaction_classes/detailed_manifest_class.rs
+++ b/crates/uniffi/uniffi_SPLIT_ME/src/wrapped_radix_engine_toolkit/low_level/transaction_classes/detailed_manifest_class.rs
@@ -14,11 +14,6 @@ pub enum DetailedManifestClass {
     /// will provide.
     General,
 
-    /// A general subintent manifest that has a number of arbitrary package and
-    /// component invocations. This manifest is guaranteed to be subintent since
-    /// we require that a yield to child is present in the manifest.
-    GeneralSubintent,
-
     /// A manifest of a 1-to-1 transfer to a one-to-many transfer of resources.
     Transfer {
         /// When `true`, then this is a one-to-one transfer and the wallet can

--- a/crates/uniffi/uniffi_SPLIT_ME/src/wrapped_radix_engine_toolkit/low_level/transaction_classes/detailed_manifest_class_kind.rs
+++ b/crates/uniffi/uniffi_SPLIT_ME/src/wrapped_radix_engine_toolkit/low_level/transaction_classes/detailed_manifest_class_kind.rs
@@ -5,7 +5,6 @@ use sargon::DetailedManifestClassKind as InternalDetailedManifestClassKind;
 #[derive(Clone, PartialEq, Eq, InternalConversion, uniffi::Enum)]
 pub enum DetailedManifestClassKind {
     General,
-    GeneralSubintent,
     Transfer,
     ValidatorClaim,
     ValidatorStake,


### PR DESCRIPTION
We were exposing a list of classification and hosts had to pick the most relevant one, [android](https://github.com/radixdlt/babylon-wallet-android/blob/96aa26209c9f16b829bce1f60f1711c87cbe1c1f/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/summary/execution/ExecutionSummaryToPreviewTypeAnalyser.kt#L25) [ios](https://github.com/radixdlt/babylon-wallet-ios/blob/644c50c6915af49e11d64f5f8d2ba6ce67bfb2c6/RadixWallet/Core/SargonExtensions/ExecutionSummary%2BExtensions.swift#L4). Instead Sargon now tells Host directly the classification that needs to be used.

Additionally, ignored the GeneralSubintent for ExecutionSummary, it is exposed from RET for implementation reasons and not for functionality. 