### PR TITLE
[WIP] Interactions Queue model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2217,6 +2217,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "interaction-queue"
+version = "1.2.1"
+dependencies = [
+ "actix-rt",
+ "core-utils",
+ "prelude",
+ "serde",
+ "transaction-models",
+]
+
+[[package]]
 name = "interactors"
 version = "1.2.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     # === FOR APP ===
     "crates/app/home-cards",
+    "crates/app/interaction-queue",
     "crates/app/radix-connect",
     "crates/app/radix-connect-models",
     "crates/app/security-center",
@@ -96,6 +97,7 @@ members = [
 default-members = [
     # === FOR APP ===
     "crates/app/home-cards",
+    "crates/app/interaction-queue",
     "crates/app/radix-connect",
     "crates/app/radix-connect-models",
     "crates/app/security-center",
@@ -204,11 +206,12 @@ debug = true
 
 # === FOR APP ===
 home-cards = { path = "crates/app/home-cards" }
+interaction-queue = { path = "crates/app/interaction-queue" }
+key-derivation-traits = { path = "crates/app/key-derivation-traits" }
 radix-connect = { path = "crates/app/radix-connect" }
 radix-connect-models = { path = "crates/app/radix-connect-models" }
 security-center = { path = "crates/app/security-center" }
 signing-traits = { path = "crates/app/signing-traits" }
-key-derivation-traits = { path = "crates/app/key-derivation-traits" }
 
 # === COMMON ===
 build-info = { path = "crates/common/build-info" }

--- a/crates/app/interaction-queue/Cargo.toml
+++ b/crates/app/interaction-queue/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "interaction-queue"
+version = "1.2.1"
+edition = "2021"
+
+[dependencies]
+# === SARGON CRATES ===
+prelude = { workspace = true }
+core-utils = { workspace = true }
+transaction-models = { workspace = true }
+
+# === RADIX DEPENDENCIES ===
+# None
+
+# === EXTERNAL DEPENDENCIES ===
+actix-rt = { workspace = true }
+serde = { workspace = true }

--- a/crates/app/interaction-queue/src/batch.rs
+++ b/crates/app/interaction-queue/src/batch.rs
@@ -1,4 +1,5 @@
 use crate::prelude::*;
+use std::time::Duration;
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 /// A batch of interactions that are to be processed in sequence.
@@ -6,9 +7,10 @@ pub struct InteractionQueueBatch {
     /// The identifier of this batch
     pub id: Uuid,
 
-    /// The remaining interaction to process from this batch.
+    /// The remaining interactions to process from this batch.
     /// We will be dispatching each of the interactions one by one, leaving a random amount of seconds among each.
-    /// The first on the top will always have its status set to `Next`, while the others will have `Queued`.
+    /// The first on the top will always have its status set to `Next`, with a random amount of seconds to wait,
+    /// while the others will have `Queued` status.
     /// Once it is time to submit an interaction, it will be removed from this list, switch its status to `InProgress` and place it in the `InteractionQueue.items`
     /// Next one in line will have its status updated to `Next`.
     pub interactions: Vec<InteractionQueueItem>,
@@ -21,10 +23,45 @@ pub struct InteractionQueueBatch {
 
 impl InteractionQueueBatch {
     /// Returns the estimated amount of time in seconds before this batch is fully processed.
-    fn remaining_seconds(&self) -> usize {
+    pub fn estimated_remaining_seconds(&self) -> usize {
         let average = ((INTERACTION_QUEUE_BATCH_MIN_DELAY
             + INTERACTION_QUEUE_BATCH_MAX_DELAY)
             / 2) as usize;
         self.interactions.len() * average
+    }
+
+    /// Returns the next interaction, if it is ready to be processed.
+    /// This is, if the first interaction in the batch has a `Next` status and its time has completed,
+    /// it will be dropped from the list and returned.
+    /// Also, the following interaction in line (if any) will have its status updated
+    /// to `Next` with a random delay.
+    pub(crate) fn get_first_if_ready(
+        &mut self,
+    ) -> Option<InteractionQueueItem> {
+        if let Some(first) = self.interactions.get(0).cloned() {
+            if let InteractionQueueItemStatus::Next(next) = first.status {
+                let now = Timestamp::now_utc();
+                if next <= now {
+                    self.drop_first_and_set_up_next();
+                    return Some(first.clone());
+                }
+            }
+        }
+        None
+    }
+
+    /// Removes the first interaction from the batch, and updates the following one to have a
+    /// `Next` status with a random delay.
+    fn drop_first_and_set_up_next(&mut self) {
+        self.interactions.remove(0);
+        if let Some(first) = self.interactions.first_mut() {
+            // TODO: Generate random number between range
+            let delay = (INTERACTION_QUEUE_BATCH_MIN_DELAY
+                + INTERACTION_QUEUE_BATCH_MAX_DELAY)
+                / 2;
+            first.status = InteractionQueueItemStatus::Next(
+                Timestamp::now_utc().add(Duration::from_secs(delay)),
+            );
+        }
     }
 }

--- a/crates/app/interaction-queue/src/batch.rs
+++ b/crates/app/interaction-queue/src/batch.rs
@@ -1,0 +1,30 @@
+use crate::prelude::*;
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+/// A batch of interactions that are to be processed in sequence.
+pub struct InteractionQueueBatch {
+    /// The identifier of this batch
+    pub id: Uuid,
+
+    /// The remaining interaction to process from this batch.
+    /// We will be dispatching each of the interactions one by one, leaving a random amount of seconds among each.
+    /// The first on the top will always have its status set to `Next`, while the others will have `Queued`.
+    /// Once it is time to submit an interaction, it will be removed from this list, switch its status to `InProgress` and place it in the `InteractionQueue.items`
+    /// Next one in line will have its status updated to `Next`.
+    pub interactions: Vec<InteractionQueueItem>,
+
+    /// The identifiers of all the interactions that were originally part of this batch.
+    /// Used to know how many interactions it contained, as well as for allowing further lookup from
+    /// the already finished interactions (if ever needed).
+    pub original_interactions: Vec<Uuid>,
+}
+
+impl InteractionQueueBatch {
+    /// Returns the estimated amount of time in seconds before this batch is fully processed.
+    fn remaining_seconds(&self) -> usize {
+        let average = ((INTERACTION_QUEUE_BATCH_MIN_DELAY
+            + INTERACTION_QUEUE_BATCH_MAX_DELAY)
+            / 2) as usize;
+        self.interactions.len() * average
+    }
+}

--- a/crates/app/interaction-queue/src/item/item.rs
+++ b/crates/app/interaction-queue/src/item/item.rs
@@ -1,0 +1,24 @@
+use crate::prelude::*;
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+/// An item that is part of the interaction queue.
+pub struct InteractionQueueItem {
+    /// The identifier of this item.
+    pub id: Uuid,
+
+    /// If set, this item belongs to a batch with the corresponding identifier.
+    /// This means that when completed, it should trigger the dispatch of next item such batch.
+    pub batch_id: Uuid,
+
+    /// The status of this item.
+    pub status: InteractionQueueItemStatus,
+
+    /// Whether this interaction was triggered form a mobile browser.
+    pub is_from_browser: bool,
+
+    /// The summary of this item, used to represent visually in the hosts.
+    pub summary: InteractionQueueItemSummary,
+
+    /// The kind of this item
+    pub kind: InteractionQueueItemKind,
+}

--- a/crates/app/interaction-queue/src/item/kind.rs
+++ b/crates/app/interaction-queue/src/item/kind.rs
@@ -1,0 +1,11 @@
+use crate::prelude::*;
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+/// An enum describing the kind of an item in the interaction queue.
+pub enum InteractionQueueItemKind {
+    /// A Transaction item.
+    Transaction(TransactionQueueItem),
+
+    /// A Pre-Authorization item.
+    PreAuthorization(PreAuthorizationQueueItem),
+}

--- a/crates/app/interaction-queue/src/item/mod.rs
+++ b/crates/app/interaction-queue/src/item/mod.rs
@@ -1,0 +1,13 @@
+mod item;
+mod kind;
+mod pre_authorization_item;
+mod status;
+mod summary;
+mod transaction_item;
+
+pub use item::*;
+pub use kind::*;
+pub use pre_authorization_item::*;
+pub use status::*;
+pub use summary::*;
+pub use transaction_item::*;

--- a/crates/app/interaction-queue/src/item/pre_authorization_item.rs
+++ b/crates/app/interaction-queue/src/item/pre_authorization_item.rs
@@ -1,0 +1,21 @@
+use crate::prelude::*;
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+/// A Pre-Authorization item that is part of the interaction queue.
+pub struct PreAuthorizationQueueItem {
+    /// The identifier of the subintent.
+    pub subintent_id: SubintentHash,
+
+    /// The identifier of the Transaction in which this PreAuthorization was committed.
+    /// Only available when status is success.
+    pub transaction_id: Option<TransactionIntentHash>,
+
+    /// The name of the DApp that requested this PreAuthorization.
+    pub dapp_name: String,
+
+    /// The timestamp at which the subintent expires
+    pub expiration_timestamp: Instant,
+    // TODO: Define if we need the interaction_id here
+    // It is currently used when dismissing the `PollPreAuthorizationStatus` on iOS, to identify the interaction that must be dismissed.
+    //pub interaction_id: WalletInteractionId,
+}

--- a/crates/app/interaction-queue/src/item/status.rs
+++ b/crates/app/interaction-queue/src/item/status.rs
@@ -1,0 +1,56 @@
+use crate::prelude::*;
+use std::cmp::Ordering;
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+/// An enum describing the status of an item in the interaction queue.
+pub enum InteractionQueueItemStatus {
+    /// The interaction is queued within a batch and waiting to be processed.
+    Queued,
+
+    /// The interaction is the next in line within a batch to be processed.
+    Next,
+
+    /// The interaction is currently being processed.
+    InProgress,
+
+    /// The interaction was successfully processed.
+    Success,
+
+    /// The interaction failed to be processed.
+    Failure(InteractionQueueItemFailureStatus),
+}
+
+impl PartialOrd for InteractionQueueItemStatus {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl Ord for InteractionQueueItemStatus {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.sort_order().cmp(&other.sort_order())
+    }
+}
+impl InteractionQueueItemStatus {
+    fn sort_order(&self) -> i32 {
+        match self {
+            InteractionQueueItemStatus::Failure(_) => 0,
+            InteractionQueueItemStatus::Success => 1,
+            InteractionQueueItemStatus::InProgress => 2,
+            InteractionQueueItemStatus::Next => 3,
+            InteractionQueueItemStatus::Queued => 4,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+/// An enum describing the failure status of an item in the interaction queue.
+pub enum InteractionQueueItemFailureStatus {
+    /// For Transactions only. Can be retried.
+    Rejected,
+
+    /// For Transactions only. Cannot be retried.
+    Failed,
+
+    /// For Transactions & PreAuthorizations. Cannot be retried.
+    TimedOut,
+}

--- a/crates/app/interaction-queue/src/item/status.rs
+++ b/crates/app/interaction-queue/src/item/status.rs
@@ -8,7 +8,8 @@ pub enum InteractionQueueItemStatus {
     Queued,
 
     /// The interaction is the next in line within a batch to be processed.
-    Next,
+    /// The associated `Instant` is the time when the interaction should be processed.
+    Next(Timestamp),
 
     /// The interaction is currently being processed.
     InProgress,
@@ -36,7 +37,7 @@ impl InteractionQueueItemStatus {
             InteractionQueueItemStatus::Failure(_) => 0,
             InteractionQueueItemStatus::Success => 1,
             InteractionQueueItemStatus::InProgress => 2,
-            InteractionQueueItemStatus::Next => 3,
+            InteractionQueueItemStatus::Next(_) => 3,
             InteractionQueueItemStatus::Queued => 4,
         }
     }

--- a/crates/app/interaction-queue/src/item/summary.rs
+++ b/crates/app/interaction-queue/src/item/summary.rs
@@ -1,0 +1,45 @@
+use crate::prelude::*;
+use serde::{Deserializer, Serializer};
+
+#[derive(Debug, Clone, PartialEq)]
+/// An enum describing the summary of an item in the interaction queue.
+/// It will include the plain summary returned by RET when performing a review of the interaction. The downsides of this option:
+/// - it isn't very optimal since it will require hosts to resolve the sections every time the queue is opened.
+/// - we need to implement Serialize/Deserialize for the associated values.
+pub enum InteractionQueueItemSummary {
+    Execution(ExecutionSummary),
+
+    Manifest(ManifestSummary),
+}
+
+impl Serialize for InteractionQueueItemSummary {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        panic!("Cannot serialize InteractionQueueItemSummary");
+    }
+}
+
+impl<'de> Deserialize<'de> for InteractionQueueItemSummary {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        panic!("Cannot deserialize InteractionQueueItemSummary")
+    }
+}
+
+/// Another summary version. It would include the necessary data used by hosts to display the UI. The downside of this option are two:
+/// - we need to implement a lot of UI models in Sargon
+/// - the data could be outdated after the interaction is resolved. For example, if an Account has its name
+/// updated after the interaction is created, the queue would always show the initial name (since, e.g., the `withdrawals`)
+/// would have information from the original account data.
+struct InteractionQueueItemSummaryV2 {
+    /*
+    pub withdrawals: Option≤Accounts>,
+    pub dapps_used: Option<InteractionReviewDappsUsed>,
+    pub deposits: Option<Accounts>,
+    // .. everything else that Hosts use to display the TransactionReview/PreAuthorizationReview
+    */
+}

--- a/crates/app/interaction-queue/src/item/transaction_item.rs
+++ b/crates/app/interaction-queue/src/item/transaction_item.rs
@@ -1,0 +1,8 @@
+use crate::prelude::*;
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+/// A Transaction item that is part of the interaction queue.
+pub struct TransactionQueueItem {
+    /// The identifier of the transaction.
+    pub transaction_id: TransactionIntentHash,
+}

--- a/crates/app/interaction-queue/src/lib.rs
+++ b/crates/app/interaction-queue/src/lib.rs
@@ -1,0 +1,17 @@
+mod batch;
+mod item;
+mod manager;
+mod observer;
+mod queue;
+
+pub mod prelude {
+    pub use crate::batch::*;
+    pub use crate::item::*;
+    pub use crate::observer::*;
+    pub use crate::queue::*;
+
+    pub(crate) use core_utils::prelude::*;
+    pub(crate) use transaction_models::prelude::*;
+
+    pub(crate) use serde::{Deserialize, Serialize};
+}

--- a/crates/app/interaction-queue/src/manager.rs
+++ b/crates/app/interaction-queue/src/manager.rs
@@ -45,7 +45,7 @@ impl InteractionsQueueManager {
 // Internal methods (called by other places inside Sargon)
 impl InteractionsQueueManager {
     pub fn add_interaction(&self, item: InteractionQueueItem) {
-        // Adds interaction to `queue.items` and process it
+        // Calls `process_interaction(item)`
         // Call observer to notify of updated queue
     }
 
@@ -58,9 +58,12 @@ impl InteractionsQueueManager {
 // Private methods
 impl InteractionsQueueManager {
     fn poll_status(&self) {
-        // Poll the status of every interaction that is `InProgress`
+        // Poll the status of every interaction that is `InProgress`.
         // For each of them that has finished and has a `batchId` set, handle the next interaction of its batch.
         // Call observer to notify of updated queue
+
+        // Also, loop over the batches and call `batch.get_first_if_ready()` for each of them.
+        // If they return an interaction, call `process_interaction()` with it.
     }
 
     fn process_interaction(&self, item: InteractionQueueItem) {

--- a/crates/app/interaction-queue/src/manager.rs
+++ b/crates/app/interaction-queue/src/manager.rs
@@ -1,0 +1,70 @@
+use crate::prelude::*;
+use std::sync::Arc;
+
+pub struct InteractionsQueueManager {
+    /// The queue of interactions.
+    queue: InteractionsQueue,
+
+    /// Observer to handle updates to the interactions queue.
+    observer: Arc<dyn InteractionQueueObserver>,
+}
+
+impl InteractionsQueueManager {
+    pub fn new(observer: Arc<dyn InteractionQueueObserver>) -> Self {
+        Self {
+            queue: InteractionsQueue::new(),
+            observer,
+        }
+    }
+}
+
+// Exported methods (called by Hosts)
+impl InteractionsQueueManager {
+    /// Method to be called by hosts every time the app is started (or whenever we want)
+    /// It will remove the stale data (success transactions).
+    pub fn bootstrap(&self) {
+        // Load queue from local storage.
+        // Removes every successful interaction from `queue.items` and every batch with no remaining interaction from `queue.batches`.
+        // Call observer to notify of updated queue
+        // Set up timer to call `poll_status` every 3 seconds
+    }
+
+    pub fn retry_interaction(&self, interaction_id: Uuid) {
+        // Find interaction in `queue.items` and retry it
+    }
+
+    pub fn dismiss_interaction(&self, interaction_id: Uuid) {
+        // Remove interaction from `queue.items`
+    }
+
+    pub fn cancel_interaction(&self, interaction_id: Uuid, batch_id: Uuid) {
+        // Find batch in `queue.batches` and remove the interaction with given id from its list.
+    }
+}
+
+// Internal methods (called by other places inside Sargon)
+impl InteractionsQueueManager {
+    pub fn add_interaction(&self, item: InteractionQueueItem) {
+        // Adds interaction to `queue.items` and process it
+        // Call observer to notify of updated queue
+    }
+
+    pub fn add_batch(&self, batch: InteractionQueueBatch) {
+        // Adds batch to `queue.batches` and process the first interaction from its list.
+        // Call observer to notify of updated queue
+    }
+}
+
+// Private methods
+impl InteractionsQueueManager {
+    fn poll_status(&self) {
+        // Poll the status of every interaction that is `InProgress`
+        // For each of them that has finished and has a `batchId` set, handle the next interaction of its batch.
+        // Call observer to notify of updated queue
+    }
+
+    fn process_interaction(&self, item: InteractionQueueItem) {
+        // Set interaction status to `InProgress`
+        // If it is a Transaction, submit it to network.
+    }
+}

--- a/crates/app/interaction-queue/src/observer.rs
+++ b/crates/app/interaction-queue/src/observer.rs
@@ -1,0 +1,7 @@
+use crate::prelude::*;
+
+/// Trait for observing interaction queue updates.
+pub trait InteractionQueueObserver: Send + Sync {
+    /// Handles updates to the queued interactions.
+    fn handle_update(&self, interactions: Vec<InteractionQueueItem>);
+}

--- a/crates/app/interaction-queue/src/queue.rs
+++ b/crates/app/interaction-queue/src/queue.rs
@@ -1,0 +1,38 @@
+use crate::prelude::*;
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+/// A struct representing all the interactions that were dispatched, or are waiting to be dispatched.
+pub struct InteractionsQueue {
+    /// Interactions that were already dispatched.
+    /// Their status will always be `InProgress`, `Success` or `Failure`.
+    pub items: Vec<InteractionQueueItem>,
+
+    /// Batches of interactions that are waiting to be dispatched.
+    pub batches: Vec<InteractionQueueBatch>,
+}
+
+impl InteractionsQueue {
+    pub fn new() -> Self {
+        Self {
+            items: Vec::new(),
+            batches: Vec::new(),
+        }
+    }
+
+    /// Returns every interaction in the queue, sorted by its status.
+    pub fn sorted_items(&self) -> Vec<InteractionQueueItem> {
+        let mut all_items: Vec<InteractionQueueItem> = self
+            .items
+            .iter()
+            .cloned()
+            .chain(
+                self.batches
+                    .iter()
+                    .flat_map(|batch| batch.interactions.clone()),
+            )
+            .collect();
+
+        all_items.sort_by_key(|item| item.status.clone());
+        all_items
+    }
+}

--- a/crates/core/misc/src/instant.rs
+++ b/crates/core/misc/src/instant.rs
@@ -10,6 +10,8 @@ pub use crate::prelude::*;
     PartialOrd,
     derive_more::Display,
     derive_more::Debug,
+    Serialize,
+    Deserialize,
 )]
 pub struct Instant {
     pub seconds_since_unix_epoch: i64,

--- a/crates/core/utils/src/constants.rs
+++ b/crates/core/utils/src/constants.rs
@@ -35,10 +35,10 @@ pub const MINUTES_PER_DAY: u32 = 24 * 60;
 pub const DAYS_PER_WEEK: u16 = 7;
 
 /// The minimum delay, in seconds, between two consecutive interaction queue items from the same batch.
-pub const INTERACTION_QUEUE_BATCH_MIN_DELAY: u16 = 10;
+pub const INTERACTION_QUEUE_BATCH_MIN_DELAY: u64 = 10;
 
 /// The maximum delay, in seconds, between two consecutive interaction queue items from the same batch.
-pub const INTERACTION_QUEUE_BATCH_MAX_DELAY: u16 = 60;
+pub const INTERACTION_QUEUE_BATCH_MAX_DELAY: u64 = 60;
 
 #[cfg(test)]
 mod tests {

--- a/crates/core/utils/src/constants.rs
+++ b/crates/core/utils/src/constants.rs
@@ -34,6 +34,12 @@ pub const MINUTES_PER_DAY: u32 = 24 * 60;
 /// Number of days per week.
 pub const DAYS_PER_WEEK: u16 = 7;
 
+/// The minimum delay, in seconds, between two consecutive interaction queue items from the same batch.
+pub const INTERACTION_QUEUE_BATCH_MIN_DELAY: u16 = 10;
+
+/// The maximum delay, in seconds, between two consecutive interaction queue items from the same batch.
+pub const INTERACTION_QUEUE_BATCH_MAX_DELAY: u16 = 60;
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
This draft PR contains a proposal on how to handle the `InteractionsQueue` ([designs](https://www.figma.com/design/6MaKVYek0m9GKkd1xujB8P/Babylon-Wallet?node-id=23825-250815&t=ZchlHEM3kqNXy6qo-0)) to support processing of `Transactions` and `PreAuthorizations`, either individually or inside a batch.

### Key items to review
- [InteractionsQueueManager](https://github.com/radixdlt/sargon/pull/383/files#diff-a74e66c6b6704dc3cf8b8c6174efad7b7ae4fb549059ef9d823bbcf82194524fR4): the API used by hosts and internally.
- [InteractionsQueueObserver](https://github.com/radixdlt/sargon/pull/383/files#diff-8f462cf47f6081e3e990b68823473a534fd76f9f896eaf3851efef6abe423a54R4): the trait implemented by hosts to get notified about updates on the queue. Is an approach similar to what we do with `HomeCards` good enough? Or should we have a more complex solution as we do for `SecurityShieldBuilder`?
- [InteractionQueueItemSummary](https://github.com/radixdlt/sargon/pull/383/files#diff-3963d1d4a6e64a0724f861a9718bb1b221170c8debc106a4ab725f1950077af2R9): should we store plain RET Summaries (and let hosts resolve them every time)? Or should we spend more time implementing UI models (which would be resolved only once, potentially leaving showing stale data)?

