### PR TITLE
Fix spot check during entity creation

### DIFF
--- a/crates/system/os/factors/src/apply_security_shield/sargon_os_apply_shield.rs
+++ b/crates/system/os/factors/src/apply_security_shield/sargon_os_apply_shield.rs
@@ -1150,6 +1150,16 @@ mod tests {
                 .await;
             let shield_id = add_unsafe_shield(&os).await.unwrap();
             let network = NetworkID::Mainnet;
+
+            let main_bdfs = os.main_bdfs().unwrap();
+            // The spot check is performed only when there are enough factor instances in cache
+            os.pre_derive_and_fill_cache_with_instances_for_factor_source(
+                main_bdfs.into(),
+                NetworkID::Mainnet,
+            )
+            .await
+            .unwrap();
+
             let account = os
                 .create_and_save_new_account_with_main_bdfs(
                     network,

--- a/crates/system/os/os/src/sargon_os.rs
+++ b/crates/system/os/os/src/sargon_os.rs
@@ -134,6 +134,7 @@ impl SargonOS {
             // only tests for now, need more work in hosts before we can do this in prod
             self.pre_derive_and_fill_cache_with_instances_for_factor_source(
                 bdfs.clone().factor_source.into(),
+                NetworkID::Mainnet, // we care not about other networks here
             )
             .await?;
         }
@@ -146,6 +147,7 @@ impl SargonOS {
     pub async fn pre_derive_and_fill_cache_with_instances_for_factor_source(
         &self,
         factor_source: FactorSource,
+        network_id: NetworkID,
     ) -> Result<FactorInstancesProviderOutcome> {
         if !factor_source.factor_source_id().is_hash() {
             panic!("Unsupported FactorSource which is not HD.")
@@ -156,7 +158,7 @@ impl SargonOS {
             Arc::new(self.clients.factor_instances_cache.clone()),
             Arc::new(profile_snapshot),
             factor_source.clone(),
-            NetworkID::Mainnet, // we care not about other networks here
+            network_id,
             keys_derivation_interactors.clone(),
         )
         .await?;

--- a/crates/system/os/os/src/sargon_os_accounts.rs
+++ b/crates/system/os/os/src/sargon_os_accounts.rs
@@ -1367,6 +1367,15 @@ mod tests {
             ))
             .await;
 
+        let main_bdfs = os.main_bdfs().unwrap();
+        // The spot check is performed only when there are enough factor instances in cache
+        os.pre_derive_and_fill_cache_with_instances_for_factor_source(
+            main_bdfs.into(),
+            NetworkID::Mainnet,
+        )
+        .await
+        .unwrap();
+
         // Attempt to add Account and check it fails with expected error
         let error = os
             .with_timeout(|x| {

--- a/crates/system/os/os/src/sargon_os_factors.rs
+++ b/crates/system/os/os/src/sargon_os_factors.rs
@@ -291,6 +291,7 @@ impl SargonOS {
             let _ = self
                 .pre_derive_and_fill_cache_with_instances_for_factor_source(
                     factor_source,
+                    NetworkID::Mainnet, // we care not about other networks here
                 )
                 .await?;
         }
@@ -553,7 +554,7 @@ impl SargonOS {
         entity_kind: EntityKind,
     ) -> Result<()> {
         let cache = self.cache_snapshot().await;
-        let should_spot_check = !cache.is_entity_creation_satisfied(
+        let should_spot_check = cache.is_entity_creation_satisfied(
             network_id,
             factor_source.id_from_hash(),
             entity_kind,

--- a/crates/system/os/os/src/sargon_os_personas.rs
+++ b/crates/system/os/os/src/sargon_os_personas.rs
@@ -1333,6 +1333,15 @@ mod tests {
             ))
             .await;
 
+        let main_bdfs = os.main_bdfs().unwrap();
+        // The spot check is performed only when there are enough factor instances in cache
+        os.pre_derive_and_fill_cache_with_instances_for_factor_source(
+            main_bdfs.into(),
+            NetworkID::Mainnet,
+        )
+        .await
+        .unwrap();
+
         // Attempt to add Persona and check it fails with expected error
         let error = os
             .with_timeout(|x| {

--- a/crates/uniffi/uniffi_SPLIT_ME/src/system/sargon_os/add_factor_source/sargon_os_factor_source_adder.rs
+++ b/crates/uniffi/uniffi_SPLIT_ME/src/system/sargon_os/add_factor_source/sargon_os_factor_source_adder.rs
@@ -18,7 +18,7 @@ impl SargonOS {
         factor_source_kind: FactorSourceKind,
         mnemonic_with_passphrase: MnemonicWithPassphrase,
         name: String,
-    ) -> Result<()> {
+    ) -> Result<FactorSourceID> {
         self.wrapped
             .add_new_mnemonic_factor_source(
                 factor_source_kind.into_internal(),


### PR DESCRIPTION
When creating a new entity, the host has to be asked for a factor source "spot check" if there are enough factor instances pre-derived or, if not, to pre-derive and fill the factor instances cache. 

- This PR fixes the condition for the spot check when creating a new entity.
- Slightly improved the factor source adding API by returning the `FactorSourceId` from `add_new_mnemonic_factor_source` method.


> The changes were tested on Android