### PR TITLE
Bridger serializers between kotlinx-serialization and rust serde

### DIFF
--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/FactorSourceIdSample.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/samples/FactorSourceIdSample.kt
@@ -1,0 +1,15 @@
+package com.radixdlt.sargon.samples
+
+import com.radixdlt.sargon.FactorSourceId
+import com.radixdlt.sargon.annotation.UsesSampleValues
+import com.radixdlt.sargon.newFactorSourceIdSample
+import com.radixdlt.sargon.newFactorSourceIdSampleOther
+
+@UsesSampleValues
+val FactorSourceId.Companion.sample: Sample<FactorSourceId>
+    get() = object : Sample<FactorSourceId> {
+        override fun invoke(): FactorSourceId = newFactorSourceIdSample()
+
+        override fun other(): FactorSourceId = newFactorSourceIdSampleOther()
+
+    }

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/serializer/FactorSourceIdFromHashSerializer.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/serializer/FactorSourceIdFromHashSerializer.kt
@@ -1,0 +1,16 @@
+package com.radixdlt.sargon.serializer
+
+import com.radixdlt.sargon.BagOfBytes
+import com.radixdlt.sargon.FactorSourceIdFromHash
+import com.radixdlt.sargon.factorSourceIDFromHashToJsonBytes
+import com.radixdlt.sargon.newFactorSourceIDFromHashFromJsonBytes
+
+object FactorSourceIdFromHashSerializer: KotlinRustSerializer<FactorSourceIdFromHash>(
+    serialName = "com.radixdlt.sargon.FactorSourceIdFromHash"
+) {
+    override fun rustFunctionFromJsonBytes(jsonBytes: BagOfBytes): FactorSourceIdFromHash =
+        newFactorSourceIDFromHashFromJsonBytes(jsonBytes = jsonBytes)
+
+    override fun rustFunctionToJsonBytes(value: FactorSourceIdFromHash): BagOfBytes =
+        factorSourceIDFromHashToJsonBytes(factorSourceIDFromHash = value)
+}

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/serializer/FactorSourceIdSerializer.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/serializer/FactorSourceIdSerializer.kt
@@ -1,0 +1,16 @@
+package com.radixdlt.sargon.serializer
+
+import com.radixdlt.sargon.BagOfBytes
+import com.radixdlt.sargon.FactorSourceId
+import com.radixdlt.sargon.factorSourceIDToJsonBytes
+import com.radixdlt.sargon.newFactorSourceIDFromJsonBytes
+
+object FactorSourceIdSerializer: KotlinRustSerializer<FactorSourceId>(
+    serialName = "com.radixdlt.sargon.FactorSourceId"
+) {
+    override fun rustFunctionFromJsonBytes(jsonBytes: BagOfBytes): FactorSourceId =
+        newFactorSourceIDFromJsonBytes(jsonBytes = jsonBytes)
+
+    override fun rustFunctionToJsonBytes(value: FactorSourceId): BagOfBytes =
+        factorSourceIDToJsonBytes(factorSourceID = value)
+}

--- a/jvm/sargon-android/src/main/java/com/radixdlt/sargon/serializer/KotlinRustSerializer.kt
+++ b/jvm/sargon-android/src/main/java/com/radixdlt/sargon/serializer/KotlinRustSerializer.kt
@@ -1,0 +1,53 @@
+package com.radixdlt.sargon.serializer
+
+import com.radixdlt.sargon.BagOfBytes
+import com.radixdlt.sargon.extensions.bagOfBytes
+import com.radixdlt.sargon.extensions.string
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonEncoder
+
+/**
+ * A class that aims to bridge the serialization logic between Rust (serde) and kotlinx
+ * serialization.
+ *
+ * This kind of serializer offloads the serialization/deserialization logic into sargon
+ * and plugs in the result into the `KSerializer` as a `JsonElement`.
+ */
+abstract class KotlinRustSerializer<T>(serialName: String): KSerializer<T> {
+
+    abstract fun rustFunctionFromJsonBytes(
+        jsonBytes: BagOfBytes
+    ): T
+
+    abstract fun rustFunctionToJsonBytes(
+        value: T
+    ): BagOfBytes
+
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor(
+        serialName = serialName,
+        kind = PrimitiveKind.STRING
+    )
+
+    override fun deserialize(decoder: Decoder): T {
+        val jsonDecoder = decoder as JsonDecoder
+        val json = jsonDecoder.decodeJsonElement().toString()
+        return rustFunctionFromJsonBytes(bagOfBytes(fromString = json))
+    }
+
+    override fun serialize(encoder: Encoder, value: T) {
+        val jsonEncoder = encoder as JsonEncoder
+
+        val jsonElement = Json.parseToJsonElement(
+            rustFunctionToJsonBytes(value = value).string
+        )
+        jsonEncoder.encodeJsonElement(jsonElement)
+    }
+
+}

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/serializer/FactorSourceIdFromHashSerializerTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/serializer/FactorSourceIdFromHashSerializerTest.kt
@@ -1,0 +1,20 @@
+package com.radixdlt.sargon.serializer
+
+import com.radixdlt.sargon.BagOfBytes
+import com.radixdlt.sargon.FactorSourceIdFromHash
+import com.radixdlt.sargon.factorSourceIDFromHashToJsonBytes
+import com.radixdlt.sargon.newFactorSourceIDFromHashFromJsonBytes
+import com.radixdlt.sargon.samples.sample
+
+class FactorSourceIdFromHashSerializerTest :
+    KotlinRustSerializerTest<FactorSourceIdFromHash, FactorSourceIdFromHashSerializer>(
+        FactorSourceIdFromHash.sample,
+        FactorSourceIdFromHashSerializer
+    ) {
+
+    override fun rustFunctionFromJsonBytes(jsonBytes: BagOfBytes): FactorSourceIdFromHash =
+        newFactorSourceIDFromHashFromJsonBytes(jsonBytes)
+
+    override fun rustFunctionToJsonBytes(value: FactorSourceIdFromHash): BagOfBytes =
+        factorSourceIDFromHashToJsonBytes(value)
+}

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/serializer/FactorSourceIdSerializerTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/serializer/FactorSourceIdSerializerTest.kt
@@ -1,0 +1,21 @@
+package com.radixdlt.sargon.serializer
+
+import com.radixdlt.sargon.BagOfBytes
+import com.radixdlt.sargon.FactorSourceId
+import com.radixdlt.sargon.factorSourceIDToJsonBytes
+import com.radixdlt.sargon.newFactorSourceIDFromJsonBytes
+import com.radixdlt.sargon.samples.sample
+
+class FactorSourceIdSerializerTest :
+    KotlinRustSerializerTest<FactorSourceId, FactorSourceIdSerializer>(
+        FactorSourceId.sample,
+        FactorSourceIdSerializer
+    ) {
+
+    override fun rustFunctionFromJsonBytes(jsonBytes: BagOfBytes): FactorSourceId =
+        newFactorSourceIDFromJsonBytes(jsonBytes)
+
+    override fun rustFunctionToJsonBytes(value: FactorSourceId): BagOfBytes =
+        factorSourceIDToJsonBytes(value)
+
+}

