### PR TITLE
Mark implicit main as explicit in boot or import wallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "account-for-display"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "addresses",
  "derive_more",
@@ -49,10 +49,10 @@ dependencies = [
 
 [[package]]
 name = "addresses"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "assert-json",
- "bytes 1.2.11",
+ "bytes 1.2.12",
  "cap26-models",
  "core-utils",
  "derive_more",
@@ -246,7 +246,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "assert-json"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "assert-json-diff",
  "error",
@@ -546,7 +546,7 @@ dependencies = [
 
 [[package]]
 name = "build-info"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "assert-json",
  "cargo_toml",
@@ -573,7 +573,7 @@ checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
 
 [[package]]
 name = "bytes"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "assert-json",
  "delegate",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "cap26-models"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "assert-json",
  "derive_more",
@@ -748,7 +748,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "clients"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -808,7 +808,7 @@ checksum = "0d8a42181e0652c2997ae4d217f25b63c5337a52fd2279736e97b832fa0a3cff"
 
 [[package]]
 name = "core-collections"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "has-sample-values",
  "indexmap 2.7.0",
@@ -835,7 +835,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-misc"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "assert-json",
  "core-utils",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "core-utils"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "error",
  "iso8601-timestamp",
@@ -1084,7 +1084,7 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "drivers"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -1108,10 +1108,10 @@ dependencies = [
 
 [[package]]
 name = "ecc"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "assert-json",
- "bytes 1.2.11",
+ "bytes 1.2.12",
  "derive_more",
  "enum-as-inner",
  "error",
@@ -1210,11 +1210,11 @@ dependencies = [
 
 [[package]]
 name = "encryption"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "aes-gcm",
  "assert-json",
- "bytes 1.2.11",
+ "bytes 1.2.12",
  "derive_more",
  "error",
  "has-sample-values",
@@ -1231,7 +1231,7 @@ dependencies = [
 
 [[package]]
 name = "entity-by-address"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "addresses",
  "error",
@@ -1243,7 +1243,7 @@ dependencies = [
 
 [[package]]
 name = "entity-foundation"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "assert-json",
  "derive_more",
@@ -1318,7 +1318,7 @@ dependencies = [
 
 [[package]]
 name = "error"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "derive_more",
  "log",
@@ -1377,7 +1377,7 @@ dependencies = [
 
 [[package]]
 name = "factor-instances-provider"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -1403,9 +1403,9 @@ dependencies = [
 
 [[package]]
 name = "factors"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
- "bytes 1.2.11",
+ "bytes 1.2.12",
  "cap26-models",
  "core-collections",
  "core-misc",
@@ -1440,7 +1440,7 @@ dependencies = [
 
 [[package]]
 name = "factors-supporting-types"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "async-trait",
  "error",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-client-and-api"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -1615,7 +1615,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-models"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "addresses",
  "assert-json",
@@ -1720,7 +1720,7 @@ dependencies = [
 
 [[package]]
 name = "has-sample-values"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "error",
  "indexmap 2.7.0",
@@ -1731,9 +1731,9 @@ dependencies = [
 
 [[package]]
 name = "hash"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
- "bytes 1.2.11",
+ "bytes 1.2.12",
  "derive_more",
  "prelude",
  "radix-common",
@@ -1797,11 +1797,11 @@ dependencies = [
 
 [[package]]
 name = "hierarchical-deterministic"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "assert-json",
  "bip39",
- "bytes 1.2.11",
+ "bytes 1.2.12",
  "cap26-models",
  "derive_more",
  "ecc",
@@ -1844,13 +1844,13 @@ dependencies = [
 
 [[package]]
 name = "home-cards"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "actix-rt",
  "addresses",
  "async-trait",
  "base64",
- "bytes 1.2.11",
+ "bytes 1.2.12",
  "core-utils",
  "derive_more",
  "drivers",
@@ -1870,7 +1870,7 @@ dependencies = [
 
 [[package]]
 name = "host-info"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "assert-json",
  "derive_more",
@@ -1917,10 +1917,10 @@ dependencies = [
 
 [[package]]
 name = "http-client"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "actix-rt",
- "bytes 1.2.11",
+ "bytes 1.2.12",
  "core-utils",
  "drivers",
  "error",
@@ -2145,7 +2145,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "identified-vec-of"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "assert-json",
  "derive_more",
@@ -2218,7 +2218,7 @@ dependencies = [
 
 [[package]]
 name = "interactors"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -2347,7 +2347,7 @@ dependencies = [
 
 [[package]]
 name = "key-derivation-traits"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "addresses",
  "async-trait",
@@ -2365,7 +2365,7 @@ dependencies = [
 
 [[package]]
 name = "keys-collector"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -2454,7 +2454,7 @@ dependencies = [
 
 [[package]]
 name = "manifests"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "account-for-display",
  "addresses",
@@ -2496,7 +2496,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "metadata"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "derive_more",
  "has-sample-values",
@@ -2596,7 +2596,7 @@ dependencies = [
 
 [[package]]
 name = "network"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "assert-json",
  "enum-iterator",
@@ -2612,7 +2612,7 @@ dependencies = [
 
 [[package]]
 name = "next-derivation-index-ephemeral"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "addresses",
  "assert-json",
@@ -2688,9 +2688,9 @@ dependencies = [
 
 [[package]]
 name = "numeric"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
- "bytes 1.2.11",
+ "bytes 1.2.12",
  "delegate",
  "derive_more",
  "enum-iterator",
@@ -2910,7 +2910,7 @@ dependencies = [
 
 [[package]]
 name = "prelude"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "radix-engine",
  "radix-engine-toolkit",
@@ -2947,7 +2947,7 @@ dependencies = [
 
 [[package]]
 name = "profile"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "account-for-display",
  "addresses",
@@ -2991,7 +2991,7 @@ dependencies = [
 
 [[package]]
 name = "profile-account"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "account-for-display",
  "addresses",
@@ -3011,7 +3011,7 @@ dependencies = [
 
 [[package]]
 name = "profile-account-or-persona"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "cap26-models",
  "derive_more",
@@ -3028,7 +3028,7 @@ dependencies = [
 
 [[package]]
 name = "profile-app-preferences"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "addresses",
  "core-misc",
@@ -3051,7 +3051,7 @@ dependencies = [
 
 [[package]]
 name = "profile-base-entity"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "addresses",
  "derive_more",
@@ -3074,7 +3074,7 @@ dependencies = [
 
 [[package]]
 name = "profile-gateway"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "addresses",
  "assert-json",
@@ -3098,7 +3098,7 @@ dependencies = [
 
 [[package]]
 name = "profile-logic"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "addresses",
  "derive_more",
@@ -3120,7 +3120,7 @@ dependencies = [
 
 [[package]]
 name = "profile-persona"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "addresses",
  "cap26-models",
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "profile-persona-data"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "addresses",
  "assert-json",
@@ -3160,7 +3160,7 @@ dependencies = [
 
 [[package]]
 name = "profile-security-structures"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "addresses",
  "cap26-models",
@@ -3188,7 +3188,7 @@ dependencies = [
 
 [[package]]
 name = "profile-state-holder"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "derive_more",
  "error",
@@ -3203,7 +3203,7 @@ dependencies = [
 
 [[package]]
 name = "profile-supporting-types"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "addresses",
  "derive_more",
@@ -3292,14 +3292,14 @@ dependencies = [
 
 [[package]]
 name = "radix-connect"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "actix-rt",
  "addresses",
  "assert-json",
  "async-trait",
  "base64",
- "bytes 1.2.11",
+ "bytes 1.2.12",
  "core-misc",
  "core-utils",
  "derive_more",
@@ -3328,10 +3328,10 @@ dependencies = [
 
 [[package]]
 name = "radix-connect-models"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "addresses",
- "bytes 1.2.11",
+ "bytes 1.2.12",
  "core-misc",
  "derive_more",
  "error",
@@ -3773,7 +3773,7 @@ dependencies = [
 
 [[package]]
 name = "sargon"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -3838,7 +3838,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -3865,7 +3865,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-accounts"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -3891,7 +3891,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-derive-public-keys"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -3910,7 +3910,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-factors"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -3944,7 +3944,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-security-center"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "actix-rt",
  "derive_more",
@@ -3960,7 +3960,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-signing"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "actix-rt",
  "async-trait",
@@ -3986,7 +3986,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-os-transaction"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "actix-rt",
  "async-std",
@@ -4021,7 +4021,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-uniffi"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "actix-rt",
  "addresses",
@@ -4078,7 +4078,7 @@ dependencies = [
 
 [[package]]
 name = "sargon-uniffi-conversion-macros"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4251,7 +4251,7 @@ dependencies = [
 
 [[package]]
 name = "security-center"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "addresses",
  "assert-json",
@@ -4419,7 +4419,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "short-string"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "arraystring",
  "assert-json",
@@ -4454,13 +4454,13 @@ dependencies = [
 
 [[package]]
 name = "signatures-collector"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "actix-rt",
  "addresses",
  "assert-json",
  "async-trait",
- "bytes 1.2.11",
+ "bytes 1.2.12",
  "cap26-models",
  "core-collections",
  "core-misc",
@@ -4492,10 +4492,10 @@ dependencies = [
 
 [[package]]
 name = "signing-traits"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "async-trait",
- "bytes 1.2.11",
+ "bytes 1.2.12",
  "core-collections",
  "derive_more",
  "ecc",
@@ -4660,7 +4660,7 @@ dependencies = [
 
 [[package]]
 name = "sub-systems"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "derive_more",
  "drivers",
@@ -4819,7 +4819,7 @@ dependencies = [
 
 [[package]]
 name = "time-utils"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "iso8601-timestamp",
  "prelude",
@@ -4969,10 +4969,10 @@ dependencies = [
 
 [[package]]
 name = "transaction-foundation"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "assert-json",
- "bytes 1.2.11",
+ "bytes 1.2.12",
  "derive_more",
  "has-sample-values",
  "paste",
@@ -4984,10 +4984,10 @@ dependencies = [
 
 [[package]]
 name = "transaction-models"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "addresses",
- "bytes 1.2.11",
+ "bytes 1.2.12",
  "cargo_toml",
  "core-collections",
  "core-misc",

--- a/crates/app/home-cards/Cargo.toml
+++ b/crates/app/home-cards/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "home-cards"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/key-derivation-traits/Cargo.toml
+++ b/crates/app/key-derivation-traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "key-derivation-traits"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/radix-connect-models/Cargo.toml
+++ b/crates/app/radix-connect-models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "radix-connect-models"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/radix-connect/Cargo.toml
+++ b/crates/app/radix-connect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "radix-connect"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 

--- a/crates/app/security-center/Cargo.toml
+++ b/crates/app/security-center/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "security-center"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/app/signing-traits/Cargo.toml
+++ b/crates/app/signing-traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signing-traits"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/build-info/Cargo.toml
+++ b/crates/common/build-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "build-info"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 build = "build.rs"
 

--- a/crates/common/bytes/Cargo.toml
+++ b/crates/common/bytes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bytes"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/entity-foundation/Cargo.toml
+++ b/crates/common/entity-foundation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entity-foundation"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/host-info/Cargo.toml
+++ b/crates/common/host-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "host-info"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/identified-vec-of/Cargo.toml
+++ b/crates/common/identified-vec-of/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "identified-vec-of"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/metadata/Cargo.toml
+++ b/crates/common/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metadata"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/network/Cargo.toml
+++ b/crates/common/network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "network"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/numeric/Cargo.toml
+++ b/crates/common/numeric/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numeric"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/common/short-string/Cargo.toml
+++ b/crates/common/short-string/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "short-string"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/assert-json/Cargo.toml
+++ b/crates/core/assert-json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assert-json"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/collections/Cargo.toml
+++ b/crates/core/collections/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-collections"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/error/Cargo.toml
+++ b/crates/core/error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "error"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/has-sample-values/Cargo.toml
+++ b/crates/core/has-sample-values/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "has-sample-values"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/misc/Cargo.toml
+++ b/crates/core/misc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-misc"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/prelude/Cargo.toml
+++ b/crates/core/prelude/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prelude"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/time-utils/Cargo.toml
+++ b/crates/core/time-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "time-utils"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/utils/Cargo.toml
+++ b/crates/core/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-utils"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/addresses/Cargo.toml
+++ b/crates/crypto/addresses/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "addresses"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/cap26-models/Cargo.toml
+++ b/crates/crypto/cap26-models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cap26-models"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/ecc/Cargo.toml
+++ b/crates/crypto/ecc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecc"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/encryption/Cargo.toml
+++ b/crates/crypto/encryption/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "encryption"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/hash/Cargo.toml
+++ b/crates/crypto/hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hash"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/hd/Cargo.toml
+++ b/crates/crypto/hd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hierarchical-deterministic"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/factors/Cargo.toml
+++ b/crates/factors/factors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factors"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/instances-provider/Cargo.toml
+++ b/crates/factors/instances-provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factor-instances-provider"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/keys-collector/Cargo.toml
+++ b/crates/factors/keys-collector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keys-collector"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/next-derivation-index-ephemeral/Cargo.toml
+++ b/crates/factors/next-derivation-index-ephemeral/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "next-derivation-index-ephemeral"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/factors/signatures-collector/Cargo.toml
+++ b/crates/factors/signatures-collector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signatures-collector"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 

--- a/crates/factors/supporting-types/Cargo.toml
+++ b/crates/factors/supporting-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factors-supporting-types"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/gateway/client-and-api/Cargo.toml
+++ b/crates/gateway/client-and-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gateway-client-and-api"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/gateway/models/Cargo.toml
+++ b/crates/gateway/models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gateway-models"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 

--- a/crates/profile/logic/logic_SPLIT_ME/Cargo.toml
+++ b/crates/profile/logic/logic_SPLIT_ME/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-logic"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/account-for-display/Cargo.toml
+++ b/crates/profile/models/account-for-display/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "account-for-display"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/account-or-persona/Cargo.toml
+++ b/crates/profile/models/account-or-persona/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-account-or-persona"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/account/Cargo.toml
+++ b/crates/profile/models/account/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-account"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/app-preferences/Cargo.toml
+++ b/crates/profile/models/app-preferences/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-app-preferences"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/base-entity/Cargo.toml
+++ b/crates/profile/models/base-entity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-base-entity"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/gateway/Cargo.toml
+++ b/crates/profile/models/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-gateway"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/persona-data/Cargo.toml
+++ b/crates/profile/models/persona-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-persona-data"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/persona/Cargo.toml
+++ b/crates/profile/models/persona/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-persona"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/profile_SPLIT_ME/Cargo.toml
+++ b/crates/profile/models/profile_SPLIT_ME/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 

--- a/crates/profile/models/security-structures/Cargo.toml
+++ b/crates/profile/models/security-structures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-security-structures"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/models/supporting-types/Cargo.toml
+++ b/crates/profile/models/supporting-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-supporting-types"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/profile/traits/entity-by-address/Cargo.toml
+++ b/crates/profile/traits/entity-by-address/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entity-by-address"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/sargon/Cargo.toml
+++ b/crates/sargon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 resolver = "2" # features enabled in integration test

--- a/crates/system/clients/clients/Cargo.toml
+++ b/crates/system/clients/clients/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clients"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 

--- a/crates/system/clients/http/Cargo.toml
+++ b/crates/system/clients/http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http-client"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/drivers/Cargo.toml
+++ b/crates/system/drivers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drivers"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 

--- a/crates/system/interactors/Cargo.toml
+++ b/crates/system/interactors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interactors"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/accounts/Cargo.toml
+++ b/crates/system/os/accounts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-accounts"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/derive-public-keys/Cargo.toml
+++ b/crates/system/os/derive-public-keys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-derive-public-keys"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/factors/Cargo.toml
+++ b/crates/system/os/factors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-factors"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/os/Cargo.toml
+++ b/crates/system/os/os/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/security-center/Cargo.toml
+++ b/crates/system/os/security-center/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-security-center"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/signing/Cargo.toml
+++ b/crates/system/os/signing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-signing"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/os/transaction/Cargo.toml
+++ b/crates/system/os/transaction/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-os-transaction"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/profile-state-holder/Cargo.toml
+++ b/crates/system/profile-state-holder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-state-holder"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/system/sub-systems/Cargo.toml
+++ b/crates/system/sub-systems/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sub-systems"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/transaction/foundation/Cargo.toml
+++ b/crates/transaction/foundation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transaction-foundation"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/transaction/manifests/Cargo.toml
+++ b/crates/transaction/manifests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "manifests"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 

--- a/crates/transaction/models/Cargo.toml
+++ b/crates/transaction/models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transaction-models"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 

--- a/crates/uniffi/conversion-macros/Cargo.toml
+++ b/crates/uniffi/conversion-macros/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "sargon-uniffi-conversion-macros"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 
 [dependencies]

--- a/crates/uniffi/uniffi_SPLIT_ME/Cargo.toml
+++ b/crates/uniffi/uniffi_SPLIT_ME/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sargon-uniffi"
-version = "1.2.11"
+version = "1.2.12"
 edition = "2021"
 build = "build.rs"
 


### PR DESCRIPTION
1. When booting from an existing wallet, old users might have come from a profile with no main BDFS. In cases like these we need to mark the implicit main as main explicitly.
2. When importing a wallet with no main bdfs
    1. if `bdfs_skipped == false` then we need to mark the implicit main as explicit.  
    2. if `bdfs_skipped == true` then a new bdfs will be created as main.
    In wallets when importing such a profile. `bdfs_skipped` will always be set to `false` since there will be no main bdfs.

The goal is to explicitly set the flag as main which will help the UI in factor sources list to display the "Default" one instead of displaying nothing.