### PR TITLE
[ABW-4158][ABW-4159] Add spot check to Create Entity & Apply Shield flows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "account-for-display"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "addresses",
  "derive_more",
@@ -49,10 +49,10 @@ dependencies = [
 
 [[package]]
 name = "addresses"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "assert-json",
- "bytes 1.2.0",
+ "bytes 1.2.1",
  "cap26-models",
  "core-utils",
  "derive_more",
@@ -246,7 +246,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "assert-json"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "assert-json-diff",
  "error",
@@ -546,7 +546,7 @@ dependencies = [
 
 [[package]]
 name = "build-info"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "assert-json",
  "cargo_toml",
@@ -573,7 +573,7 @@ checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
 
 [[package]]
 name = "bytes"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "assert-json",
  "delegate",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "cap26-models"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "assert-json",
  "derive_more",
@@ -748,7 +748,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "clients"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -808,7 +808,7 @@ checksum = "0d8a42181e0652c2997ae4d217f25b63c5337a52fd2279736e97b832fa0a3cff"
 
 [[package]]
 name = "core-collections"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "has-sample-values",
  "indexmap 2.7.0",
@@ -835,7 +835,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-misc"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "assert-json",
  "core-utils",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "core-utils"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "error",
  "iso8601-timestamp",
@@ -1084,7 +1084,7 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "drivers"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -1108,10 +1108,10 @@ dependencies = [
 
 [[package]]
 name = "ecc"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "assert-json",
- "bytes 1.2.0",
+ "bytes 1.2.1",
  "derive_more",
  "enum-as-inner",
  "error",
@@ -1210,11 +1210,11 @@ dependencies = [
 
 [[package]]
 name = "encryption"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aes-gcm",
  "assert-json",
- "bytes 1.2.0",
+ "bytes 1.2.1",
  "derive_more",
  "error",
  "has-sample-values",
@@ -1231,7 +1231,7 @@ dependencies = [
 
 [[package]]
 name = "entity-by-address"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "addresses",
  "error",
@@ -1243,7 +1243,7 @@ dependencies = [
 
 [[package]]
 name = "entity-foundation"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "assert-json",
  "derive_more",
@@ -1318,7 +1318,7 @@ dependencies = [
 
 [[package]]
 name = "error"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "derive_more",
  "log",
@@ -1377,7 +1377,7 @@ dependencies = [
 
 [[package]]
 name = "factor-instances-provider"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -1403,9 +1403,9 @@ dependencies = [
 
 [[package]]
 name = "factors"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
- "bytes 1.2.0",
+ "bytes 1.2.1",
  "cap26-models",
  "core-collections",
  "core-misc",
@@ -1440,7 +1440,7 @@ dependencies = [
 
 [[package]]
 name = "factors-supporting-types"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "error",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-client-and-api"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -1615,7 +1615,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-models"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "addresses",
  "assert-json",
@@ -1720,7 +1720,7 @@ dependencies = [
 
 [[package]]
 name = "has-sample-values"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "error",
  "indexmap 2.7.0",
@@ -1731,9 +1731,9 @@ dependencies = [
 
 [[package]]
 name = "hash"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
- "bytes 1.2.0",
+ "bytes 1.2.1",
  "derive_more",
  "prelude",
  "radix-common",
@@ -1797,11 +1797,11 @@ dependencies = [
 
 [[package]]
 name = "hierarchical-deterministic"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "assert-json",
  "bip39",
- "bytes 1.2.0",
+ "bytes 1.2.1",
  "cap26-models",
  "derive_more",
  "ecc",
@@ -1844,13 +1844,13 @@ dependencies = [
 
 [[package]]
 name = "home-cards"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "actix-rt",
  "addresses",
  "async-trait",
  "base64",
- "bytes 1.2.0",
+ "bytes 1.2.1",
  "core-utils",
  "derive_more",
  "drivers",
@@ -1870,7 +1870,7 @@ dependencies = [
 
 [[package]]
 name = "host-info"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "assert-json",
  "derive_more",
@@ -1917,10 +1917,10 @@ dependencies = [
 
 [[package]]
 name = "http-client"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "actix-rt",
- "bytes 1.2.0",
+ "bytes 1.2.1",
  "core-utils",
  "drivers",
  "error",
@@ -2145,7 +2145,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "identified-vec-of"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "assert-json",
  "derive_more",
@@ -2218,7 +2218,7 @@ dependencies = [
 
 [[package]]
 name = "interactors"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -2347,7 +2347,7 @@ dependencies = [
 
 [[package]]
 name = "key-derivation-traits"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "addresses",
  "async-trait",
@@ -2365,7 +2365,7 @@ dependencies = [
 
 [[package]]
 name = "keys-collector"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -2454,7 +2454,7 @@ dependencies = [
 
 [[package]]
 name = "manifests"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "account-for-display",
  "addresses",
@@ -2496,7 +2496,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "metadata"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "derive_more",
  "has-sample-values",
@@ -2596,7 +2596,7 @@ dependencies = [
 
 [[package]]
 name = "network"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "assert-json",
  "enum-iterator",
@@ -2612,7 +2612,7 @@ dependencies = [
 
 [[package]]
 name = "next-derivation-index-ephemeral"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "addresses",
  "assert-json",
@@ -2688,9 +2688,9 @@ dependencies = [
 
 [[package]]
 name = "numeric"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
- "bytes 1.2.0",
+ "bytes 1.2.1",
  "delegate",
  "derive_more",
  "enum-iterator",
@@ -2910,7 +2910,7 @@ dependencies = [
 
 [[package]]
 name = "prelude"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "radix-engine",
  "radix-engine-toolkit",
@@ -2947,7 +2947,7 @@ dependencies = [
 
 [[package]]
 name = "profile"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "account-for-display",
  "addresses",
@@ -2991,7 +2991,7 @@ dependencies = [
 
 [[package]]
 name = "profile-account"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "account-for-display",
  "addresses",
@@ -3011,7 +3011,7 @@ dependencies = [
 
 [[package]]
 name = "profile-account-or-persona"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cap26-models",
  "derive_more",
@@ -3028,7 +3028,7 @@ dependencies = [
 
 [[package]]
 name = "profile-app-preferences"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "addresses",
  "core-misc",
@@ -3051,7 +3051,7 @@ dependencies = [
 
 [[package]]
 name = "profile-base-entity"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "addresses",
  "derive_more",
@@ -3074,7 +3074,7 @@ dependencies = [
 
 [[package]]
 name = "profile-gateway"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "addresses",
  "assert-json",
@@ -3098,7 +3098,7 @@ dependencies = [
 
 [[package]]
 name = "profile-logic"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "addresses",
  "derive_more",
@@ -3120,7 +3120,7 @@ dependencies = [
 
 [[package]]
 name = "profile-persona"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "addresses",
  "cap26-models",
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "profile-persona-data"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "addresses",
  "assert-json",
@@ -3160,7 +3160,7 @@ dependencies = [
 
 [[package]]
 name = "profile-security-structures"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "addresses",
  "cap26-models",
@@ -3188,7 +3188,7 @@ dependencies = [
 
 [[package]]
 name = "profile-state-holder"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "derive_more",
  "error",
@@ -3203,7 +3203,7 @@ dependencies = [
 
 [[package]]
 name = "profile-supporting-types"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "addresses",
  "derive_more",
@@ -3292,14 +3292,14 @@ dependencies = [
 
 [[package]]
 name = "radix-connect"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "actix-rt",
  "addresses",
  "assert-json",
  "async-trait",
  "base64",
- "bytes 1.2.0",
+ "bytes 1.2.1",
  "core-misc",
  "core-utils",
  "derive_more",
@@ -3328,10 +3328,10 @@ dependencies = [
 
 [[package]]
 name = "radix-connect-models"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "addresses",
- "bytes 1.2.0",
+ "bytes 1.2.1",
  "core-misc",
  "derive_more",
  "error",
@@ -3773,7 +3773,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -3838,7 +3838,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -3865,7 +3865,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-accounts"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -3891,7 +3891,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-derive-public-keys"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -3910,7 +3910,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-factors"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -3943,7 +3943,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-security-center"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "actix-rt",
  "derive_more",
@@ -3959,7 +3959,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-signing"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -3985,7 +3985,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-transaction"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "actix-rt",
  "async-std",
@@ -4020,7 +4020,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-uniffi"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -4077,7 +4077,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-uniffi-conversion-macros"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4250,7 +4250,7 @@ dependencies = [
 
 [[package]]
 name = "security-center"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "addresses",
  "assert-json",
@@ -4418,7 +4418,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "short-string"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "arraystring",
  "assert-json",
@@ -4453,13 +4453,13 @@ dependencies = [
 
 [[package]]
 name = "signatures-collector"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "actix-rt",
  "addresses",
  "assert-json",
  "async-trait",
- "bytes 1.2.0",
+ "bytes 1.2.1",
  "cap26-models",
  "core-collections",
  "core-misc",
@@ -4491,10 +4491,10 @@ dependencies = [
 
 [[package]]
 name = "signing-traits"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
- "bytes 1.2.0",
+ "bytes 1.2.1",
  "core-collections",
  "derive_more",
  "ecc",
@@ -4659,7 +4659,7 @@ dependencies = [
 
 [[package]]
 name = "sub-systems"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "derive_more",
  "drivers",
@@ -4818,7 +4818,7 @@ dependencies = [
 
 [[package]]
 name = "time-utils"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "iso8601-timestamp",
  "prelude",
@@ -4968,10 +4968,10 @@ dependencies = [
 
 [[package]]
 name = "transaction-foundation"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "assert-json",
- "bytes 1.2.0",
+ "bytes 1.2.1",
  "derive_more",
  "has-sample-values",
  "paste",
@@ -4983,10 +4983,10 @@ dependencies = [
 
 [[package]]
 name = "transaction-models"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "addresses",
- "bytes 1.2.0",
+ "bytes 1.2.1",
  "cargo_toml",
  "core-collections",
  "core-misc",

--- a/apple/Sources/Sargon/Extensions/Methods/Crypto/Derivation/MnemonicWithPassphrase+Wrap+Functions.swift
+++ b/apple/Sources/Sargon/Extensions/Methods/Crypto/Derivation/MnemonicWithPassphrase+Wrap+Functions.swift
@@ -36,6 +36,15 @@ extension MnemonicWithPassphrase {
 		)
 	}
 
+	public func derivePublicKeys(
+		paths: some Collection<some DerivationPathProtocol>,
+		factorSourceId: FactorSourceIDFromHash
+	) -> [HierarchicalDeterministicFactorInstance] {
+		derivePublicKeys(paths: paths).map {
+			.init(factorSourceId: factorSourceId, publicKey: $0)
+		}
+	}
+
 	public func sign(
 		hash: Hash,
 		path: some DerivationPathProtocol

--- a/apple/Tests/TestCases/Crypto/BIP39/MnemonicWithPassphraseTests.swift
+++ b/apple/Tests/TestCases/Crypto/BIP39/MnemonicWithPassphraseTests.swift
@@ -35,6 +35,13 @@ final class MnemonicWithPassphraseTests: Test<MnemonicWithPassphrase> {
 		XCTAssertEqual(SUT.sample.derivePublicKeys(paths: [DerivationPath.sample]), [HierarchicalDeterministicPublicKey.sample])
 	}
 
+	func test_derive_public_keys_factor_instances() {
+		XCTAssertEqual(
+			SUT.sample.derivePublicKeys(paths: [DerivationPath.sample], factorSourceId: FactorSourceIDFromHash.sample),
+			[HierarchicalDeterministicFactorInstance.sample]
+		)
+	}
+
 	func test_validate() {
 		XCTAssertTrue(SUT.sample.validate(publicKeys: [HierarchicalDeterministicPublicKey.sample]))
 		XCTAssertFalse(SUT.sampleOther.validate(publicKeys: [HierarchicalDeterministicPublicKey.sample]))

--- a/crates/app/home-cards/Cargo.toml
+++ b/crates/app/home-cards/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "home-cards"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/key-derivation-traits/Cargo.toml
+++ b/crates/app/key-derivation-traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "key-derivation-traits"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/radix-connect-models/Cargo.toml
+++ b/crates/app/radix-connect-models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "radix-connect-models"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/radix-connect/Cargo.toml
+++ b/crates/app/radix-connect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "radix-connect"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 

--- a/crates/app/security-center/Cargo.toml
+++ b/crates/app/security-center/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "security-center"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/signing-traits/Cargo.toml
+++ b/crates/app/signing-traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signing-traits"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/build-info/Cargo.toml
+++ b/crates/common/build-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "build-info"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/common/bytes/Cargo.toml
+++ b/crates/common/bytes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bytes"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/entity-foundation/Cargo.toml
+++ b/crates/common/entity-foundation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entity-foundation"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/host-info/Cargo.toml
+++ b/crates/common/host-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "host-info"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/identified-vec-of/Cargo.toml
+++ b/crates/common/identified-vec-of/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "identified-vec-of"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/metadata/Cargo.toml
+++ b/crates/common/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metadata"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/network/Cargo.toml
+++ b/crates/common/network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "network"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/numeric/Cargo.toml
+++ b/crates/common/numeric/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numeric"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/short-string/Cargo.toml
+++ b/crates/common/short-string/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "short-string"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/assert-json/Cargo.toml
+++ b/crates/core/assert-json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assert-json"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/collections/Cargo.toml
+++ b/crates/core/collections/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-collections"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/error/Cargo.toml
+++ b/crates/core/error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "error"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/has-sample-values/Cargo.toml
+++ b/crates/core/has-sample-values/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "has-sample-values"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/misc/Cargo.toml
+++ b/crates/core/misc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-misc"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/prelude/Cargo.toml
+++ b/crates/core/prelude/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prelude"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/time-utils/Cargo.toml
+++ b/crates/core/time-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "time-utils"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/utils/Cargo.toml
+++ b/crates/core/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-utils"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/addresses/Cargo.toml
+++ b/crates/crypto/addresses/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "addresses"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/cap26-models/Cargo.toml
+++ b/crates/crypto/cap26-models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cap26-models"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/ecc/Cargo.toml
+++ b/crates/crypto/ecc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecc"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/encryption/Cargo.toml
+++ b/crates/crypto/encryption/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "encryption"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/hash/Cargo.toml
+++ b/crates/crypto/hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hash"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/hd/Cargo.toml
+++ b/crates/crypto/hd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hierarchical-deterministic"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/factors/Cargo.toml
+++ b/crates/factors/factors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factors"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/instances-provider/Cargo.toml
+++ b/crates/factors/instances-provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factor-instances-provider"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/keys-collector/Cargo.toml
+++ b/crates/factors/keys-collector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keys-collector"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/next-derivation-index-ephemeral/Cargo.toml
+++ b/crates/factors/next-derivation-index-ephemeral/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "next-derivation-index-ephemeral"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/next-derivation-index-ephemeral/src/agnostic_paths/derivation_preset.rs
+++ b/crates/factors/next-derivation-index-ephemeral/src/agnostic_paths/derivation_preset.rs
@@ -43,7 +43,7 @@ pub enum DerivationPreset {
     IdentityMfa,
 
     /// Used to form DerivationPaths used to derive FactorInstances
-    /// for Authentication Signing (Securified) for peresonas
+    /// for Authentication Signing (Securified) for personas
     /// `(EntityKind::Identity, KeySpace::Securified, KeyKind::AuthenticationSigning)`
     #[debug("I-Rola")]
     IdentityRola,

--- a/crates/factors/signatures-collector/Cargo.toml
+++ b/crates/factors/signatures-collector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signatures-collector"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 

--- a/crates/factors/supporting-types/Cargo.toml
+++ b/crates/factors/supporting-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factors-supporting-types"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/gateway/client-and-api/Cargo.toml
+++ b/crates/gateway/client-and-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gateway-client-and-api"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/gateway/models/Cargo.toml
+++ b/crates/gateway/models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gateway-models"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 

--- a/crates/profile/logic/logic_SPLIT_ME/Cargo.toml
+++ b/crates/profile/logic/logic_SPLIT_ME/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-logic"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/account-for-display/Cargo.toml
+++ b/crates/profile/models/account-for-display/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "account-for-display"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/account-or-persona/Cargo.toml
+++ b/crates/profile/models/account-or-persona/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-account-or-persona"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/account/Cargo.toml
+++ b/crates/profile/models/account/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-account"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/app-preferences/Cargo.toml
+++ b/crates/profile/models/app-preferences/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-app-preferences"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/base-entity/Cargo.toml
+++ b/crates/profile/models/base-entity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-base-entity"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/gateway/Cargo.toml
+++ b/crates/profile/models/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-gateway"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/persona-data/Cargo.toml
+++ b/crates/profile/models/persona-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-persona-data"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/persona/Cargo.toml
+++ b/crates/profile/models/persona/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-persona"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/profile_SPLIT_ME/Cargo.toml
+++ b/crates/profile/models/profile_SPLIT_ME/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 

--- a/crates/profile/models/security-structures/Cargo.toml
+++ b/crates/profile/models/security-structures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-security-structures"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/supporting-types/Cargo.toml
+++ b/crates/profile/models/supporting-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-supporting-types"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/traits/entity-by-address/Cargo.toml
+++ b/crates/profile/traits/entity-by-address/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entity-by-address"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/sargon/Cargo.toml
+++ b/crates/sargon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 resolver = "2" # features enabled in integration test

--- a/crates/system/clients/clients/Cargo.toml
+++ b/crates/system/clients/clients/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clients"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 

--- a/crates/system/clients/clients/src/clients/client/factor_instances_cache_client/cache/factor_instances_cache.rs
+++ b/crates/system/clients/clients/src/clients/client/factor_instances_cache_client/cache/factor_instances_cache.rs
@@ -560,14 +560,13 @@ impl FactorInstancesCache {
             QuantifiedDerivationPreset,
         >,
     ) -> bool {
-        let Ok(outcome) = self.get(
+        self.get(
             &IndexSet::just(factor_source_id),
             quantified_derivation_presets,
             network_id,
-        ) else {
-            return false;
-        };
-        outcome.is_satisfied()
+        )
+        .ok()
+        .map_or_else(|| false, |outcome| outcome.is_satisfied())
     }
 
     /// Queries if the cache is satisfied for creating an entity with a `factor_source_id`.

--- a/crates/system/clients/clients/src/clients/client/factor_instances_cache_client/cache/factor_instances_cache.rs
+++ b/crates/system/clients/clients/src/clients/client/factor_instances_cache_client/cache/factor_instances_cache.rs
@@ -1087,8 +1087,7 @@ mod tests {
     }
 }
 
-// #[cfg(test)]
-
+#[cfg(debug_assertions)]
 impl FactorInstancesCache {
     /// Creates a new `FactorInstancesCache` with the given instances for the given `factor_source_id`.
     #[allow(clippy::too_many_arguments)]

--- a/crates/system/clients/clients/src/clients/client/factor_instances_cache_client/cache/factor_instances_cache.rs
+++ b/crates/system/clients/clients/src/clients/client/factor_instances_cache_client/cache/factor_instances_cache.rs
@@ -1012,49 +1012,9 @@ mod tests {
         // Create a cache which has the following instances for factor source `fs`:
         // - AccountVeci: 1
         // - AccountMfa: 2
-        let sut = SUT::default();
+        // - IdentityRola: 3
         let fs = FactorSourceIDFromHash::sample_at(0);
-
-        let av_fi_0 = HierarchicalDeterministicFactorInstance::new_for_entity(
-            fs,
-            CAP26EntityKind::Account,
-            Hardened::from_local_key_space_unsecurified(0u32).unwrap(),
-        );
-        let am_fi_0 = HierarchicalDeterministicFactorInstance::new_for_entity(
-            fs,
-            CAP26EntityKind::Account,
-            Hardened::from_local_key_space(0u32, IsSecurified(true)).unwrap(),
-        );
-        let am_fi_1 = HierarchicalDeterministicFactorInstance::new_for_entity(
-            fs,
-            CAP26EntityKind::Account,
-            Hardened::from_local_key_space(1u32, IsSecurified(true)).unwrap(),
-        );
-
-        HierarchicalDeterministicFactorInstance::new_for_entity(
-            fs,
-            CAP26EntityKind::Account,
-            Hardened::from_local_key_space(1u32, IsSecurified(true)).unwrap(),
-        );
-
-        let instances: InstancesPerDerivationPresetPerFactorSource =
-            IndexMap::from_iter([
-                (
-                    DerivationPreset::AccountVeci,
-                    IndexMap::from_iter([(
-                        fs,
-                        FactorInstances::from_iter([av_fi_0]),
-                    )]),
-                ),
-                (
-                    DerivationPreset::AccountMfa,
-                    IndexMap::from_iter([(
-                        fs,
-                        FactorInstances::from_iter([am_fi_0, am_fi_1]),
-                    )]),
-                ),
-            ]);
-        sut.insert(&instances).unwrap();
+        let sut = SUT::build_with_instances(fs, 1, 2, 0, 0, 0, 3);
 
         // Test that cache is satisfied for Account entity creation
         let result = sut.is_entity_creation_satisfied(
@@ -1078,6 +1038,17 @@ mod tests {
                     2,
                 ),
             ]),
+        );
+        assert!(result);
+
+        // Test that cache is satisfied for 3 IdentityRola
+        let result = sut.is_satisfied(
+            NetworkID::Mainnet,
+            fs,
+            &IdentifiedVecOf::from_iter([QuantifiedDerivationPreset::new(
+                DerivationPreset::IdentityRola,
+                3,
+            )]),
         );
         assert!(result);
 
@@ -1113,5 +1084,176 @@ mod tests {
             )]),
         );
         assert!(!result);
+    }
+}
+
+// #[cfg(test)]
+
+impl FactorInstancesCache {
+    /// Creates a new `FactorInstancesCache` with the given instances for the given `factor_source_id`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn build_with_instances(
+        factor_source_id: FactorSourceIDFromHash,
+        account_veci_count: usize,
+        account_mfa_count: usize,
+        account_rola_count: usize,
+        identity_veci_count: usize,
+        identity_mfa_count: usize,
+        identity_rola_count: usize,
+    ) -> Self {
+        let sut = Self::default();
+        sut.add_instances(
+            factor_source_id,
+            account_veci_count,
+            account_mfa_count,
+            account_rola_count,
+            identity_veci_count,
+            identity_mfa_count,
+            identity_rola_count,
+        );
+        sut
+    }
+
+    /// Adds the given number of instances for the given `factor_source_id` to the cache.
+    #[allow(clippy::too_many_arguments)]
+    pub fn add_instances(
+        &self,
+        factor_source_id: FactorSourceIDFromHash,
+        account_veci_count: usize,
+        account_mfa_count: usize,
+        account_rola_count: usize,
+        identity_veci_count: usize,
+        identity_mfa_count: usize,
+        identity_rola_count: usize,
+    ) {
+        let av_factor_instances = (0..account_veci_count)
+            .map(|index| {
+                HierarchicalDeterministicFactorInstance::new_for_entity(
+                    factor_source_id,
+                    CAP26EntityKind::Account,
+                    Hardened::from_local_key_space_unsecurified(index as u32)
+                        .unwrap(),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let am_factor_instances = (0..account_mfa_count)
+            .map(|index| {
+                HierarchicalDeterministicFactorInstance::new_for_entity(
+                    factor_source_id,
+                    CAP26EntityKind::Account,
+                    Hardened::from_local_key_space(
+                        index as u32,
+                        IsSecurified(true),
+                    )
+                    .unwrap(),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let ar_factor_instances = (0..account_rola_count)
+            .map(|index| {
+                HierarchicalDeterministicFactorInstance::new_for_entity_with_key_kind_on_network(
+                    CAP26KeyKind::AuthenticationSigning,
+                    NetworkID::Mainnet,
+                    factor_source_id,
+                    CAP26EntityKind::Account,
+                    Hardened::from_local_key_space(
+                        index as u32,
+                        IsSecurified(true),
+                    )
+                    .unwrap(),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let iv_factor_instances = (0..identity_veci_count)
+            .map(|index| {
+                HierarchicalDeterministicFactorInstance::new_for_entity(
+                    factor_source_id,
+                    CAP26EntityKind::Identity,
+                    Hardened::from_local_key_space_unsecurified(index as u32)
+                        .unwrap(),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let im_factor_instances = (0..identity_mfa_count)
+            .map(|index| {
+                HierarchicalDeterministicFactorInstance::new_for_entity(
+                    factor_source_id,
+                    CAP26EntityKind::Identity,
+                    Hardened::from_local_key_space(
+                        index as u32,
+                        IsSecurified(true),
+                    )
+                    .unwrap(),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let ir_factor_instances = (0..identity_rola_count)
+            .map(|index| {
+                HierarchicalDeterministicFactorInstance::new_for_entity_with_key_kind_on_network(
+                    CAP26KeyKind::AuthenticationSigning,
+                    NetworkID::Mainnet,
+                    factor_source_id,
+                    CAP26EntityKind::Identity,
+                    Hardened::from_local_key_space(
+                        index as u32,
+                        IsSecurified(true),
+                    )
+                        .unwrap(),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let instances: InstancesPerDerivationPresetPerFactorSource =
+            IndexMap::from_iter([
+                (
+                    DerivationPreset::AccountVeci,
+                    IndexMap::from_iter([(
+                        factor_source_id,
+                        FactorInstances::from_iter(av_factor_instances),
+                    )]),
+                ),
+                (
+                    DerivationPreset::AccountMfa,
+                    IndexMap::from_iter([(
+                        factor_source_id,
+                        FactorInstances::from_iter(am_factor_instances),
+                    )]),
+                ),
+                (
+                    DerivationPreset::AccountRola,
+                    IndexMap::from_iter([(
+                        factor_source_id,
+                        FactorInstances::from_iter(ar_factor_instances),
+                    )]),
+                ),
+                (
+                    DerivationPreset::IdentityVeci,
+                    IndexMap::from_iter([(
+                        factor_source_id,
+                        FactorInstances::from_iter(iv_factor_instances),
+                    )]),
+                ),
+                (
+                    DerivationPreset::IdentityMfa,
+                    IndexMap::from_iter([(
+                        factor_source_id,
+                        FactorInstances::from_iter(im_factor_instances),
+                    )]),
+                ),
+                (
+                    DerivationPreset::IdentityRola,
+                    IndexMap::from_iter([(
+                        factor_source_id,
+                        FactorInstances::from_iter(ir_factor_instances),
+                    )]),
+                ),
+            ]);
+
+        self.insert(&instances).unwrap();
     }
 }

--- a/crates/system/clients/clients/src/clients/client/factor_instances_cache_client/cache/factor_instances_cache.rs
+++ b/crates/system/clients/clients/src/clients/client/factor_instances_cache_client/cache/factor_instances_cache.rs
@@ -552,6 +552,26 @@ impl FactorInstancesCache {
         outcome.is_satisfied()
     }
 
+    /// Queries if the cache is satisfied for the given `factor_source_id` & `quantified_derivation_presets`
+    pub fn is_satisfied(
+        &self,
+        network_id: NetworkID,
+        factor_source_id: FactorSourceIDFromHash,
+        quantified_derivation_presets: &IdentifiedVecOf<
+            QuantifiedDerivationPreset,
+        >,
+    ) -> bool {
+        let Ok(outcome) = self.get(
+            &IndexSet::just(factor_source_id),
+            quantified_derivation_presets,
+            network_id,
+        ) else {
+            return false;
+        };
+
+        outcome.is_satisfied()
+    }
+
     pub fn assert_is_full(
         &self,
         network_id: NetworkID,

--- a/crates/system/clients/clients/src/clients/client/factor_instances_cache_client/cache/factor_instances_cache.rs
+++ b/crates/system/clients/clients/src/clients/client/factor_instances_cache_client/cache/factor_instances_cache.rs
@@ -286,7 +286,6 @@ impl FactorInstancesCache {
                             // for this factor source for this derivation preset
                             let instances_to_use_from_cache =
                                 for_preset.split_at(target_quantity).0;
-                            assert!(!instances_to_use_from_cache.is_empty());
                             Some(CacheInstancesAndRemainingQuantityToDerive {
                                 // Only take the first `target_quantity` instances
                                 // to be used, the rest are not needed and should
@@ -570,6 +569,27 @@ impl FactorInstancesCache {
         };
 
         outcome.is_satisfied()
+    }
+
+    /// Queries if the cache is satisfied for creating an entity with the given `factor_source_id` & `entity_kind`
+    pub fn is_entity_creation_satisfied(
+        &self,
+        network_id: NetworkID,
+        factor_source_id: FactorSourceIDFromHash,
+        entity_kind: EntityKind,
+    ) -> bool {
+        let derivation_preset = match entity_kind {
+            EntityKind::Account => DerivationPreset::AccountVeci,
+            EntityKind::Persona => DerivationPreset::IdentityVeci,
+        };
+        let quantified_derivation_presets: IdentifiedVecOf<
+            QuantifiedDerivationPreset,
+        > = vec![QuantifiedDerivationPreset::new(derivation_preset, 1)].into();
+        self.is_satisfied(
+            network_id,
+            factor_source_id,
+            &quantified_derivation_presets,
+        )
     }
 
     pub fn assert_is_full(

--- a/crates/system/clients/http/Cargo.toml
+++ b/crates/system/clients/http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http-client"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/drivers/Cargo.toml
+++ b/crates/system/drivers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drivers"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 

--- a/crates/system/interactors/Cargo.toml
+++ b/crates/system/interactors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interactors"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/accounts/Cargo.toml
+++ b/crates/system/os/accounts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-accounts"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/derive-public-keys/Cargo.toml
+++ b/crates/system/os/derive-public-keys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-derive-public-keys"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/factors/Cargo.toml
+++ b/crates/system/os/factors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-factors"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/os/Cargo.toml
+++ b/crates/system/os/os/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/os/src/sargon_os.rs
+++ b/crates/system/os/os/src/sargon_os.rs
@@ -440,6 +440,7 @@ impl SargonOS {
         authorization_interactor: impl Into<
             Option<Arc<dyn AuthorizationInteractor>>,
         >,
+        spot_check_interactor: impl Into<Option<Arc<dyn SpotCheckInteractor>>>,
         pre_derive_factor_instance_for_bdfs: bool,
     ) -> Result<Arc<Self>> {
         let test_drivers =
@@ -461,11 +462,17 @@ impl SargonOS {
                 Arc::new(TestAuthorizationInteractor::stubborn_authorizing())
             });
 
+        let spot_check_interactor =
+            spot_check_interactor.into().unwrap_or_else(|| {
+                Arc::new(TestSpotCheckInteractor::new_succeeded())
+            });
+
         let os = Self::boot_with_clients_and_interactor(
             clients,
-            Interactors::new_with_derivation_and_authorization_interactor(
+            Interactors::new_with_derivation_authorization_and_spot_check_interactor(
                 keys_derivation_interactor,
                 authorization_interactor,
+                spot_check_interactor
             ),
         )
         .await;
@@ -495,13 +502,11 @@ impl SargonOS {
         derivation_interactor: impl Into<Option<Arc<dyn KeyDerivationInteractor>>>,
         pre_derive_factor_instance_for_bdfs: bool,
     ) -> Arc<Self> {
-        let authorization_interactor: Arc<dyn AuthorizationInteractor> =
-            Arc::new(TestAuthorizationInteractor::stubborn_authorizing());
-
         let req = Self::boot_test_with_bdfs_mnemonic_and_interactors(
             bdfs_mnemonic,
             derivation_interactor,
-            authorization_interactor,
+            None,
+            None,
             pre_derive_factor_instance_for_bdfs,
         );
 
@@ -519,7 +524,7 @@ impl SargonOS {
 
     pub async fn boot_test() -> Result<Arc<Self>> {
         Self::boot_test_with_bdfs_mnemonic_and_interactors(
-            None, None, None, true,
+            None, None, None, None, true,
         )
         .await
     }

--- a/crates/system/os/os/src/sargon_os_accounts.rs
+++ b/crates/system/os/os/src/sargon_os_accounts.rs
@@ -1338,23 +1338,10 @@ mod tests {
     #[actix_rt::test]
     async fn test_create_and_save_new_account_continues_when_user_skips_spot_check(
     ) {
-        let mut clients = Clients::new(Bios::new(Drivers::test()));
-        clients.factor_instances_cache =
-            FactorInstancesCacheClient::in_memory();
-        let interactors =
-            Interactors::new_from_clients_and_spot_check_interactor(
-                &clients,
-                Arc::new(TestSpotCheckInteractor::new_skipped()),
-            );
-        let os = timeout(
-            SARGON_OS_TEST_MAX_ASYNC_DURATION,
-            SUT::boot_with_clients_and_interactor(clients, interactors),
+        let os = SUT::boot_test_empty_wallet_with_spot_check_interactor(
+            Arc::new(TestSpotCheckInteractor::new_skipped()),
         )
-        .await
-        .unwrap();
-
-        // Create empty Wallet
-        os.with_timeout(|x| x.new_wallet(false)).await.unwrap();
+        .await;
 
         // Add Account and verify it was added
         let account = os
@@ -1371,6 +1358,29 @@ mod tests {
             os.profile().unwrap().networks[0].accounts,
             Accounts::just(account)
         );
+    }
+
+    #[actix_rt::test]
+    async fn test_create_and_save_new_account_fails_when_spot_check_fails() {
+        let spot_check_error = CommonError::sample_other();
+        let os =
+            SUT::boot_test_empty_wallet_with_spot_check_interactor(Arc::new(
+                TestSpotCheckInteractor::new_failed(spot_check_error.clone()),
+            ))
+            .await;
+
+        // Attempt to add Account and check it fails with expected error
+        let error = os
+            .with_timeout(|x| {
+                x.create_and_save_new_account_with_main_bdfs(
+                    NetworkID::Mainnet,
+                    DisplayName::sample(),
+                )
+            })
+            .await
+            .expect_err("Expected error");
+
+        assert_eq!(error, spot_check_error,);
     }
 
     #[actix_rt::test]

--- a/crates/system/os/os/src/sargon_os_accounts.rs
+++ b/crates/system/os/os/src/sargon_os_accounts.rs
@@ -301,15 +301,13 @@ impl SargonOS {
         network_id: NetworkID,
         name: DisplayName,
     ) -> Result<(Account, FactorInstancesProviderOutcomeForFactor)> {
-        debug!("Spot checking the factor source...");
-        let spot_check_response = self
-            .spot_check_interactor()
-            .spot_check(factor_source.clone(), true)
-            .await?;
-        debug!(
-            "Spot check response: {:?}. Creating account...",
-            spot_check_response
-        );
+        self.spot_check_factor_source_before_entity_creation_if_necessary(
+            factor_source.clone(),
+            network_id,
+            EntityKind::Account,
+        )
+        .await?;
+        debug!("Creating account.");
         let (account, instances_in_cache_consumer, derivation_outcome) = self
             .create_unsaved_account_with_factor_source_with_derivation_outcome(
                 factor_source,

--- a/crates/system/os/os/src/sargon_os_factors.rs
+++ b/crates/system/os/os/src/sargon_os_factors.rs
@@ -534,6 +534,34 @@ impl SargonOS {
             SpotCheckResponse::Skipped => Ok(false),
         }
     }
+
+    /// If necessary, performs a spot check on the factor source before creating an entity.
+    ///
+    /// We only perform the spot check when we have enough keys in the cache to create the entity without deriving anymore.
+    pub async fn spot_check_factor_source_before_entity_creation_if_necessary(
+        &self,
+        factor_source: FactorSource,
+        network_id: NetworkID,
+        entity_kind: EntityKind,
+    ) -> Result<()> {
+        let cache = self.cache_snapshot().await;
+        let should_spot_check = !cache.is_entity_creation_satisfied(
+            network_id,
+            factor_source.id_from_hash(),
+            entity_kind,
+        );
+        if should_spot_check {
+            debug!("Spot checking the factor source...");
+            let response = self
+                .spot_check_interactor()
+                .spot_check(factor_source, false)
+                .await?;
+            debug!("Spot check response: {:?}", response);
+        } else {
+            debug!("No need to spot check the factor source.");
+        }
+        Ok(())
+    }
 }
 
 #[cfg(debug_assertions)]

--- a/crates/system/os/os/src/sargon_os_personas.rs
+++ b/crates/system/os/os/src/sargon_os_personas.rs
@@ -287,15 +287,13 @@ impl SargonOS {
         name: DisplayName,
         persona_data: Option<PersonaData>,
     ) -> Result<(Persona, FactorInstancesProviderOutcomeForFactor)> {
-        debug!("Spot checking the factor source...");
-        let spot_check_response = self
-            .spot_check_interactor()
-            .spot_check(factor_source.clone(), true)
-            .await?;
-        debug!(
-            "Spot check response: {:?}. Creating persona...",
-            spot_check_response
-        );
+        self.spot_check_factor_source_before_entity_creation_if_necessary(
+            factor_source.clone(),
+            network_id,
+            EntityKind::Persona,
+        )
+        .await?;
+        debug!("Creating persona.");
         let (mut persona, instances_in_cache_consumer, derivation_outcome) = self
             .create_unsaved_persona_with_factor_source_with_derivation_outcome(
                 factor_source,

--- a/crates/system/os/os/src/testing_interactors.rs
+++ b/crates/system/os/os/src/testing_interactors.rs
@@ -5,9 +5,10 @@ pub trait InteractorsCtors {
         keys_derivation_interactor: Arc<dyn KeyDerivationInteractor>,
     ) -> Interactors;
 
-    fn new_with_derivation_and_authorization_interactor(
+    fn new_with_derivation_authorization_and_spot_check_interactor(
         keys_derivation_interactor: Arc<dyn KeyDerivationInteractor>,
         authorization_interactor: Arc<dyn AuthorizationInteractor>,
+        spot_check_interactor: Arc<dyn SpotCheckInteractor>,
     ) -> Interactors;
 
     fn new_from_clients_and_spot_check_interactor(
@@ -28,12 +29,13 @@ pub trait InteractorsCtors {
         clients: &Clients,
         authorization_interactor: Arc<dyn AuthorizationInteractor>,
     ) -> Interactors {
-        Self::new_with_derivation_and_authorization_interactor(
+        Self::new_with_derivation_authorization_and_spot_check_interactor(
             Arc::new(TestDerivationInteractor::new(
                 false,
                 Arc::new(clients.secure_storage.clone()),
             )),
             authorization_interactor,
+            Arc::new(TestSpotCheckInteractor::new_succeeded()),
         )
     }
 }
@@ -63,9 +65,10 @@ impl InteractorsCtors for Interactors {
         )
     }
 
-    fn new_with_derivation_and_authorization_interactor(
+    fn new_with_derivation_authorization_and_spot_check_interactor(
         keys_derivation_interactor: Arc<dyn KeyDerivationInteractor>,
         authorization_interactor: Arc<dyn AuthorizationInteractor>,
+        spot_check_interactor: Arc<dyn SpotCheckInteractor>,
     ) -> Interactors {
         let use_factor_sources_interactors =
             TestUseFactorSourcesInteractors::new(
@@ -84,7 +87,7 @@ impl InteractorsCtors for Interactors {
         Self::new(
             Arc::new(use_factor_sources_interactors),
             authorization_interactor,
-            Arc::new(TestSpotCheckInteractor::new_succeeded()),
+            spot_check_interactor,
         )
     }
 

--- a/crates/system/os/security-center/Cargo.toml
+++ b/crates/system/os/security-center/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-security-center"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/signing/Cargo.toml
+++ b/crates/system/os/signing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-signing"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/transaction/Cargo.toml
+++ b/crates/system/os/transaction/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-transaction"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/profile-state-holder/Cargo.toml
+++ b/crates/system/profile-state-holder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-state-holder"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/sub-systems/Cargo.toml
+++ b/crates/system/sub-systems/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sub-systems"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/transaction/foundation/Cargo.toml
+++ b/crates/transaction/foundation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transaction-foundation"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/transaction/manifests/Cargo.toml
+++ b/crates/transaction/manifests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "manifests"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 

--- a/crates/transaction/models/Cargo.toml
+++ b/crates/transaction/models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transaction-models"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 

--- a/crates/uniffi/conversion-macros/Cargo.toml
+++ b/crates/uniffi/conversion-macros/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "sargon-uniffi-conversion-macros"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/uniffi/uniffi_SPLIT_ME/Cargo.toml
+++ b/crates/uniffi/uniffi_SPLIT_ME/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-uniffi"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 build = "build.rs"
 

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/MnemonicWithPassphrase.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/extensions/MnemonicWithPassphrase.kt
@@ -6,6 +6,7 @@ import com.radixdlt.sargon.DerivationPath
 import com.radixdlt.sargon.FactorSourceIdFromHash
 import com.radixdlt.sargon.FactorSourceKind
 import com.radixdlt.sargon.Hash
+import com.radixdlt.sargon.HierarchicalDeterministicFactorInstance
 import com.radixdlt.sargon.HierarchicalDeterministicPublicKey
 import com.radixdlt.sargon.Mnemonic
 import com.radixdlt.sargon.MnemonicWithPassphrase
@@ -64,6 +65,15 @@ fun MnemonicWithPassphrase.derivePublicKeys(
     mnemonicWithPassphrase = this,
     derivationPaths = paths
 )
+
+fun MnemonicWithPassphrase.derivePublicKeys(
+    paths: List<DerivationPath>,
+    factorSourceId: FactorSourceIdFromHash
+): List<HierarchicalDeterministicFactorInstance> {
+    return derivePublicKeys(paths).map {
+        HierarchicalDeterministicFactorInstance(factorSourceId, it)
+    }
+}
 
 fun MnemonicWithPassphrase.sign(
     hash: Hash,

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/MnemonicWithPassphraseTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/MnemonicWithPassphraseTest.kt
@@ -2,6 +2,7 @@ package com.radixdlt.sargon
 
 import com.radixdlt.sargon.extensions.compile
 import com.radixdlt.sargon.extensions.derivePublicKey
+import com.radixdlt.sargon.extensions.derivePublicKeys
 import com.radixdlt.sargon.extensions.factorSourceId
 import com.radixdlt.sargon.extensions.fromJson
 import com.radixdlt.sargon.extensions.hash
@@ -133,6 +134,14 @@ class MnemonicWithPassphraseTest {
         assertEquals(
             HierarchicalDeterministicPublicKey.sample(),
             MnemonicWithPassphrase.sample().derivePublicKey(DerivationPath.sample())
+        )
+    }
+
+    @Test
+    fun testDerivePublicKeysFactorInstances() {
+        assertEquals(
+            listOf(HierarchicalDeterministicFactorInstance.sample()),
+            MnemonicWithPassphrase.sample().derivePublicKeys(listOf(DerivationPath.sample()), FactorSourceIdFromHash.sample())
         )
     }
 


### PR DESCRIPTION
JIRA ticket: [ABW-4158](https://radixdlt.atlassian.net/browse/ABW-4158)
JIRA ticket: [ABW-4159](https://radixdlt.atlassian.net/browse/ABW-4159)

## Changelog
Sargon will now perform a spot check on the corresponding factor sources when creating an entity or applying a shield. 

The spot check will only be performed on a given factor source that is used on the corresponding flow, but that has enough instances in cache to fulfill the requirements.

## Examples

| Flow | Cache status | Output |
| -- | -- | -- |
| Create an account using BDFS | `[BDFS: [AccountVeci1]]` | Spot check performed on BDFS |
| Create an account using BDFS | `[:]` | Spot check isn't performed on BDFS |
| Apply to 2 Accounts a shield <br> that uses `BDFS` & `Arculus` as factors | `[BDFS: [AccountMFA1]],` <br> `[Arculus: [AccountMFA1, AcountMFA2]]` | Spot check performed on Arculus only |


[ABW-4158]: https://radixdlt.atlassian.net/browse/ABW-4158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ABW-4159]: https://radixdlt.atlassian.net/browse/ABW-4159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