--- a/jvm/sargon-android/src/test/java/com/radixdlt/sargon/serializer/KotlinRustSerializerTest.kt
+++ b/jvm/sargon-android/src/test/java/com/radixdlt/sargon/serializer/KotlinRustSerializerTest.kt
@@ -1,0 +1,105 @@
+package com.radixdlt.sargon.serializer
+
+import com.radixdlt.sargon.BagOfBytes
+import com.radixdlt.sargon.extensions.bagOfBytes
+import com.radixdlt.sargon.extensions.string
+import com.radixdlt.sargon.samples.Sample
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+/**
+ * A tester class that verifies the implementation of custom serializers that aim
+ * to bridge the serialization between Rust (serde) and Kotlinx serialization. By using these
+ * serializers we can essentially use Rust's serde implementation directly in kotlinx-serialization.
+ */
+abstract class KotlinRustSerializerTest<TYPE, SERIALIZER>(
+    val sample: Sample<TYPE>,
+    val serializer: SERIALIZER
+) where SERIALIZER: KSerializer<TYPE> {
+
+    abstract fun rustFunctionFromJsonBytes(
+        jsonBytes: BagOfBytes
+    ): TYPE
+
+    abstract fun rustFunctionToJsonBytes(
+        value: TYPE
+    ): BagOfBytes
+
+    @Nested
+    inner class SingleValueTests {
+        @Test
+        fun testSerializeKotlinDeserializeRust() {
+            val sampleValue = sample()
+
+            val json = Json.encodeToString(
+                serializer,
+                sampleValue
+            )
+
+            assertEquals(
+                sampleValue,
+                rustFunctionFromJsonBytes(bagOfBytes(json))
+            )
+        }
+
+        @Test
+        fun testSerializeRustDeserializeKotlin() {
+            val sampleValue = sample()
+
+            val rustJson = rustFunctionToJsonBytes(sampleValue).string
+
+            assertEquals(
+                sampleValue,
+                Json.decodeFromString(
+                    serializer,
+                    rustJson
+                )
+            )
+        }
+
+        @Test
+        fun testRoundtrip() {
+            val sampleValue = sample()
+
+            val json = Json.encodeToString(
+                serializer,
+                sampleValue
+            )
+
+            assertEquals(
+                sampleValue,
+                Json.decodeFromString(
+                    serializer,
+                    json
+                )
+            )
+        }
+    }
+
+    @Nested
+    inner class CollectionTests {
+
+        @Test
+        fun testRoundtrip() {
+            val sampleValues = sample.all
+
+            val json = Json.encodeToString(
+                ListSerializer(elementSerializer = serializer),
+                sampleValues
+            )
+
+            assertEquals(
+                sampleValues,
+                Json.decodeFromString(
+                    ListSerializer(elementSerializer = serializer),
+                    json
+                )
+            )
+        }
+    }
+
+}


### PR DESCRIPTION
This PR aims to introduce a way to bridge serialization logic between Rust (`serde`) and Kotlin (`kotlinx-serialization`).

In order to achieve this we can create custom serializers which internally can reuse the uniffi exported functions that expose sargon's serialization logic. This can be achieved by parsing those functions as json elements and plug them into the `KSerializer`s.

With this we can use sargon objects directly into our own serializable ones and in the same time keep the logic of serialization in rust.
```
@Serializable // This would create a warning, since FactorSourceId is not serializable
data class ExampleClass(
   @Serializable(with = FactorSourceIdSerializer::class)
  val id: FactorSourceId
)

// This would result in
{"id":{"kind":"device","body":"f1a93d324dd0f2bff89963ab81ed6e0c2ee7e18c0827dc1d3576b2d9f26bbd0a"}}
```